### PR TITLE
feat: add pagination to /project list for >25 projects

### DIFF
--- a/src/ui/projectListUi.ts
+++ b/src/ui/projectListUi.ts
@@ -1,0 +1,109 @@
+import {
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+    EmbedBuilder,
+    StringSelectMenuBuilder,
+} from 'discord.js';
+
+import { t } from '../utils/i18n';
+
+/** Select menu custom ID (legacy, page 0) */
+export const PROJECT_SELECT_ID = 'project_select';
+/** Backward compatibility: also accept old ID */
+export const WORKSPACE_SELECT_ID = 'workspace_select';
+
+/** Button customId prefix for page navigation. Format: project_page:<page> */
+export const PROJECT_PAGE_PREFIX = 'project_page';
+
+/** Maximum items per page (Discord select menu limit) */
+export const ITEMS_PER_PAGE = 25;
+
+/**
+ * Parse page number from a page-button customId.
+ * Returns NaN if the customId does not match the expected format.
+ */
+export function parseProjectPageId(customId: string): number {
+    if (!customId.startsWith(`${PROJECT_PAGE_PREFIX}:`)) return NaN;
+    return parseInt(customId.slice(PROJECT_PAGE_PREFIX.length + 1), 10);
+}
+
+/**
+ * Check if a customId belongs to a project select menu.
+ * Matches legacy IDs (`project_select`, `workspace_select`) and
+ * paginated IDs (`project_select:<page>`).
+ */
+export function isProjectSelectId(customId: string): boolean {
+    return (
+        customId === PROJECT_SELECT_ID ||
+        customId === WORKSPACE_SELECT_ID ||
+        customId.startsWith(`${PROJECT_SELECT_ID}:`)
+    );
+}
+
+/**
+ * Build the project list UI with select menu and optional Prev/Next buttons.
+ *
+ * @param workspaces - Full list of workspace names
+ * @param page - Zero-based page index (clamped to valid range)
+ * @returns Object with embeds and components arrays ready for Discord reply
+ */
+export function buildProjectListUI(
+    workspaces: string[],
+    page: number = 0,
+): { embeds: EmbedBuilder[]; components: ActionRowBuilder<any>[] } {
+    const totalPages = Math.max(1, Math.ceil(workspaces.length / ITEMS_PER_PAGE));
+    const safePage = Math.max(0, Math.min(page, totalPages - 1));
+
+    const embed = new EmbedBuilder()
+        .setTitle('\u{1F4C1} Projects')
+        .setColor(0x5865F2)
+        .setDescription(t('Select a project to auto-create a category and session channel'))
+        .setTimestamp();
+
+    if (workspaces.length === 0) {
+        return { embeds: [embed], components: [] };
+    }
+
+    const start = safePage * ITEMS_PER_PAGE;
+    const end = Math.min(start + ITEMS_PER_PAGE, workspaces.length);
+    const pageItems = workspaces.slice(start, end);
+
+    if (totalPages > 1) {
+        embed.setFooter({
+            text: `Page ${safePage + 1} / ${totalPages} (${workspaces.length} projects total)`,
+        });
+    }
+
+    const components: ActionRowBuilder<any>[] = [];
+
+    const options = pageItems.map((ws) => ({ label: ws, value: ws }));
+    const selectMenu = new StringSelectMenuBuilder()
+        .setCustomId(`${PROJECT_SELECT_ID}:${safePage}`)
+        .setPlaceholder(t('Select a project...'))
+        .addOptions(options);
+
+    components.push(
+        new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(selectMenu),
+    );
+
+    if (totalPages > 1) {
+        const prevBtn = new ButtonBuilder()
+            .setCustomId(`${PROJECT_PAGE_PREFIX}:${Math.max(0, safePage - 1)}`)
+            .setLabel('\u25C0 Prev')
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(safePage === 0);
+
+        const nextBtn = new ButtonBuilder()
+            .setCustomId(`${PROJECT_PAGE_PREFIX}:${safePage + 1}`)
+            .setLabel('Next \u25B6')
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(safePage >= totalPages - 1);
+
+        components.push(
+            new ActionRowBuilder<ButtonBuilder>().addComponents(prevBtn, nextBtn),
+        );
+    }
+
+    return { embeds: [embed], components };
+}

