### PR TITLE
feat: auto update check on startup

### DIFF
--- a/src/bin/commands/start.ts
+++ b/src/bin/commands/start.ts
@@ -4,6 +4,8 @@ import { acquireLock } from '../../utils/lockfile';
 import { startBot } from '../../bot';
 import { logger } from '../../utils/logger';
 import type { LogLevel } from '../../utils/logger';
+import { version } from '../../../package.json';
+import { checkForUpdates } from '../../services/updateCheckService';
 
 /**
  * Resolve log level from CLI flags on the root program.
@@ -29,6 +31,10 @@ export async function startAction(
 
     console.log(LOGO);
     acquireLock();
+
+    // Non-blocking update check (fire-and-forget)
+    checkForUpdates(version).catch(() => {});
+
     await startBot(cliLevel).catch((err) => {
         logger.error('Failed to start bot:', err);
         process.exit(1);

--- a/src/services/updateCheckService.ts
+++ b/src/services/updateCheckService.ts
@@ -1,0 +1,118 @@
+import * as https from 'https';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const CONFIG_DIR = '.lazy-gravity';
+export const UPDATE_CHECK_FILE = 'update-check.json';
+export const COOLDOWN_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+const REGISTRY_URL = 'https://registry.npmjs.org/lazy-gravity/latest';
+const REQUEST_TIMEOUT_MS = 5000;
+
+interface UpdateCheckCache {
+    lastCheck: number;
+}
+
+function getCachePath(): string {
+    return path.join(os.homedir(), CONFIG_DIR, UPDATE_CHECK_FILE);
+}
+
+/**
+ * Determine whether enough time has elapsed since the last update check.
+ * Returns true if we should query the registry.
+ */
+export function shouldCheckForUpdates(): boolean {
+    const cachePath = getCachePath();
+    try {
+        if (!fs.existsSync(cachePath)) return true;
+        const raw = fs.readFileSync(cachePath, 'utf-8');
+        const cache: UpdateCheckCache = JSON.parse(raw);
+        return Date.now() - cache.lastCheck >= COOLDOWN_MS;
+    } catch {
+        return true;
+    }
+}
+
+/**
+ * Query the npm registry for the latest published version.
+ */
+export function fetchLatestVersion(): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const req = https.get(REGISTRY_URL, (res) => {
+            if (res.statusCode !== 200) {
+                reject(new Error(`HTTP ${res.statusCode}`));
+                return;
+            }
+
+            let body = '';
+            res.on('data', (chunk: string) => {
+                body += chunk;
+            });
+            res.on('end', () => {
+                try {
+                    const data = JSON.parse(body);
+                    resolve(data.version);
+                } catch (err) {
+                    reject(err);
+                }
+            });
+        });
+
+        req.on('error', reject);
+        req.on('timeout', () => {
+            req.destroy();
+            reject(new Error('Request timed out'));
+        });
+    });
+}
+
+function writeCache(): void {
+    const cachePath = getCachePath();
+    const dir = path.dirname(cachePath);
+    try {
+        if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir, { recursive: true });
+        }
+        const cache: UpdateCheckCache = { lastCheck: Date.now() };
+        fs.writeFileSync(cachePath, JSON.stringify(cache), 'utf-8');
+    } catch {
+        // Silently ignore cache write failures
+    }
+}
+
+/**
+ * Compare two semver strings. Returns:
+ *  -1 if a < b, 0 if a === b, 1 if a > b
+ */
+function compareSemver(a: string, b: string): number {
+    const partsA = a.split('.').map(Number);
+    const partsB = b.split('.').map(Number);
+    for (let i = 0; i < 3; i++) {
+        const diff = (partsA[i] ?? 0) - (partsB[i] ?? 0);
+        if (diff < 0) return -1;
+        if (diff > 0) return 1;
+    }
+    return 0;
+}
+
+/**
+ * Non-blocking update check. Call at startup (fire-and-forget).
+ * Respects a 24-hour cooldown via a local cache file.
+ */
+export async function checkForUpdates(currentVersion: string): Promise<void> {
+    if (!shouldCheckForUpdates()) return;
+
+    try {
+        const latest = await fetchLatestVersion();
+        writeCache();
+
+        if (compareSemver(currentVersion, latest) < 0) {
+            console.info(
+                `\n  Update available: ${currentVersion} \u2192 ${latest} \u2014 run \x1b[36mnpm i -g lazy-gravity\x1b[0m\n`,
+            );
+        }
+    } catch {
+        // Silently ignore — update check should never block startup
+    }
+}

