### PR TITLE
fix: suppress output on /stop and add error popup detection

### DIFF
--- a/src/events/messageCreateHandler.ts
+++ b/src/events/messageCreateHandler.ts
@@ -7,6 +7,7 @@ import { ChatSessionRepository } from '../database/chatSessionRepository';
 import {
     CdpBridge,
     ensureApprovalDetector as ensureApprovalDetectorFn,
+    ensureErrorPopupDetector as ensureErrorPopupDetectorFn,
     ensurePlanningDetector as ensurePlanningDetectorFn,
     getCurrentCdp as getCurrentCdpFn,
     registerApprovalSessionChannel as registerApprovalSessionChannelFn,
@@ -58,6 +59,7 @@ export interface MessageCreateHandlerDeps {
     handleScreenshot: (target: Message, cdp: CdpService | null) => Promise<void>;
     getCurrentCdp?: (bridge: CdpBridge) => CdpService | null;
     ensureApprovalDetector?: (bridge: CdpBridge, cdp: CdpService, workspaceDirName: string, client: any) => void;
+    ensureErrorPopupDetector?: (bridge: CdpBridge, cdp: CdpService, workspaceDirName: string, client: any) => void;
     ensurePlanningDetector?: (bridge: CdpBridge, cdp: CdpService, workspaceDirName: string, client: any) => void;
     registerApprovalWorkspaceChannel?: (bridge: CdpBridge, workspaceDirName: string, channel: Message['channel']) => void;
     registerApprovalSessionChannel?: (bridge: CdpBridge, workspaceDirName: string, sessionTitle: string, channel: Message['channel']) => void;
@@ -69,6 +71,7 @@ export interface MessageCreateHandlerDeps {
 export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
     const getCurrentCdp = deps.getCurrentCdp ?? getCurrentCdpFn;
     const ensureApprovalDetector = deps.ensureApprovalDetector ?? ensureApprovalDetectorFn;
+    const ensureErrorPopupDetector = deps.ensureErrorPopupDetector ?? ensureErrorPopupDetectorFn;
     const ensurePlanningDetector = deps.ensurePlanningDetector ?? ensurePlanningDetectorFn;
     const registerApprovalWorkspaceChannel = deps.registerApprovalWorkspaceChannel ?? registerApprovalWorkspaceChannelFn;
     const registerApprovalSessionChannel = deps.registerApprovalSessionChannel ?? registerApprovalSessionChannelFn;
@@ -183,6 +186,7 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
                         registerApprovalWorkspaceChannel(deps.bridge, dirName, message.channel);
 
                         ensureApprovalDetector(deps.bridge, cdp, dirName, deps.client);
+                        ensureErrorPopupDetector(deps.bridge, cdp, dirName, deps.client);
                         ensurePlanningDetector(deps.bridge, cdp, dirName, deps.client);
 
                         const session = deps.chatSessionRepo.findByChannelId(message.channelId);

--- a/src/services/errorPopupDetector.ts
+++ b/src/services/errorPopupDetector.ts
@@ -1,0 +1,293 @@
+import { logger } from '../utils/logger';
+import { buildClickScript } from './approvalDetector';
+import { CdpService } from './cdpService';
+
+/** Error popup information */
+export interface ErrorPopupInfo {
+    /** Error popup title text */
+    title: string;
+    /** Error popup body/description text */
+    body: string;
+    /** Button labels found in the popup */
+    buttons: string[];
+}
+
+export interface ErrorPopupDetectorOptions {
+    /** CDP service instance */
+    cdpService: CdpService;
+    /** Poll interval in milliseconds (default: 3000ms) */
+    pollIntervalMs?: number;
+    /** Callback when an error popup is detected */
+    onErrorPopup: (info: ErrorPopupInfo) => void;
+}
+
+/**
+ * Detection script for the Antigravity UI error popup.
+ *
+ * Looks for dialog/modal containers containing error-related text patterns
+ * like "agent terminated", "error", "failed", etc. and extracts popup info.
+ */
+const DETECT_ERROR_POPUP_SCRIPT = `(() => {
+    const ERROR_PATTERNS = [
+        'agent terminated',
+        'terminated due to error',
+        'unexpected error',
+        'something went wrong',
+        'an error occurred',
+    ];
+
+    const normalize = (text) => (text || '').toLowerCase().replace(/\\s+/g, ' ').trim();
+
+    // Try dialog/modal first
+    const dialogs = Array.from(document.querySelectorAll(
+        '[role="dialog"], [role="alertdialog"], .modal, .dialog'
+    )).filter(el => el.offsetParent !== null || el.getAttribute('aria-modal') === 'true');
+
+    // Fallback: look for fixed/absolute positioned overlays
+    if (dialogs.length === 0) {
+        const overlays = Array.from(document.querySelectorAll('div[class*="fixed"], div[class*="absolute"]'))
+            .filter(el => {
+                const style = window.getComputedStyle(el);
+                return (style.position === 'fixed' || style.position === 'absolute')
+                    && style.zIndex && parseInt(style.zIndex, 10) > 10
+                    && el.querySelector('button');
+            });
+        dialogs.push(...overlays);
+    }
+
+    for (const dialog of dialogs) {
+        const fullText = normalize(dialog.textContent || '');
+        const isError = ERROR_PATTERNS.some(p => fullText.includes(p));
+        if (!isError) continue;
+
+        // Extract title from heading elements or first prominent text
+        const headingEl = dialog.querySelector('h1, h2, h3, h4, [class*="title"], [class*="heading"]');
+        const title = headingEl ? (headingEl.textContent || '').trim() : '';
+
+        // Extract body text (excluding button text and title)
+        const allButtons = Array.from(dialog.querySelectorAll('button'))
+            .filter(btn => btn.offsetParent !== null);
+        const buttonTexts = new Set(allButtons.map(btn => (btn.textContent || '').trim()));
+
+        const bodyParts = [];
+        const walker = document.createTreeWalker(dialog, NodeFilter.SHOW_TEXT);
+        let node;
+        while ((node = walker.nextNode())) {
+            const text = (node.textContent || '').trim();
+            if (!text) continue;
+            if (buttonTexts.has(text)) continue;
+            if (text === title) continue;
+            bodyParts.push(text);
+        }
+        const body = bodyParts.join(' ').slice(0, 1000);
+
+        const buttons = allButtons.map(btn => (btn.textContent || '').trim()).filter(t => t.length > 0);
+
+        if (buttons.length === 0) continue;
+
+        return { title: title || 'Error', body, buttons };
+    }
+
+    return null;
+})()`;
+
+/**
+ * Read clipboard content via navigator.clipboard.readText().
+ * Requires awaitPromise=true since clipboard API returns a Promise.
+ */
+const READ_CLIPBOARD_SCRIPT = `(async () => {
+    try {
+        const text = await navigator.clipboard.readText();
+        return text || null;
+    } catch (e) {
+        return null;
+    }
+})()`;
+
+/**
+ * Detects error popup dialogs (e.g. "Agent terminated due to error") in the
+ * Antigravity UI via polling.
+ *
+ * Follows the same polling pattern as PlanningDetector / ApprovalDetector:
+ * - start()/stop() lifecycle
+ * - Duplicate notification prevention via lastDetectedKey
+ * - Cooldown to suppress rapid re-detection
+ * - CDP error tolerance (continues polling on error)
+ */
+export class ErrorPopupDetector {
+    private cdpService: CdpService;
+    private pollIntervalMs: number;
+    private onErrorPopup: (info: ErrorPopupInfo) => void;
+
+    private pollTimer: NodeJS.Timeout | null = null;
+    private isRunning: boolean = false;
+    /** Key of the last detected error popup (for duplicate notification prevention) */
+    private lastDetectedKey: string | null = null;
+    /** Full ErrorPopupInfo from the last detection */
+    private lastDetectedInfo: ErrorPopupInfo | null = null;
+    /** Timestamp of last notification (for cooldown-based dedup) */
+    private lastNotifiedAt: number = 0;
+    /** Cooldown period in ms to suppress duplicate notifications (10s for error popups) */
+    private static readonly COOLDOWN_MS = 10000;
+
+    constructor(options: ErrorPopupDetectorOptions) {
+        this.cdpService = options.cdpService;
+        this.pollIntervalMs = options.pollIntervalMs ?? 3000;
+        this.onErrorPopup = options.onErrorPopup;
+    }
+
+    /** Start monitoring. */
+    start(): void {
+        if (this.isRunning) return;
+        this.isRunning = true;
+        this.lastDetectedKey = null;
+        this.lastDetectedInfo = null;
+        this.lastNotifiedAt = 0;
+        this.schedulePoll();
+    }
+
+    /** Stop monitoring. */
+    async stop(): Promise<void> {
+        this.isRunning = false;
+        if (this.pollTimer) {
+            clearTimeout(this.pollTimer);
+            this.pollTimer = null;
+        }
+    }
+
+    /** Return the last detected error popup info. Returns null if nothing has been detected. */
+    getLastDetectedInfo(): ErrorPopupInfo | null {
+        return this.lastDetectedInfo;
+    }
+
+    /** Returns whether monitoring is currently active. */
+    isActive(): boolean {
+        return this.isRunning;
+    }
+
+    /**
+     * Click the Dismiss button via CDP.
+     * @returns true if click succeeded
+     */
+    async clickDismissButton(): Promise<boolean> {
+        return this.clickButton('Dismiss');
+    }
+
+    /**
+     * Click the "Copy debug info" button via CDP.
+     * @returns true if click succeeded
+     */
+    async clickCopyDebugInfoButton(): Promise<boolean> {
+        return this.clickButton('Copy debug info');
+    }
+
+    /**
+     * Click the Retry button via CDP.
+     * @returns true if click succeeded
+     */
+    async clickRetryButton(): Promise<boolean> {
+        return this.clickButton('Retry');
+    }
+
+    /**
+     * Read clipboard content from the browser via navigator.clipboard.readText().
+     * Should be called after clickCopyDebugInfoButton() with a short delay.
+     * @returns Clipboard text or null if unavailable
+     */
+    async readClipboard(): Promise<string | null> {
+        try {
+            const result = await this.runEvaluateScript(READ_CLIPBOARD_SCRIPT, true);
+            return typeof result === 'string' ? result : null;
+        } catch (error) {
+            logger.error('[ErrorPopupDetector] Error reading clipboard:', error);
+            return null;
+        }
+    }
+
+    /** Schedule the next poll. */
+    private schedulePoll(): void {
+        if (!this.isRunning) return;
+        this.pollTimer = setTimeout(async () => {
+            await this.poll();
+            if (this.isRunning) {
+                this.schedulePoll();
+            }
+        }, this.pollIntervalMs);
+    }
+
+    /**
+     * Single poll iteration:
+     *   1. Detect error popup from DOM (with contextId)
+     *   2. Notify via callback only on new detection (prevent duplicates)
+     *   3. Reset lastDetectedKey / lastDetectedInfo when popup disappears
+     */
+    private async poll(): Promise<void> {
+        try {
+            const contextId = this.cdpService.getPrimaryContextId();
+            const callParams: Record<string, unknown> = {
+                expression: DETECT_ERROR_POPUP_SCRIPT,
+                returnByValue: true,
+                awaitPromise: false,
+            };
+            if (contextId !== null) {
+                callParams.contextId = contextId;
+            }
+
+            const result = await this.cdpService.call('Runtime.evaluate', callParams);
+            const info: ErrorPopupInfo | null = result?.result?.value ?? null;
+
+            if (info) {
+                // Duplicate prevention: use title + body snippet as key
+                const key = `${info.title}::${info.body.slice(0, 100)}`;
+                const now = Date.now();
+                const withinCooldown = (now - this.lastNotifiedAt) < ErrorPopupDetector.COOLDOWN_MS;
+                if (key !== this.lastDetectedKey && !withinCooldown) {
+                    this.lastDetectedKey = key;
+                    this.lastDetectedInfo = info;
+                    this.lastNotifiedAt = now;
+                    this.onErrorPopup(info);
+                } else if (key === this.lastDetectedKey) {
+                    // Same key -- update stored info silently
+                    this.lastDetectedInfo = info;
+                }
+            } else {
+                // Reset when popup disappears (prepare for next detection)
+                this.lastDetectedKey = null;
+                this.lastDetectedInfo = null;
+            }
+        } catch (error) {
+            // Ignore CDP errors and continue monitoring
+            const message = error instanceof Error ? error.message : String(error);
+            if (message.includes('WebSocket is not connected')) {
+                return;
+            }
+            logger.error('[ErrorPopupDetector] Error during polling:', error);
+        }
+    }
+
+    /** Internal click handler using buildClickScript from approvalDetector. */
+    private async clickButton(buttonText: string): Promise<boolean> {
+        try {
+            const result = await this.runEvaluateScript(buildClickScript(buttonText));
+            return result?.ok === true;
+        } catch (error) {
+            logger.error('[ErrorPopupDetector] Error while clicking button:', error);
+            return false;
+        }
+    }
+
+    /** Execute Runtime.evaluate with contextId and return result.value. */
+    private async runEvaluateScript(expression: string, awaitPromise: boolean = false): Promise<any> {
+        const contextId = this.cdpService.getPrimaryContextId();
+        const callParams: Record<string, unknown> = {
+            expression,
+            returnByValue: true,
+            awaitPromise,
+        };
+        if (contextId !== null) {
+            callParams.contextId = contextId;
+        }
+        const result = await this.cdpService.call('Runtime.evaluate', callParams);
+        return result?.result?.value;
+    }
+}

--- a/tests/events/interactionCreateHandler.errorPopup.test.ts
+++ b/tests/events/interactionCreateHandler.errorPopup.test.ts
@@ -1,0 +1,447 @@
+/**
+ * Error popup button interaction handler tests
+ *
+ * Tests the Dismiss, Copy debug info, and Retry button interactions
+ * for the error popup feature in the interactionCreateHandler.
+ */
+
+import { createInteractionCreateHandler } from '../../src/events/interactionCreateHandler';
+
+describe('interactionCreateHandler - error popup buttons', () => {
+    function createBaseDeps(overrides: Record<string, any> = {}) {
+        return {
+            config: { allowedUserIds: ['allowed'] },
+            bridge: {
+                pool: {
+                    getApprovalDetector: jest.fn(),
+                    getErrorPopupDetector: jest.fn(),
+                    getPlanningDetector: jest.fn(),
+                },
+                lastActiveWorkspace: null,
+                autoAccept: { handle: jest.fn(), isEnabled: jest.fn().mockReturnValue(false) },
+            } as any,
+            cleanupHandler: {} as any,
+            modeService: {} as any,
+            modelService: {} as any,
+            slashCommandHandler: {} as any,
+            wsHandler: {} as any,
+            chatHandler: {} as any,
+            client: {} as any,
+            sendModeUI: jest.fn(),
+            sendModelsUI: jest.fn(),
+            sendAutoAcceptUI: jest.fn(),
+            handleScreenshot: jest.fn(),
+            getCurrentCdp: jest.fn(),
+            parseApprovalCustomId: jest.fn().mockReturnValue(null),
+            parseErrorPopupCustomId: jest.fn().mockReturnValue(null),
+            parsePlanningCustomId: jest.fn().mockReturnValue(null),
+            handleSlashInteraction: jest.fn(),
+            ...overrides,
+        };
+    }
+
+    it('rejects error popup actions from a different channel than the bound session', async () => {
+        const reply = jest.fn().mockResolvedValue(undefined);
+
+        const interaction = {
+            isButton: () => true,
+            user: { id: 'allowed' },
+            customId: 'error_popup_dismiss_action:ws-a:channel-a',
+            channelId: 'channel-b',
+            reply,
+            message: { embeds: [], components: [] },
+        } as any;
+
+        const handler = createInteractionCreateHandler(createBaseDeps({
+            parseErrorPopupCustomId: jest.fn().mockReturnValue({
+                action: 'dismiss',
+                workspaceDirName: 'ws-a',
+                channelId: 'channel-a',
+            }),
+        }));
+
+        await handler(interaction);
+
+        expect(reply).toHaveBeenCalled();
+    });
+
+    it('replies with error when error popup detector is not found', async () => {
+        const reply = jest.fn().mockResolvedValue(undefined);
+
+        const interaction = {
+            isButton: () => true,
+            user: { id: 'allowed' },
+            customId: 'error_popup_dismiss_action:ws-a:channel-a',
+            channelId: 'channel-a',
+            reply,
+            message: { embeds: [], components: [] },
+        } as any;
+
+        const handler = createInteractionCreateHandler(createBaseDeps({
+            parseErrorPopupCustomId: jest.fn().mockReturnValue({
+                action: 'dismiss',
+                workspaceDirName: 'ws-a',
+                channelId: 'channel-a',
+            }),
+            bridge: {
+                pool: {
+                    getApprovalDetector: jest.fn(),
+                    getErrorPopupDetector: jest.fn().mockReturnValue(undefined),
+                    getPlanningDetector: jest.fn(),
+                },
+                lastActiveWorkspace: null,
+            } as any,
+        }));
+
+        await handler(interaction);
+
+        expect(reply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: expect.any(String),
+                flags: 64,
+            }),
+        );
+    });
+
+    it('handles Dismiss button: clicks Dismiss, updates embed and disables buttons', async () => {
+        const update = jest.fn().mockResolvedValue(undefined);
+
+        const errorDetector = {
+            clickDismissButton: jest.fn().mockResolvedValue(true),
+        };
+
+        const interaction = {
+            isButton: () => true,
+            user: { id: 'allowed' },
+            customId: 'error_popup_dismiss_action:ws-a:channel-a',
+            channelId: 'channel-a',
+            update,
+            channel: { send: jest.fn() },
+            message: {
+                embeds: [{
+                    title: 'Agent terminated due to error',
+                    description: 'The agent encountered an error.',
+                    color: 0xE74C3C,
+                }],
+                components: [{
+                    components: [
+                        {
+                            type: 2,
+                            data: { type: 2 },
+                            toJSON: () => ({
+                                type: 2,
+                                style: 2,
+                                label: 'Dismiss',
+                                custom_id: 'error_popup_dismiss_action:ws-a:channel-a',
+                            }),
+                        },
+                        {
+                            type: 2,
+                            data: { type: 2 },
+                            toJSON: () => ({
+                                type: 2,
+                                style: 1,
+                                label: 'Copy debug info',
+                                custom_id: 'error_popup_copy_debug_action:ws-a:channel-a',
+                            }),
+                        },
+                        {
+                            type: 2,
+                            data: { type: 2 },
+                            toJSON: () => ({
+                                type: 2,
+                                style: 3,
+                                label: 'Retry',
+                                custom_id: 'error_popup_retry_action:ws-a:channel-a',
+                            }),
+                        },
+                    ],
+                }],
+            },
+        } as any;
+
+        const handler = createInteractionCreateHandler(createBaseDeps({
+            parseErrorPopupCustomId: jest.fn().mockReturnValue({
+                action: 'dismiss',
+                workspaceDirName: 'ws-a',
+                channelId: 'channel-a',
+            }),
+            bridge: {
+                pool: {
+                    getApprovalDetector: jest.fn(),
+                    getErrorPopupDetector: jest.fn().mockReturnValue(errorDetector),
+                    getPlanningDetector: jest.fn(),
+                },
+                lastActiveWorkspace: null,
+            } as any,
+        }));
+
+        await handler(interaction);
+
+        expect(errorDetector.clickDismissButton).toHaveBeenCalled();
+        expect(update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                embeds: expect.arrayContaining([
+                    expect.objectContaining({
+                        data: expect.objectContaining({
+                            color: 0x95A5A6, // Grey for dismissed
+                        }),
+                    }),
+                ]),
+            }),
+        );
+    });
+
+    it('handles Copy debug info button: clicks button, reads clipboard, sends debug embed', async () => {
+        const deferUpdate = jest.fn().mockResolvedValue(undefined);
+        const editReply = jest.fn().mockResolvedValue(undefined);
+        const followUp = jest.fn().mockResolvedValue(undefined);
+        const channelSend = jest.fn().mockResolvedValue(undefined);
+
+        const errorDetector = {
+            clickCopyDebugInfoButton: jest.fn().mockResolvedValue(true),
+            readClipboard: jest.fn().mockResolvedValue('Error: Agent terminated\nStack: at line 42\nVersion: 1.0.0'),
+        };
+
+        const interaction = {
+            isButton: () => true,
+            user: { id: 'allowed' },
+            customId: 'error_popup_copy_debug_action:ws-a:channel-a',
+            channelId: 'channel-a',
+            deferUpdate,
+            editReply,
+            followUp,
+            channel: { send: channelSend },
+            message: {
+                embeds: [{
+                    title: 'Agent terminated due to error',
+                    description: 'The agent encountered an error.',
+                    color: 0xE74C3C,
+                }],
+                components: [],
+            },
+        } as any;
+
+        const handler = createInteractionCreateHandler(createBaseDeps({
+            parseErrorPopupCustomId: jest.fn().mockReturnValue({
+                action: 'copy_debug',
+                workspaceDirName: 'ws-a',
+                channelId: 'channel-a',
+            }),
+            bridge: {
+                pool: {
+                    getApprovalDetector: jest.fn(),
+                    getErrorPopupDetector: jest.fn().mockReturnValue(errorDetector),
+                    getPlanningDetector: jest.fn(),
+                },
+                lastActiveWorkspace: null,
+            } as any,
+        }));
+
+        await handler(interaction);
+
+        expect(deferUpdate).toHaveBeenCalled();
+        expect(errorDetector.clickCopyDebugInfoButton).toHaveBeenCalled();
+        expect(errorDetector.readClipboard).toHaveBeenCalled();
+        expect(channelSend).toHaveBeenCalledWith(
+            expect.objectContaining({
+                embeds: expect.arrayContaining([
+                    expect.objectContaining({
+                        data: expect.objectContaining({
+                            title: expect.any(String),
+                            description: expect.stringContaining('Error: Agent terminated'),
+                        }),
+                    }),
+                ]),
+            }),
+        );
+    });
+
+    it('handles Copy debug info button: sends ephemeral when button click fails', async () => {
+        const deferUpdate = jest.fn().mockResolvedValue(undefined);
+        const followUp = jest.fn().mockResolvedValue(undefined);
+
+        const errorDetector = {
+            clickCopyDebugInfoButton: jest.fn().mockResolvedValue(false),
+        };
+
+        const interaction = {
+            isButton: () => true,
+            user: { id: 'allowed' },
+            customId: 'error_popup_copy_debug_action:ws-a:channel-a',
+            channelId: 'channel-a',
+            deferUpdate,
+            followUp,
+            channel: { send: jest.fn() },
+            message: { embeds: [], components: [] },
+        } as any;
+
+        const handler = createInteractionCreateHandler(createBaseDeps({
+            parseErrorPopupCustomId: jest.fn().mockReturnValue({
+                action: 'copy_debug',
+                workspaceDirName: 'ws-a',
+                channelId: 'channel-a',
+            }),
+            bridge: {
+                pool: {
+                    getApprovalDetector: jest.fn(),
+                    getErrorPopupDetector: jest.fn().mockReturnValue(errorDetector),
+                    getPlanningDetector: jest.fn(),
+                },
+                lastActiveWorkspace: null,
+            } as any,
+        }));
+
+        await handler(interaction);
+
+        expect(deferUpdate).toHaveBeenCalled();
+        expect(followUp).toHaveBeenCalledWith(
+            expect.objectContaining({
+                flags: 64,
+            }),
+        );
+    });
+
+    it('handles Copy debug info button: sends ephemeral when clipboard is empty', async () => {
+        const deferUpdate = jest.fn().mockResolvedValue(undefined);
+        const editReply = jest.fn().mockResolvedValue(undefined);
+        const followUp = jest.fn().mockResolvedValue(undefined);
+
+        const errorDetector = {
+            clickCopyDebugInfoButton: jest.fn().mockResolvedValue(true),
+            readClipboard: jest.fn().mockResolvedValue(null),
+        };
+
+        const interaction = {
+            isButton: () => true,
+            user: { id: 'allowed' },
+            customId: 'error_popup_copy_debug_action:ws-a:channel-a',
+            channelId: 'channel-a',
+            deferUpdate,
+            editReply,
+            followUp,
+            channel: { send: jest.fn() },
+            message: {
+                embeds: [{
+                    title: 'Agent Error',
+                    description: 'Test',
+                    color: 0xE74C3C,
+                }],
+                components: [],
+            },
+        } as any;
+
+        const handler = createInteractionCreateHandler(createBaseDeps({
+            parseErrorPopupCustomId: jest.fn().mockReturnValue({
+                action: 'copy_debug',
+                workspaceDirName: 'ws-a',
+                channelId: 'channel-a',
+            }),
+            bridge: {
+                pool: {
+                    getApprovalDetector: jest.fn(),
+                    getErrorPopupDetector: jest.fn().mockReturnValue(errorDetector),
+                    getPlanningDetector: jest.fn(),
+                },
+                lastActiveWorkspace: null,
+            } as any,
+        }));
+
+        await handler(interaction);
+
+        expect(followUp).toHaveBeenCalledWith(
+            expect.objectContaining({
+                flags: 64,
+            }),
+        );
+    });
+
+    it('handles Retry button: clicks Retry, updates embed with green and disables buttons', async () => {
+        const update = jest.fn().mockResolvedValue(undefined);
+
+        const errorDetector = {
+            clickRetryButton: jest.fn().mockResolvedValue(true),
+        };
+
+        const interaction = {
+            isButton: () => true,
+            user: { id: 'allowed' },
+            customId: 'error_popup_retry_action:ws-a:channel-a',
+            channelId: 'channel-a',
+            update,
+            channel: { send: jest.fn() },
+            message: {
+                embeds: [{
+                    title: 'Agent terminated due to error',
+                    description: 'The agent encountered an error.',
+                    color: 0xE74C3C,
+                }],
+                components: [{
+                    components: [
+                        {
+                            type: 2,
+                            data: { type: 2 },
+                            toJSON: () => ({
+                                type: 2,
+                                style: 2,
+                                label: 'Dismiss',
+                                custom_id: 'error_popup_dismiss_action:ws-a:channel-a',
+                            }),
+                        },
+                        {
+                            type: 2,
+                            data: { type: 2 },
+                            toJSON: () => ({
+                                type: 2,
+                                style: 1,
+                                label: 'Copy debug info',
+                                custom_id: 'error_popup_copy_debug_action:ws-a:channel-a',
+                            }),
+                        },
+                        {
+                            type: 2,
+                            data: { type: 2 },
+                            toJSON: () => ({
+                                type: 2,
+                                style: 3,
+                                label: 'Retry',
+                                custom_id: 'error_popup_retry_action:ws-a:channel-a',
+                            }),
+                        },
+                    ],
+                }],
+            },
+        } as any;
+
+        const handler = createInteractionCreateHandler(createBaseDeps({
+            parseErrorPopupCustomId: jest.fn().mockReturnValue({
+                action: 'retry',
+                workspaceDirName: 'ws-a',
+                channelId: 'channel-a',
+            }),
+            bridge: {
+                pool: {
+                    getApprovalDetector: jest.fn(),
+                    getErrorPopupDetector: jest.fn().mockReturnValue(errorDetector),
+                    getPlanningDetector: jest.fn(),
+                },
+                lastActiveWorkspace: null,
+            } as any,
+        }));
+
+        await handler(interaction);
+
+        expect(errorDetector.clickRetryButton).toHaveBeenCalled();
+        expect(update).toHaveBeenCalledWith(
+            expect.objectContaining({
+                embeds: expect.arrayContaining([
+                    expect.objectContaining({
+                        data: expect.objectContaining({
+                            color: 0x2ECC71, // Green for retry success
+                        }),
+                    }),
+                ]),
+            }),
+        );
+    });
+});