--- a/tests/ui/projectListUi.test.ts
+++ b/tests/ui/projectListUi.test.ts
@@ -1,0 +1,186 @@
+import {
+    buildProjectListUI,
+    isProjectSelectId,
+    parseProjectPageId,
+    PROJECT_PAGE_PREFIX,
+    PROJECT_SELECT_ID,
+    WORKSPACE_SELECT_ID,
+    ITEMS_PER_PAGE,
+} from '../../src/ui/projectListUi';
+
+describe('projectListUi', () => {
+    describe('parseProjectPageId', () => {
+        it('parses a valid page button customId', () => {
+            expect(parseProjectPageId('project_page:0')).toBe(0);
+            expect(parseProjectPageId('project_page:3')).toBe(3);
+            expect(parseProjectPageId('project_page:99')).toBe(99);
+        });
+
+        it('returns NaN for non-matching customId', () => {
+            expect(parseProjectPageId('other_id')).toBeNaN();
+            expect(parseProjectPageId('project_page')).toBeNaN();
+            expect(parseProjectPageId('')).toBeNaN();
+        });
+
+        it('returns NaN for malformed page number', () => {
+            expect(parseProjectPageId('project_page:abc')).toBeNaN();
+        });
+    });
+
+    describe('isProjectSelectId', () => {
+        it('matches legacy project_select', () => {
+            expect(isProjectSelectId(PROJECT_SELECT_ID)).toBe(true);
+        });
+
+        it('matches legacy workspace_select', () => {
+            expect(isProjectSelectId(WORKSPACE_SELECT_ID)).toBe(true);
+        });
+
+        it('matches paginated project_select:<page>', () => {
+            expect(isProjectSelectId('project_select:0')).toBe(true);
+            expect(isProjectSelectId('project_select:5')).toBe(true);
+        });
+
+        it('does not match unrelated customIds', () => {
+            expect(isProjectSelectId('mode_select')).toBe(false);
+            expect(isProjectSelectId('project_page:0')).toBe(false);
+            expect(isProjectSelectId('')).toBe(false);
+        });
+    });
+
+    describe('buildProjectListUI', () => {
+        const makeWorkspaces = (count: number): string[] =>
+            Array.from({ length: count }, (_, i) => `project-${String(i + 1).padStart(3, '0')}`);
+
+        it('returns empty components for zero workspaces', () => {
+            const { embeds, components } = buildProjectListUI([], 0);
+
+            expect(embeds).toHaveLength(1);
+            expect(components).toHaveLength(0);
+        });
+
+        it('shows a single select menu for <=25 workspaces (no pagination buttons)', () => {
+            const workspaces = makeWorkspaces(10);
+            const { embeds, components } = buildProjectListUI(workspaces, 0);
+
+            expect(embeds).toHaveLength(1);
+            // 1 row: select menu only (no Prev/Next buttons)
+            expect(components).toHaveLength(1);
+
+            const selectRow = components[0].toJSON();
+            expect(selectRow.components).toHaveLength(1);
+            expect(selectRow.components[0].type).toBe(3); // StringSelect
+            expect(selectRow.components[0].options).toHaveLength(10);
+        });
+
+        it('does not add a footer for single-page results', () => {
+            const workspaces = makeWorkspaces(5);
+            const { embeds } = buildProjectListUI(workspaces, 0);
+
+            const embedJson = embeds[0].toJSON();
+            expect(embedJson.footer).toBeUndefined();
+        });
+
+        it('shows select menu + Prev/Next buttons for >25 workspaces', () => {
+            const workspaces = makeWorkspaces(30);
+            const { embeds, components } = buildProjectListUI(workspaces, 0);
+
+            // 2 rows: select menu + button row
+            expect(components).toHaveLength(2);
+
+            // First row is select menu with 25 items
+            const selectRow = components[0].toJSON();
+            expect(selectRow.components[0].options).toHaveLength(25);
+
+            // Second row has 2 buttons (Prev, Next)
+            const buttonRow = components[1].toJSON();
+            expect(buttonRow.components).toHaveLength(2);
+            expect(buttonRow.components[0].label).toContain('Prev');
+            expect(buttonRow.components[1].label).toContain('Next');
+
+            // On page 0, Prev is disabled and Next is enabled
+            expect(buttonRow.components[0].disabled).toBe(true);
+            expect(buttonRow.components[1].disabled).toBe(false);
+
+            // Footer shows page info
+            const embedJson = embeds[0].toJSON();
+            expect(embedJson.footer?.text).toContain('Page 1 / 2');
+            expect(embedJson.footer?.text).toContain('30 projects total');
+        });
+
+        it('page 1 shows remaining items and enables Prev', () => {
+            const workspaces = makeWorkspaces(30);
+            const { components } = buildProjectListUI(workspaces, 1);
+
+            // Select menu has 5 remaining items
+            const selectRow = components[0].toJSON();
+            expect(selectRow.components[0].options).toHaveLength(5);
+
+            // Prev enabled, Next disabled (last page)
+            const buttonRow = components[1].toJSON();
+            expect(buttonRow.components[0].disabled).toBe(false);
+            expect(buttonRow.components[1].disabled).toBe(true);
+        });
+
+        it('clamps out-of-range page to the last valid page', () => {
+            const workspaces = makeWorkspaces(30);
+            const { embeds, components } = buildProjectListUI(workspaces, 100);
+
+            const embedJson = embeds[0].toJSON();
+            expect(embedJson.footer?.text).toContain('Page 2 / 2');
+
+            const selectRow = components[0].toJSON();
+            expect(selectRow.components[0].options).toHaveLength(5);
+        });
+
+        it('clamps negative page to 0', () => {
+            const workspaces = makeWorkspaces(30);
+            const { embeds } = buildProjectListUI(workspaces, -5);
+
+            const embedJson = embeds[0].toJSON();
+            expect(embedJson.footer?.text).toContain('Page 1 / 2');
+        });
+
+        it('select menu customId includes page number', () => {
+            const workspaces = makeWorkspaces(60);
+            const { components } = buildProjectListUI(workspaces, 1);
+
+            const selectRow = components[0].toJSON();
+            expect(selectRow.components[0].custom_id).toBe('project_select:1');
+        });
+
+        it('button customIds encode correct page numbers', () => {
+            const workspaces = makeWorkspaces(80); // 4 pages
+            const { components } = buildProjectListUI(workspaces, 2);
+
+            const buttonRow = components[1].toJSON();
+            // Prev button should navigate to page 1
+            expect(buttonRow.components[0].custom_id).toBe(`${PROJECT_PAGE_PREFIX}:1`);
+            // Next button should navigate to page 3
+            expect(buttonRow.components[1].custom_id).toBe(`${PROJECT_PAGE_PREFIX}:3`);
+        });
+
+        it('handles exactly 25 workspaces (single page, no buttons)', () => {
+            const workspaces = makeWorkspaces(25);
+            const { components } = buildProjectListUI(workspaces, 0);
+
+            expect(components).toHaveLength(1);
+            const selectRow = components[0].toJSON();
+            expect(selectRow.components[0].options).toHaveLength(25);
+        });
+
+        it('handles exactly 50 workspaces (2 full pages)', () => {
+            const workspaces = makeWorkspaces(50);
+
+            const page0 = buildProjectListUI(workspaces, 0);
+            expect(page0.components[0].toJSON().components[0].options).toHaveLength(25);
+
+            const page1 = buildProjectListUI(workspaces, 1);
+            expect(page1.components[0].toJSON().components[0].options).toHaveLength(25);
+
+            // Verify page 1 Next is disabled (last page)
+            const buttonRow = page1.components[1].toJSON();
+            expect(buttonRow.components[1].disabled).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Extract project list UI logic into `src/ui/projectListUi.ts`, following existing `templateUi.ts` / `modelsUi.ts` patterns
- Add Prev/Next button pagination so users can browse all projects 25 at a time
- Stateless design: page number encoded in button `customId`
- No UX change when there are 25 or fewer projects
- Full backward compatibility with legacy `project_select` / `workspace_select` customIds

Closes #20

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (410 tests)
- [x] Manual test: ≤25 projects — no pagination buttons shown
- [x] Manual test: >25 projects — Prev/Next buttons appear, page navigation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)