### PR TITLE
fix: make Antigravity paths platform-aware for Windows support

### DIFF
--- a/src/bin/commands/doctor.ts
+++ b/src/bin/commands/doctor.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { CDP_PORTS } from '../../utils/cdpPorts';
 import { ConfigLoader } from '../../utils/configLoader';
+import { getAntigravityCdpHint } from '../../utils/antigravityPaths';
 import { COLORS } from '../../utils/logger';
 
 const ok = (msg: string) => console.log(`  ${COLORS.green}[OK]${COLORS.reset} ${msg}`);
@@ -104,7 +105,7 @@ export async function doctorAction(): Promise<void> {
     }
     if (!cdpOk) {
         fail('No CDP ports responding');
-        hint('Run: open -a Antigravity --args --remote-debugging-port=9222');
+        hint(`Run: ${getAntigravityCdpHint(9222)}`);
         allOk = false;
     }
 

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -43,6 +43,7 @@ import { CdpService } from '../services/cdpService';
 import { ChatSessionService } from '../services/chatSessionService';
 import { ResponseMonitor, RESPONSE_SELECTORS } from '../services/responseMonitor';
 import { ensureAntigravityRunning } from '../services/antigravityLauncher';
+import { getAntigravityCdpHint } from '../utils/antigravityPaths';
 import { AutoAcceptService } from '../services/autoAcceptService';
 import { PromptDispatcher } from '../services/promptDispatcher';
 import {
@@ -291,7 +292,7 @@ async function sendPromptToAntigravity(
     if (!cdp.isConnected()) {
         await sendEmbed(
             `${PHASE_ICONS.error} Connection Error`,
-            'Not connected to Antigravity.\nStart with `open -a Antigravity --args --remote-debugging-port=9223`, then send a message to auto-connect.',
+            `Not connected to Antigravity.\nStart with \`${getAntigravityCdpHint(9223)}\`, then send a message to auto-connect.`,
             PHASE_COLORS.error,
         );
         await clearWatchingReaction();

--- a/src/services/antigravityLauncher.ts
+++ b/src/services/antigravityLauncher.ts
@@ -1,5 +1,6 @@
 import { logger } from '../utils/logger';
 import { CDP_PORTS } from '../utils/cdpPorts';
+import { getAntigravityCdpHint } from '../utils/antigravityPaths';
 import * as http from 'http';
 
 /**
@@ -50,7 +51,7 @@ export async function ensureAntigravityRunning(): Promise<void> {
     logger.warn('  Please run AntigravityDebug.command before starting the Bot');
     logger.warn('');
     logger.warn('  Or manually:');
-    logger.warn('    open -a Antigravity --args --remote-debugging-port=9222');
+    logger.warn(`    ${getAntigravityCdpHint(9222)}`);
     logger.warn('='.repeat(70));
     logger.warn('');
 }

--- a/src/utils/antigravityPaths.ts
+++ b/src/utils/antigravityPaths.ts
@@ -1,0 +1,60 @@
+import * as os from 'os';
+import * as path from 'path';
+
+const APP_NAME = 'Antigravity';
+
+/**
+ * Get the Antigravity CLI binary path for the current platform.
+ *
+ * - macOS: /Applications/Antigravity.app/Contents/Resources/app/bin/antigravity
+ * - Windows: %LOCALAPPDATA%\Programs\Antigravity\Antigravity.exe
+ * - Linux: antigravity (assumed in PATH)
+ */
+export function getAntigravityCliPath(): string {
+    switch (process.platform) {
+        case 'darwin':
+            return '/Applications/Antigravity.app/Contents/Resources/app/bin/antigravity';
+        case 'win32': {
+            const localAppData = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
+            return path.join(localAppData, 'Programs', APP_NAME, `${APP_NAME}.exe`);
+        }
+        default:
+            return APP_NAME.toLowerCase();
+    }
+}
+
+/**
+ * Get fallback launch command and args for opening a workspace.
+ *
+ * - macOS: open -a Antigravity <path>
+ * - Windows: use full exe path with shell (handles spaces in paths)
+ * - Linux: antigravity <path>
+ */
+export function getAntigravityFallback(workspacePath: string): { command: string; args: string[]; options?: { shell: boolean } } {
+    switch (process.platform) {
+        case 'darwin':
+            return { command: 'open', args: ['-a', APP_NAME, workspacePath] };
+        case 'win32': {
+            const exePath = getAntigravityCliPath();
+            return { command: exePath, args: [workspacePath], options: { shell: true } };
+        }
+        default:
+            return { command: APP_NAME.toLowerCase(), args: [workspacePath] };
+    }
+}
+
+/**
+ * Get a platform-appropriate hint for starting Antigravity with CDP.
+ *
+ * Used in user-facing messages (Discord embeds, CLI doctor, logs).
+ */
+export function getAntigravityCdpHint(port: number = 9222): string {
+    switch (process.platform) {
+        case 'darwin':
+            return `open -a ${APP_NAME} --args --remote-debugging-port=${port}`;
+        case 'win32':
+            return `${APP_NAME}.exe --remote-debugging-port=${port}`;
+        default:
+            return `${APP_NAME.toLowerCase()} --remote-debugging-port=${port}`;
+    }
+}

--- a/tests/utils/antigravityPaths.test.ts
+++ b/tests/utils/antigravityPaths.test.ts
@@ -1,0 +1,141 @@
+import { getAntigravityCliPath, getAntigravityFallback, getAntigravityCdpHint } from '../../src/utils/antigravityPaths';
+import * as os from 'os';
+import * as path from 'path';
+
+// Helper to temporarily override process.platform
+function withPlatform(platform: string, fn: () => void): void {
+    const original = Object.getOwnPropertyDescriptor(process, 'platform')!;
+    Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+    try {
+        fn();
+    } finally {
+        Object.defineProperty(process, 'platform', original);
+    }
+}
+
+describe('antigravityPaths', () => {
+    describe('getAntigravityCliPath', () => {
+        it('returns macOS CLI path on darwin', () => {
+            withPlatform('darwin', () => {
+                expect(getAntigravityCliPath()).toBe(
+                    '/Applications/Antigravity.app/Contents/Resources/app/bin/antigravity',
+                );
+            });
+        });
+
+        it('returns Windows exe path on win32', () => {
+            const origEnv = process.env.LOCALAPPDATA;
+            process.env.LOCALAPPDATA = 'C:\\Users\\test\\AppData\\Local';
+            try {
+                withPlatform('win32', () => {
+                    expect(getAntigravityCliPath()).toBe(
+                        path.join('C:\\Users\\test\\AppData\\Local', 'Programs', 'Antigravity', 'Antigravity.exe'),
+                    );
+                });
+            } finally {
+                if (origEnv === undefined) {
+                    delete process.env.LOCALAPPDATA;
+                } else {
+                    process.env.LOCALAPPDATA = origEnv;
+                }
+            }
+        });
+
+        it('falls back to homedir on win32 without LOCALAPPDATA', () => {
+            const origEnv = process.env.LOCALAPPDATA;
+            delete process.env.LOCALAPPDATA;
+            try {
+                withPlatform('win32', () => {
+                    const expected = path.join(os.homedir(), 'AppData', 'Local', 'Programs', 'Antigravity', 'Antigravity.exe');
+                    expect(getAntigravityCliPath()).toBe(expected);
+                });
+            } finally {
+                if (origEnv !== undefined) {
+                    process.env.LOCALAPPDATA = origEnv;
+                }
+            }
+        });
+
+        it('returns lowercase command on linux', () => {
+            withPlatform('linux', () => {
+                expect(getAntigravityCliPath()).toBe('antigravity');
+            });
+        });
+    });
+
+    describe('getAntigravityFallback', () => {
+        it('returns open -a on darwin', () => {
+            withPlatform('darwin', () => {
+                const result = getAntigravityFallback('/test/path');
+                expect(result.command).toBe('open');
+                expect(result.args).toEqual(['-a', 'Antigravity', '/test/path']);
+                expect(result.options).toBeUndefined();
+            });
+        });
+
+        it('returns exe path with shell on win32', () => {
+            const origEnv = process.env.LOCALAPPDATA;
+            process.env.LOCALAPPDATA = 'C:\\Users\\test\\AppData\\Local';
+            try {
+                withPlatform('win32', () => {
+                    const result = getAntigravityFallback('D:\\ripper');
+                    expect(result.command).toContain('Antigravity.exe');
+                    expect(result.args).toEqual(['D:\\ripper']);
+                    expect(result.options).toEqual({ shell: true });
+                });
+            } finally {
+                if (origEnv === undefined) {
+                    delete process.env.LOCALAPPDATA;
+                } else {
+                    process.env.LOCALAPPDATA = origEnv;
+                }
+            }
+        });
+
+        it('returns lowercase command on linux', () => {
+            withPlatform('linux', () => {
+                const result = getAntigravityFallback('/home/user/project');
+                expect(result.command).toBe('antigravity');
+                expect(result.args).toEqual(['/home/user/project']);
+            });
+        });
+    });
+
+    describe('getAntigravityCdpHint', () => {
+        it('returns open -a hint on darwin', () => {
+            withPlatform('darwin', () => {
+                expect(getAntigravityCdpHint(9222)).toBe(
+                    'open -a Antigravity --args --remote-debugging-port=9222',
+                );
+            });
+        });
+
+        it('returns exe hint on win32', () => {
+            withPlatform('win32', () => {
+                expect(getAntigravityCdpHint(9222)).toBe(
+                    'Antigravity.exe --remote-debugging-port=9222',
+                );
+            });
+        });
+
+        it('returns lowercase hint on linux', () => {
+            withPlatform('linux', () => {
+                expect(getAntigravityCdpHint(9222)).toBe(
+                    'antigravity --remote-debugging-port=9222',
+                );
+            });
+        });
+
+        it('uses default port 9222', () => {
+            withPlatform('darwin', () => {
+                expect(getAntigravityCdpHint()).toContain('9222');
+            });
+        });
+
+        it('uses custom port', () => {
+            withPlatform('darwin', () => {
+                expect(getAntigravityCdpHint(9223)).toContain('9223');
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Add `src/utils/antigravityPaths.ts` with platform-aware utility functions (`getAntigravityCliPath`, `getAntigravityFallback`, `getAntigravityCdpHint`)
- Replace hardcoded macOS paths in `cdpService.ts`, `antigravityLauncher.ts`, `bot/index.ts`, `doctor.ts` with the new utilities
- macOS behavior is unchanged — only adds Windows (`win32`) and Linux support

## Changes

| File | Change |
|------|--------|
| `src/utils/antigravityPaths.ts` | New: platform-aware path resolution |
| `tests/utils/antigravityPaths.test.ts` | New: 12 tests covering all 3 platforms |
| `src/services/cdpService.ts` | Use `getAntigravityCliPath()` + `getAntigravityFallback()` |
| `src/services/antigravityLauncher.ts` | Use `getAntigravityCdpHint()` for warning message |
| `src/bot/index.ts` | Use `getAntigravityCdpHint()` for error embed |
| `src/bin/commands/doctor.ts` | Use `getAntigravityCdpHint()` for hint message |

## Test plan

- [x] All 631 existing tests pass
- [x] 12 new platform-specific tests pass (darwin, win32, linux)
- [x] TypeScript build succeeds
- [ ] **Windows user verification needed** — @mcbobbo please test by installing from this branch:
  ```sh
  npm install github:tokyoweb3/LazyGravity#fix/windows-platform-support
  ```

closes #41