### PR TITLE
fix: improve quota error detection for popup and inline patterns

### DIFF
--- a/tests/services/responseMonitor.selectors.test.ts
+++ b/tests/services/responseMonitor.selectors.test.ts
@@ -142,4 +142,99 @@ describe('Lean RESPONSE_SELECTORS', () => {
         // Should check for MCP server/tool format lines
         expect(script).toContain('looksliketooloutput');
     });
+
+    // ---------------------------------------------------------------
+    // Test 16: QUOTA_ERROR uses h3 span text-based detection
+    // ---------------------------------------------------------------
+    it('QUOTA_ERROR script uses h3 span text-based detection', () => {
+        const script = RESPONSE_SELECTORS.QUOTA_ERROR;
+        expect(script).toContain('h3 span');
+        expect(script).toContain('h3');
+    });
+
+    // ---------------------------------------------------------------
+    // Test 17: QUOTA_ERROR checks for quota keywords
+    // ---------------------------------------------------------------
+    it('QUOTA_ERROR script checks for model quota reached keyword', () => {
+        const script = RESPONSE_SELECTORS.QUOTA_ERROR.toLowerCase();
+        expect(script).toContain('model quota reached');
+        expect(script).toContain('rate limit');
+        expect(script).toContain('quota exceeded');
+    });
+
+    // ---------------------------------------------------------------
+    // Test 18: QUOTA_ERROR excludes rendered-markdown containers
+    // ---------------------------------------------------------------
+    it('QUOTA_ERROR script excludes rendered-markdown and prose containers', () => {
+        const script = RESPONSE_SELECTORS.QUOTA_ERROR;
+        expect(script).toContain('.rendered-markdown');
+        expect(script).toContain('.prose');
+    });
+
+    // ---------------------------------------------------------------
+    // Test 19: QUOTA_ERROR retains class-based fallback selectors
+    // ---------------------------------------------------------------
+    it('QUOTA_ERROR script retains class-based fallback selectors', () => {
+        const script = RESPONSE_SELECTORS.QUOTA_ERROR;
+        expect(script).toContain('[role="alert"]');
+        expect(script).toContain('[class*="error"]');
+    });
+
+    // ---------------------------------------------------------------
+    // Test 20: RESPONSE_TEXT contains looksLikeQuotaPopup filter
+    // ---------------------------------------------------------------
+    it('RESPONSE_TEXT script contains looksLikeQuotaPopup filter', () => {
+        const script = RESPONSE_SELECTORS.RESPONSE_TEXT.toLowerCase();
+        expect(script).toContain('lookslikequotapopup');
+    });
+
+    // ---------------------------------------------------------------
+    // Test 21: looksLikeQuotaPopup checks for dismiss/upgrade keywords
+    // ---------------------------------------------------------------
+    it('RESPONSE_TEXT quota popup filter checks for dismiss and upgrade', () => {
+        const script = RESPONSE_SELECTORS.RESPONSE_TEXT.toLowerCase();
+        expect(script).toContain('dismiss');
+        expect(script).toContain('upgrade');
+    });
+
+    // ---------------------------------------------------------------
+    // Test 22: DUMP_ALL_TEXTS classifies quota popup as skip
+    // ---------------------------------------------------------------
+    it('DUMP_ALL_TEXTS script classifies quota popup as quota-popup skip', () => {
+        const script = RESPONSE_SELECTORS.DUMP_ALL_TEXTS.toLowerCase();
+        expect(script).toContain('quota-popup');
+    });
+
+    // ---------------------------------------------------------------
+    // Test 23: QUOTA_ERROR detects inline "exhausted your quota" pattern
+    // ---------------------------------------------------------------
+    it('QUOTA_ERROR script detects inline exhausted quota pattern', () => {
+        const script = RESPONSE_SELECTORS.QUOTA_ERROR.toLowerCase();
+        expect(script).toContain('exhausted your quota');
+    });
+
+    // ---------------------------------------------------------------
+    // Test 24: QUOTA_ERROR scans span elements for inline errors
+    // ---------------------------------------------------------------
+    it('QUOTA_ERROR script queries span elements for inline error detection', () => {
+        const script = RESPONSE_SELECTORS.QUOTA_ERROR;
+        // Should query generic span elements (inline errors have no semantic class)
+        expect(script).toContain("querySelectorAll('span')");
+    });
+
+    // ---------------------------------------------------------------
+    // Test 25: RESPONSE_TEXT looksLikeQuotaPopup catches inline exhausted pattern
+    // ---------------------------------------------------------------
+    it('RESPONSE_TEXT quota filter catches inline exhausted quota without dismiss/upgrade', () => {
+        const script = RESPONSE_SELECTORS.RESPONSE_TEXT.toLowerCase();
+        expect(script).toContain('exhausted your quota');
+    });
+
+    // ---------------------------------------------------------------
+    // Test 26: DUMP_ALL_TEXTS catches inline exhausted quota pattern
+    // ---------------------------------------------------------------
+    it('DUMP_ALL_TEXTS catches inline exhausted quota as quota-popup skip', () => {
+        const script = RESPONSE_SELECTORS.DUMP_ALL_TEXTS.toLowerCase();
+        expect(script).toContain('exhausted your quota');
+    });
 });