--- a/tests/services/updateCheckService.test.ts
+++ b/tests/services/updateCheckService.test.ts
@@ -1,0 +1,275 @@
+import * as https from 'https';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { EventEmitter } from 'events';
+import {
+    checkForUpdates,
+    fetchLatestVersion,
+    shouldCheckForUpdates,
+    UPDATE_CHECK_FILE,
+    COOLDOWN_MS,
+} from '../../src/services/updateCheckService';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('https');
+jest.mock('fs');
+jest.mock('os');
+
+const mockedHttps = jest.mocked(https);
+const mockedFs = jest.mocked(fs);
+const mockedOs = jest.mocked(os);
+
+// Stable home directory for all tests
+const FAKE_HOME = '/home/testuser';
+const CACHE_PATH = path.join(FAKE_HOME, '.lazy-gravity', UPDATE_CHECK_FILE);
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockedOs.homedir.mockReturnValue(FAKE_HOME);
+});
+
+// ---------------------------------------------------------------------------
+// Helper: build a fake HTTP response
+// ---------------------------------------------------------------------------
+
+function fakeResponse(statusCode: number, body: string) {
+    const res = new EventEmitter() as EventEmitter & { statusCode: number };
+    res.statusCode = statusCode;
+    // Emit data + end on next tick so listeners are registered first
+    process.nextTick(() => {
+        res.emit('data', body);
+        res.emit('end');
+    });
+    return res;
+}
+
+function fakeRequest(
+    statusCode: number,
+    body: string,
+): { req: EventEmitter; setup: () => void } {
+    const req = new EventEmitter() as EventEmitter & { end: jest.Mock };
+    req.end = jest.fn();
+    const setup = () => {
+        mockedHttps.get.mockImplementation((_url: any, cb: any) => {
+            const res = fakeResponse(statusCode, body);
+            cb(res);
+            return req as any;
+        });
+    };
+    return { req, setup };
+}
+
+// ---------------------------------------------------------------------------
+// shouldCheckForUpdates
+// ---------------------------------------------------------------------------
+
+describe('shouldCheckForUpdates', () => {
+    it('returns true when no cache file exists', () => {
+        mockedFs.existsSync.mockReturnValue(false);
+        expect(shouldCheckForUpdates()).toBe(true);
+    });
+
+    it('returns true when the cache file has an old timestamp', () => {
+        mockedFs.existsSync.mockReturnValue(true);
+        const oldTimestamp = Date.now() - COOLDOWN_MS - 1000;
+        mockedFs.readFileSync.mockReturnValue(
+            JSON.stringify({ lastCheck: oldTimestamp }),
+        );
+        expect(shouldCheckForUpdates()).toBe(true);
+    });
+
+    it('returns false when the cache file has a recent timestamp', () => {
+        mockedFs.existsSync.mockReturnValue(true);
+        const recentTimestamp = Date.now() - 1000; // 1 second ago
+        mockedFs.readFileSync.mockReturnValue(
+            JSON.stringify({ lastCheck: recentTimestamp }),
+        );
+        expect(shouldCheckForUpdates()).toBe(false);
+    });
+
+    it('returns true when the cache file is corrupted', () => {
+        mockedFs.existsSync.mockReturnValue(true);
+        mockedFs.readFileSync.mockReturnValue('not-json');
+        expect(shouldCheckForUpdates()).toBe(true);
+    });
+
+    it('returns true when readFileSync throws', () => {
+        mockedFs.existsSync.mockReturnValue(true);
+        mockedFs.readFileSync.mockImplementation(() => {
+            throw new Error('EACCES');
+        });
+        expect(shouldCheckForUpdates()).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// fetchLatestVersion
+// ---------------------------------------------------------------------------
+
+describe('fetchLatestVersion', () => {
+    it('returns the version from npm registry', async () => {
+        const { setup } = fakeRequest(200, JSON.stringify({ version: '1.2.3' }));
+        setup();
+
+        const version = await fetchLatestVersion();
+        expect(version).toBe('1.2.3');
+        expect(mockedHttps.get).toHaveBeenCalledWith(
+            'https://registry.npmjs.org/lazy-gravity/latest',
+            expect.any(Function),
+        );
+    });
+
+    it('rejects on non-200 status code', async () => {
+        const { setup } = fakeRequest(404, 'Not Found');
+        setup();
+
+        await expect(fetchLatestVersion()).rejects.toThrow('HTTP 404');
+    });
+
+    it('rejects on invalid JSON response', async () => {
+        const { setup } = fakeRequest(200, 'not-json');
+        setup();
+
+        await expect(fetchLatestVersion()).rejects.toThrow();
+    });
+
+    it('rejects on network error', async () => {
+        const req = new EventEmitter() as EventEmitter & { end: jest.Mock };
+        req.end = jest.fn();
+
+        mockedHttps.get.mockImplementation((_url: any, _cb: any) => {
+            process.nextTick(() => req.emit('error', new Error('ECONNREFUSED')));
+            return req as any;
+        });
+
+        await expect(fetchLatestVersion()).rejects.toThrow('ECONNREFUSED');
+    });
+
+    it('rejects on timeout', async () => {
+        const req = new EventEmitter() as EventEmitter & {
+            end: jest.Mock;
+            destroy: jest.Mock;
+        };
+        req.end = jest.fn();
+        req.destroy = jest.fn();
+
+        mockedHttps.get.mockImplementation((_url: any, _cb: any) => {
+            process.nextTick(() => req.emit('timeout'));
+            return req as any;
+        });
+
+        await expect(fetchLatestVersion()).rejects.toThrow('timed out');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// checkForUpdates (integration of the above)
+// ---------------------------------------------------------------------------
+
+describe('checkForUpdates', () => {
+    const consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation();
+
+    afterEach(() => {
+        consoleInfoSpy.mockClear();
+    });
+
+    afterAll(() => {
+        consoleInfoSpy.mockRestore();
+    });
+
+    it('prints update notice when a newer version is available', async () => {
+        // No cache file → should check
+        mockedFs.existsSync.mockReturnValue(false);
+        mockedFs.mkdirSync.mockReturnValue(undefined);
+        mockedFs.writeFileSync.mockReturnValue(undefined);
+
+        const { setup } = fakeRequest(200, JSON.stringify({ version: '99.0.0' }));
+        setup();
+
+        await checkForUpdates('0.1.0');
+
+        expect(consoleInfoSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Update available'),
+        );
+        expect(consoleInfoSpy).toHaveBeenCalledWith(
+            expect.stringContaining('99.0.0'),
+        );
+        // Should write cache
+        expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+            CACHE_PATH,
+            expect.stringContaining('lastCheck'),
+            'utf-8',
+        );
+    });
+
+    it('does nothing when already on latest version', async () => {
+        mockedFs.existsSync.mockReturnValue(false);
+        mockedFs.mkdirSync.mockReturnValue(undefined);
+        mockedFs.writeFileSync.mockReturnValue(undefined);
+
+        const { setup } = fakeRequest(200, JSON.stringify({ version: '0.1.0' }));
+        setup();
+
+        await checkForUpdates('0.1.0');
+
+        expect(consoleInfoSpy).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when local version is newer than registry', async () => {
+        mockedFs.existsSync.mockReturnValue(false);
+        mockedFs.mkdirSync.mockReturnValue(undefined);
+        mockedFs.writeFileSync.mockReturnValue(undefined);
+
+        const { setup } = fakeRequest(200, JSON.stringify({ version: '0.0.9' }));
+        setup();
+
+        await checkForUpdates('0.1.0');
+
+        expect(consoleInfoSpy).not.toHaveBeenCalled();
+    });
+
+    it('skips check when cooldown has not elapsed', async () => {
+        // Cache file exists and is recent
+        mockedFs.existsSync.mockReturnValue(true);
+        mockedFs.readFileSync.mockReturnValue(
+            JSON.stringify({ lastCheck: Date.now() }),
+        );
+
+        await checkForUpdates('0.1.0');
+
+        expect(mockedHttps.get).not.toHaveBeenCalled();
+        expect(consoleInfoSpy).not.toHaveBeenCalled();
+    });
+
+    it('silently swallows network errors', async () => {
+        mockedFs.existsSync.mockReturnValue(false);
+
+        const req = new EventEmitter() as EventEmitter & { end: jest.Mock };
+        req.end = jest.fn();
+        mockedHttps.get.mockImplementation((_url: any, _cb: any) => {
+            process.nextTick(() => req.emit('error', new Error('offline')));
+            return req as any;
+        });
+
+        // Should not throw
+        await expect(checkForUpdates('0.1.0')).resolves.toBeUndefined();
+        expect(consoleInfoSpy).not.toHaveBeenCalled();
+    });
+
+    it('writes cache even when versions match', async () => {
+        mockedFs.existsSync.mockReturnValue(false);
+        mockedFs.mkdirSync.mockReturnValue(undefined);
+        mockedFs.writeFileSync.mockReturnValue(undefined);
+
+        const { setup } = fakeRequest(200, JSON.stringify({ version: '0.1.0' }));
+        setup();
+
+        await checkForUpdates('0.1.0');
+
+        expect(mockedFs.writeFileSync).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- Query npm registry (`lazy-gravity/latest`) on startup and print a one-line notice when a newer version is available
- Non-blocking: uses fire-and-forget pattern so bot startup is never delayed
- 24-hour cooldown cached in `~/.lazy-gravity/update-check.json` to avoid excessive requests

Closes #11

## Changes
- **New**: `src/services/updateCheckService.ts` — `fetchLatestVersion()`, `shouldCheckForUpdates()`, `checkForUpdates()`
- **Modified**: `src/bin/commands/start.ts` — call `checkForUpdates()` after `acquireLock()`
- **New**: `tests/services/updateCheckService.test.ts` — 16 tests covering cache logic, HTTP handling, semver comparison, and error resilience

## Test plan
- [x] 16 unit tests pass (cache cooldown, HTTP success/error/timeout, semver comparison, fire-and-forget error swallowing)
- [x] Full test suite passes (585 tests)
- [x] Build succeeds