--- a/tests/events/interactionCreateHandler.planning.test.ts
+++ b/tests/events/interactionCreateHandler.planning.test.ts
@@ -32,6 +32,7 @@ describe('interactionCreateHandler - planning buttons', () => {
             handleScreenshot: jest.fn(),
             getCurrentCdp: jest.fn(),
             parseApprovalCustomId: jest.fn().mockReturnValue(null),
+            parseErrorPopupCustomId: jest.fn().mockReturnValue(null),
             parsePlanningCustomId: jest.fn().mockReturnValue(null),
             handleSlashInteraction: jest.fn(),
             ...overrides,

--- a/tests/events/interactionCreateHandler.test.ts
+++ b/tests/events/interactionCreateHandler.test.ts
@@ -25,6 +25,7 @@ describe('interactionCreateHandler', () => {
             handleScreenshot: jest.fn(),
             getCurrentCdp: jest.fn(),
             parseApprovalCustomId: jest.fn(),
+            parseErrorPopupCustomId: jest.fn().mockReturnValue(null),
             parsePlanningCustomId: jest.fn().mockReturnValue(null),
             handleSlashInteraction: jest.fn(),
         });
@@ -76,6 +77,7 @@ describe('interactionCreateHandler', () => {
                 workspaceDirName: 'ws-a',
                 channelId: 'channel-a',
             }),
+            parseErrorPopupCustomId: jest.fn().mockReturnValue(null),
             parsePlanningCustomId: jest.fn().mockReturnValue(null),
             handleSlashInteraction: jest.fn(),
         });