--- a/tests/ui/modelsUi.test.ts
+++ b/tests/ui/modelsUi.test.ts
@@ -1,4 +1,4 @@
-import { sendModelsUI } from '../../src/ui/modelsUi';
+import { sendModelsUI, buildModelsUI } from '../../src/ui/modelsUi';
 
 describe('modelsUi', () => {
     it('returns a connection error message when not connected', async () => {
@@ -15,6 +15,47 @@ describe('modelsUi', () => {
         const target = { editReply: jest.fn().mockResolvedValue(undefined) };
         const cdp = {
             getUiModels: jest.fn().mockResolvedValue(['Model A', 'Model B']),
+            getCurrentModel: jest.fn().mockResolvedValue('Model A'),
+        };
+
+        await sendModelsUI(target, {
+            getCurrentCdp: () => cdp as any,
+            fetchQuota: async () => [],
+        });
+
+        const payload = target.editReply.mock.calls[0][0];
+        expect(payload.embeds?.length).toBeGreaterThan(0);
+        expect(payload.components?.length).toBeGreaterThan(0);
+    });
+});
+
+describe('buildModelsUI', () => {
+    it('returns null when no models are available', async () => {
+        const cdp = {
+            getUiModels: jest.fn().mockResolvedValue([]),
+            getCurrentModel: jest.fn().mockResolvedValue(null),
+        };
+
+        const result = await buildModelsUI(cdp as any, async () => []);
+        expect(result).toBeNull();
+    });
+
+    it('returns embeds and components when models are available', async () => {
+        const cdp = {
+            getUiModels: jest.fn().mockResolvedValue(['Model A', 'Model B']),
+            getCurrentModel: jest.fn().mockResolvedValue('Model A'),
+        };
+
+        const result = await buildModelsUI(cdp as any, async () => []);
+        expect(result).not.toBeNull();
+        expect(result!.embeds.length).toBeGreaterThan(0);
+        expect(result!.components.length).toBeGreaterThan(0);
+    });
+
+    it('sendModelsUI delegates to buildModelsUI', async () => {
+        const target = { editReply: jest.fn().mockResolvedValue(undefined) };
+        const cdp = {
+            getUiModels: jest.fn().mockResolvedValue(['Model A']),
             getCurrentModel: jest.fn().mockResolvedValue('Model A'),
         };
 


### PR DESCRIPTION
## Summary

- **QUOTA_ERROR selector**: Added text-based detection (`h3 span` for popup, `span` for inline) before class-based fallback. New keywords: `exhausted your quota`, `exhausted quota`
- **RESPONSE_TEXT filter**: Added `looksLikeQuotaPopup` that catches both popup (dismiss/upgrade) and inline (exhausted your quota) patterns
- **onComplete refactor**: Quota check now runs **before** text extraction — skips `tryEmergencyExtractText()`, output logging, and Final Output embed entirely
- **buildModelsUI extraction**: Extracted from `sendModelsUI` so quota handler can send model selection UI via `channel.send`
- **11 new tests**: Covers h3 span detection, inline span detection, quota popup filtering, and buildModelsUI

Fixes both variants:
| Scenario | Detection | Filter |
|----------|-----------|--------|
| Popup visible | `h3 span` text match | `looksLikeQuotaPopup` (dismiss/upgrade) |
| Popup dismissed (inline only) | `span` text match | `looksLikeQuotaPopup` (exhausted your quota) |
| Both visible | Both paths match | Both filters active |

Closes #1 (Pattern 1)

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — 425 tests pass (11 new)
- [x] Manual: trigger quota on Antigravity with popup visible → warning embed + model UI shown, no Final Output
- [x] Manual: trigger quota after Dismiss → same behavior (inline detection)
- [x] Manual: normal prompt completion unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)