### PR TITLE
fix: exclude role="dialog" containers from activity scan

### DIFF
--- a/src/services/assistantDomExtractor.ts
+++ b/src/services/assistantDomExtractor.ts
@@ -173,6 +173,7 @@ export function extractAssistantSegmentsPayloadScript(): string {
         if (node.closest('details')) return true;
         if (node.closest('[class*="feedback"], footer')) return true;
         if (node.closest('.notify-user-container')) return true;
+        if (node.closest('[role="dialog"]')) return true;
         return false;
     };
 

--- a/src/services/responseMonitor.ts
+++ b/src/services/responseMonitor.ts
@@ -48,6 +48,7 @@ export const RESPONSE_SELECTORS = {
             if (node.closest('details')) return true;
             if (node.closest('[class*="feedback"], footer')) return true;
             if (node.closest('.notify-user-container')) return true;
+            if (node.closest('[role="dialog"]')) return true;
             return false;
         };
 
@@ -215,6 +216,7 @@ export const RESPONSE_SELECTORS = {
             if (node.closest('details')) return true;
             if (node.closest('[class*="feedback"], footer')) return true;
             if (node.closest('.notify-user-container')) return true;
+            if (node.closest('[role="dialog"]')) return true;
             return false;
         };
         const looksLikeToolOutput = (text) => {
@@ -307,6 +309,7 @@ export const RESPONSE_SELECTORS = {
             if (node.closest('details')) return true;
             if (node.closest('[class*="feedback"], footer')) return true;
             if (node.closest('.notify-user-container')) return true;
+            if (node.closest('[role="dialog"]')) return true;
             return false;
         };
 

--- a/tests/services/assistantDomExtractor.test.ts
+++ b/tests/services/assistantDomExtractor.test.ts
@@ -206,6 +206,40 @@ describe('assistantDomExtractor', () => {
             }
         });
 
+        it('skips mode description inside role="dialog" container', () => {
+            const panel = document.createElement('div');
+            panel.className = 'antigravity-agent-side-panel';
+
+            // AG mode selector popup: role="dialog" container
+            const dialog = document.createElement('div');
+            dialog.setAttribute('role', 'dialog');
+            const modeOption = document.createElement('div');
+            modeOption.className = 'flex flex-col';
+            const modeName = document.createElement('div');
+            modeName.className = 'font-medium';
+            modeName.textContent = 'Planning';
+            const modeDesc = document.createElement('div');
+            modeDesc.className = 'text-xs opacity-50';
+            modeDesc.textContent =
+                'Agent can plan before executing tasks. Use for deep research, complex tasks, or collaborative work';
+            modeOption.appendChild(modeName);
+            modeOption.appendChild(modeDesc);
+            dialog.appendChild(modeOption);
+            panel.appendChild(dialog);
+
+            document.body.appendChild(panel);
+
+            const script = extractAssistantSegmentsPayloadScript();
+            const scriptEl = document.createElement('script');
+            scriptEl.textContent = `window.__pass25DialogPayload = ${script};`;
+            document.body.appendChild(scriptEl);
+            const payload = (window as any).__pass25DialogPayload;
+            const result = classifyAssistantSegments(payload);
+
+            // Neither "Planning" nor the description should appear in activity
+            expect(result.activityLines).toEqual([]);
+        });
+
         it('skips container elements with more than 3 children', () => {
             const panel = document.createElement('div');
             panel.className = 'antigravity-agent-side-panel';


### PR DESCRIPTION
## Summary

- AG's mode selector popup (`role="dialog"`) contains mode descriptions starting with activity verbs (e.g. "Planning Agent can plan before executing tasks...")
- Pass 2.5 broad activity scan was incorrectly capturing these as process log entries
- Add `[role="dialog"]` to `isInsideExcludedContainer` in both structured and legacy extraction paths

## Changes

| File | Change |
|------|--------|
| `src/services/assistantDomExtractor.ts` | Add `[role="dialog"]` exclusion (structured mode) |
| `src/services/responseMonitor.ts` | Add `[role="dialog"]` exclusion to all 3 IIFE instances (legacy mode) |
| `tests/services/assistantDomExtractor.test.ts` | Add test: mode description inside `role="dialog"` is excluded |

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 532 tests pass (`npm test`)
- [x] Manual: open mode selector → verify mode descriptions don't appear in process log
- [x] Manual: verify thinking entries and activity logs still appear normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)