@@ -123,6 +125,7 @@ describe('interactionCreateHandler', () => {
             handleScreenshot: jest.fn(),
             getCurrentCdp: jest.fn(),
             parseApprovalCustomId: jest.fn().mockReturnValue(null),
+            parseErrorPopupCustomId: jest.fn().mockReturnValue(null),
             parsePlanningCustomId: jest.fn().mockReturnValue(null),
             handleSlashInteraction: jest.fn(),
         });

--- a/tests/events/messageCreateHandler.test.ts
+++ b/tests/events/messageCreateHandler.test.ts
@@ -67,6 +67,7 @@ describe('messageCreateHandler', () => {
             handleScreenshot: jest.fn(),
             getCurrentCdp: jest.fn(),
             ensureApprovalDetector: jest.fn(),
+            ensureErrorPopupDetector: jest.fn(),
             ensurePlanningDetector: jest.fn(),
             registerApprovalWorkspaceChannel: jest.fn(),
             registerApprovalSessionChannel,

--- a/tests/services/errorPopupDetector.test.ts
+++ b/tests/services/errorPopupDetector.test.ts
@@ -1,0 +1,526 @@
+/**
+ * Error popup detection and remote execution TDD test
+ *
+ * Test strategy:
+ *   - ErrorPopupDetector class is the test target
+ *   - Mock CdpService to simulate DOM error popup detection
+ *   - Verify that onErrorPopup callback is called upon detection
+ *   - Verify clickDismissButton / clickCopyDebugInfoButton / clickRetryButton / readClipboard behavior
+ *   - Verify duplicate prevention, cooldown, stop, and CDP error recovery
+ */
+
+import { ErrorPopupDetector, ErrorPopupDetectorOptions, ErrorPopupInfo } from '../../src/services/errorPopupDetector';
+import { CdpService } from '../../src/services/cdpService';
+
+// Mock CdpService
+jest.mock('../../src/services/cdpService');
+const MockedCdpService = CdpService as jest.MockedClass<typeof CdpService>;
+
+describe('ErrorPopupDetector - error popup detection and remote execution', () => {
+    let detector: ErrorPopupDetector;
+    let mockCdpService: jest.Mocked<CdpService>;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        mockCdpService = new MockedCdpService() as jest.Mocked<CdpService>;
+        mockCdpService.getPrimaryContextId = jest.fn().mockReturnValue(42);
+        jest.clearAllMocks();
+    });
+
+    afterEach(async () => {
+        if (detector) {
+            await detector.stop();
+        }
+        jest.useRealTimers();
+    });
+
+    /** Helper to generate ErrorPopupInfo for testing */
+    function makeErrorPopupInfo(overrides: Partial<ErrorPopupInfo> = {}): ErrorPopupInfo {
+        return {
+            title: 'Agent terminated due to error',
+            body: 'The agent encountered an unexpected error and was terminated.',
+            buttons: ['Dismiss', 'Copy debug info', 'Retry'],
+            ...overrides,
+        };
+    }
+
+    // ──────────────────────────────────────────────────────
+    // Test 1: Call onErrorPopup when error popup is detected
+    // ──────────────────────────────────────────────────────
+    it('calls the onErrorPopup callback when an error popup is detected', async () => {
+        const onErrorPopup = jest.fn();
+        const mockInfo = makeErrorPopupInfo();
+
+        mockCdpService.call.mockResolvedValue({
+            result: { value: mockInfo },
+        });
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup,
+        });
+        detector.start();
+
+        await jest.advanceTimersByTimeAsync(500);
+
+        expect(onErrorPopup).toHaveBeenCalledTimes(1);
+        expect(onErrorPopup).toHaveBeenCalledWith(
+            expect.objectContaining({
+                title: 'Agent terminated due to error',
+                buttons: expect.arrayContaining(['Dismiss', 'Copy debug info', 'Retry']),
+            }),
+        );
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 2: Do not call the callback when no error popup exists
+    // ──────────────────────────────────────────────────────
+    it('does not call the callback when no error popup exists', async () => {
+        const onErrorPopup = jest.fn();
+        mockCdpService.call.mockResolvedValue({ result: { value: null } });
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup,
+        });
+        detector.start();
+
+        await jest.advanceTimersByTimeAsync(500);
+
+        expect(onErrorPopup).not.toHaveBeenCalled();
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 3: No duplicate calls for the same popup detected consecutively
+    // ──────────────────────────────────────────────────────
+    it('does not call the callback multiple times when the same error popup is detected', async () => {
+        const onErrorPopup = jest.fn();
+        const mockInfo = makeErrorPopupInfo();
+
+        mockCdpService.call.mockResolvedValue({
+            result: { value: mockInfo },
+        });
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup,
+        });
+        detector.start();
+
+        // 3 polling cycles
+        await jest.advanceTimersByTimeAsync(500);
+        await jest.advanceTimersByTimeAsync(500);
+        await jest.advanceTimersByTimeAsync(500);
+
+        // Should be called only once since the content is the same
+        expect(onErrorPopup).toHaveBeenCalledTimes(1);
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 3b: Dedup uses title + body snippet as key
+    // ──────────────────────────────────────────────────────
+    it('treats detections with same title and body as duplicate', async () => {
+        const onErrorPopup = jest.fn();
+
+        const info1 = makeErrorPopupInfo({ buttons: ['Dismiss', 'Retry'] });
+        const info2 = makeErrorPopupInfo({ buttons: ['Dismiss', 'Copy debug info', 'Retry'] });
+        // Both have same title + body -> same key
+
+        mockCdpService.call
+            .mockResolvedValueOnce({ result: { value: info1 } })
+            .mockResolvedValueOnce({ result: { value: info2 } });
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup,
+        });
+        detector.start();
+
+        await jest.advanceTimersByTimeAsync(500);
+        await jest.advanceTimersByTimeAsync(500);
+
+        // Same title+body pair -> only 1 notification
+        expect(onErrorPopup).toHaveBeenCalledTimes(1);
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 3c: Cooldown suppresses rapid re-detection after key reset
+    // ──────────────────────────────────────────────────────
+    it('suppresses re-detection within 10s cooldown even after key reset', async () => {
+        const onErrorPopup = jest.fn();
+        const mockInfo = makeErrorPopupInfo();
+
+        // detected -> disappear -> re-detected (within cooldown)
+        mockCdpService.call
+            .mockResolvedValueOnce({ result: { value: mockInfo } })   // detected
+            .mockResolvedValueOnce({ result: { value: null } })       // disappear (key reset)
+            .mockResolvedValueOnce({ result: { value: mockInfo } });  // re-detected
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup,
+        });
+        detector.start();
+
+        await jest.advanceTimersByTimeAsync(500);  // detect
+        expect(onErrorPopup).toHaveBeenCalledTimes(1);
+
+        await jest.advanceTimersByTimeAsync(500);  // disappear
+        await jest.advanceTimersByTimeAsync(500);  // re-detect within cooldown (1500ms total)
+
+        // Still only 1 notification due to cooldown (10s)
+        expect(onErrorPopup).toHaveBeenCalledTimes(1);
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 4: clickDismissButton() can click the Dismiss button
+    // ──────────────────────────────────────────────────────
+    it('executes a click script via CDP when clickDismissButton() is called', async () => {
+        mockCdpService.call.mockResolvedValue({
+            result: { value: { ok: true } },
+        });
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup: jest.fn(),
+        });
+
+        const result = await detector.clickDismissButton();
+
+        expect(result).toBe(true);
+        expect(mockCdpService.call).toHaveBeenCalledWith(
+            'Runtime.evaluate',
+            expect.objectContaining({
+                expression: expect.stringContaining('Dismiss'),
+                returnByValue: true,
+                contextId: 42,
+            }),
+        );
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 5: clickCopyDebugInfoButton() can click the Copy debug info button
+    // ──────────────────────────────────────────────────────
+    it('executes a click script via CDP when clickCopyDebugInfoButton() is called', async () => {
+        mockCdpService.call.mockResolvedValue({
+            result: { value: { ok: true } },
+        });
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup: jest.fn(),
+        });
+
+        const result = await detector.clickCopyDebugInfoButton();
+
+        expect(result).toBe(true);
+        expect(mockCdpService.call).toHaveBeenCalledWith(
+            'Runtime.evaluate',
+            expect.objectContaining({
+                expression: expect.stringContaining('Copy debug info'),
+                returnByValue: true,
+                contextId: 42,
+            }),
+        );
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 6: clickRetryButton() can click the Retry button
+    // ──────────────────────────────────────────────────────
+    it('executes a click script via CDP when clickRetryButton() is called', async () => {
+        mockCdpService.call.mockResolvedValue({
+            result: { value: { ok: true } },
+        });
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup: jest.fn(),
+        });
+
+        const result = await detector.clickRetryButton();
+
+        expect(result).toBe(true);
+        expect(mockCdpService.call).toHaveBeenCalledWith(
+            'Runtime.evaluate',
+            expect.objectContaining({
+                expression: expect.stringContaining('Retry'),
+                returnByValue: true,
+                contextId: 42,
+            }),
+        );
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 7: readClipboard() returns clipboard text
+    // ──────────────────────────────────────────────────────
+    it('readClipboard() returns the clipboard text', async () => {
+        const debugInfo = 'Error: Agent terminated\nStack: at line 42\nVersion: 1.0.0';
+        mockCdpService.call.mockResolvedValue({
+            result: { value: debugInfo },
+        });
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup: jest.fn(),
+        });
+
+        const content = await detector.readClipboard();
+
+        expect(content).toBe(debugInfo);
+        expect(mockCdpService.call).toHaveBeenCalledWith(
+            'Runtime.evaluate',
+            expect.objectContaining({
+                awaitPromise: true,
+            }),
+        );
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 8: readClipboard() returns null when clipboard is empty
+    // ──────────────────────────────────────────────────────
+    it('readClipboard() returns null when clipboard content is not available', async () => {
+        mockCdpService.call.mockResolvedValue({
+            result: { value: null },
+        });
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup: jest.fn(),
+        });
+
+        const content = await detector.readClipboard();
+
+        expect(content).toBeNull();
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 9: readClipboard() returns null on CDP error
+    // ──────────────────────────────────────────────────────
+    it('readClipboard() returns null when a CDP error occurs', async () => {
+        mockCdpService.call.mockRejectedValue(new Error('CDP connection lost'));
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup: jest.fn(),
+        });
+
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
+
+        const content = await detector.readClipboard();
+
+        expect(content).toBeNull();
+
+        consoleErrorSpy.mockRestore();
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 10: Polling stops after stop()
+    // ──────────────────────────────────────────────────────
+    it('stops polling and no longer calls the callback after stop()', async () => {
+        const onErrorPopup = jest.fn();
+        const mockInfo = makeErrorPopupInfo();
+
+        mockCdpService.call.mockResolvedValue({
+            result: { value: mockInfo },
+        });
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup,
+        });
+        detector.start();
+
+        await jest.advanceTimersByTimeAsync(500);
+        expect(onErrorPopup).toHaveBeenCalledTimes(1);
+
+        await detector.stop();
+
+        // Polling after stop is skipped
+        await jest.advanceTimersByTimeAsync(1000);
+        expect(onErrorPopup).toHaveBeenCalledTimes(1); // does not increase
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 11: Monitoring continues on CDP error
+    // ──────────────────────────────────────────────────────
+    it('continues monitoring even when a CDP error occurs', async () => {
+        const onErrorPopup = jest.fn();
+        const mockInfo = makeErrorPopupInfo({ title: 'Recovery Error' });
+
+        mockCdpService.call
+            .mockRejectedValueOnce(new Error('CDP error'))  // 1st call: error
+            .mockResolvedValueOnce({ result: { value: mockInfo } }); // 2nd call: success
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup,
+        });
+        detector.start();
+
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
+
+        await jest.advanceTimersByTimeAsync(500); // error
+        await jest.advanceTimersByTimeAsync(500); // success
+
+        expect(onErrorPopup).toHaveBeenCalledWith(
+            expect.objectContaining({ title: 'Recovery Error' }),
+        );
+
+        consoleErrorSpy.mockRestore();
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 12: getLastDetectedInfo() returns detected info
+    // ──────────────────────────────────────────────────────
+    it('getLastDetectedInfo() returns the detected ErrorPopupInfo', async () => {
+        const mockInfo = makeErrorPopupInfo({
+            title: 'Custom Error',
+            body: 'Something went wrong with the agent.',
+        });
+
+        mockCdpService.call.mockResolvedValue({
+            result: { value: mockInfo },
+        });
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup: jest.fn(),
+        });
+
+        // null before detection
+        expect(detector.getLastDetectedInfo()).toBeNull();
+
+        detector.start();
+        await jest.advanceTimersByTimeAsync(500);
+
+        const info = detector.getLastDetectedInfo();
+        expect(info).not.toBeNull();
+        expect(info?.title).toBe('Custom Error');
+        expect(info?.body).toBe('Something went wrong with the agent.');
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 13: lastDetectedInfo resets when popup disappears
+    // ──────────────────────────────────────────────────────
+    it('getLastDetectedInfo() returns null when error popup disappears', async () => {
+        const mockInfo = makeErrorPopupInfo();
+
+        mockCdpService.call
+            .mockResolvedValueOnce({ result: { value: mockInfo } })  // 1st: detected
+            .mockResolvedValueOnce({ result: { value: null } });     // 2nd: disappeared
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup: jest.fn(),
+        });
+        detector.start();
+
+        await jest.advanceTimersByTimeAsync(500); // detection
+        expect(detector.getLastDetectedInfo()).not.toBeNull();
+
+        await jest.advanceTimersByTimeAsync(500); // disappearance
+        expect(detector.getLastDetectedInfo()).toBeNull();
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 14: isActive() returns correct state
+    // ──────────────────────────────────────────────────────
+    it('isActive() returns true while running and false after stop', async () => {
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup: jest.fn(),
+        });
+
+        expect(detector.isActive()).toBe(false);
+
+        detector.start();
+        expect(detector.isActive()).toBe(true);
+
+        await detector.stop();
+        expect(detector.isActive()).toBe(false);
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 15: Calls without contextId parameter when contextId is null
+    // ──────────────────────────────────────────────────────
+    it('calls without the contextId parameter when contextId is null', async () => {
+        mockCdpService.getPrimaryContextId = jest.fn().mockReturnValue(null);
+        mockCdpService.call.mockResolvedValue({ result: { value: null } });
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup: jest.fn(),
+        });
+        detector.start();
+
+        await jest.advanceTimersByTimeAsync(500);
+
+        expect(mockCdpService.call).toHaveBeenCalledWith(
+            'Runtime.evaluate',
+            expect.not.objectContaining({ contextId: expect.anything() }),
+        );
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 16: clickDismissButton() returns false on CDP error
+    // ──────────────────────────────────────────────────────
+    it('clickDismissButton() returns false when a CDP error occurs', async () => {
+        mockCdpService.call.mockRejectedValue(new Error('CDP error'));
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup: jest.fn(),
+        });
+
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
+
+        const result = await detector.clickDismissButton();
+
+        expect(result).toBe(false);
+
+        consoleErrorSpy.mockRestore();
+    });
+
+    // ──────────────────────────────────────────────────────
+    // Test 17: WebSocket disconnect errors are silently ignored
+    // ──────────────────────────────────────────────────────
+    it('silently ignores WebSocket disconnect errors during polling', async () => {
+        const onErrorPopup = jest.fn();
+        mockCdpService.call.mockRejectedValue(new Error('WebSocket is not connected'));
+
+        detector = new ErrorPopupDetector({
+            cdpService: mockCdpService,
+            pollIntervalMs: 500,
+            onErrorPopup,
+        });
+
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
+
+        detector.start();
+        await jest.advanceTimersByTimeAsync(500);
+
+        expect(onErrorPopup).not.toHaveBeenCalled();
+        // The WebSocket error should be silently ignored (not logged)
+        expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+        consoleErrorSpy.mockRestore();
+    });
+});


### PR DESCRIPTION
## Summary
- **Stop output suppression**: When user invokes `/stop`, only the "⏹️ Generation Interrupted" embed is shown. The "✅ Final Output" embed is no longer displayed, preventing confusing partial output after intentional stop.
- **Error popup detection**: Add `ErrorPopupDetector` service that monitors for error popups in the Antigravity UI via CDP, with dismiss/retry/copy-debug actions forwarded to Discord.

Closes #1

## Changes
- `src/bot/index.ts`: Add `userStopRequestedChannels` Set to track channels where `/stop` was used; skip output in `onComplete` when flagged
- `src/services/errorPopupDetector.ts`: New service for detecting and handling error popups
- `src/services/cdpBridgeManager.ts`: Wire `ErrorPopupDetector` into CDP bridge lifecycle
- `src/services/cdpConnectionPool.ts`: Add error popup detector storage
- `src/events/interactionCreateHandler.ts`: Handle error popup button interactions
- `src/events/messageCreateHandler.ts`: Initialize error popup detector on message

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 490 tests pass (`npm test`) — 55 suites, 0 failures
- [x] Manual: Send prompt, invoke `/stop` mid-generation → verify only "⏹️ Generation Interrupted" is shown, no "✅ Final Output"
- [ ] Manual: Trigger error popup in Antigravity → verify Discord notification with dismiss/retry buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)