### PR TITLE
fix: platform-aware CDP hints and cross-platform path extraction in connection pool

### DIFF
--- a/src/bin/commands/doctor.ts
+++ b/src/bin/commands/doctor.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { CDP_PORTS } from '../../utils/cdpPorts';
 import { ConfigLoader } from '../../utils/configLoader';
+import { getAntigravityCdpHint } from '../../utils/pathUtils';
 import { COLORS } from '../../utils/logger';
 
 const ok = (msg: string) => console.log(`  ${COLORS.green}[OK]${COLORS.reset} ${msg}`);
@@ -104,7 +105,7 @@ export async function doctorAction(): Promise<void> {
     }
     if (!cdpOk) {
         fail('No CDP ports responding');
-        hint('Run: open -a Antigravity --args --remote-debugging-port=9222');
+        hint(`Run: ${getAntigravityCdpHint(9222)}`);
         allOk = false;
     }
 

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -43,6 +43,7 @@ import { CdpService } from '../services/cdpService';
 import { ChatSessionService } from '../services/chatSessionService';
 import { ResponseMonitor, RESPONSE_SELECTORS } from '../services/responseMonitor';
 import { ensureAntigravityRunning } from '../services/antigravityLauncher';
+import { getAntigravityCdpHint } from '../utils/pathUtils';
 import { AutoAcceptService } from '../services/autoAcceptService';
 import { PromptDispatcher } from '../services/promptDispatcher';
 import {
@@ -291,7 +292,7 @@ async function sendPromptToAntigravity(
     if (!cdp.isConnected()) {
         await sendEmbed(
             `${PHASE_ICONS.error} Connection Error`,
-            'Not connected to Antigravity.\nStart with `open -a Antigravity --args --remote-debugging-port=9223`, then send a message to auto-connect.',
+            `Not connected to Antigravity.\nStart with \`${getAntigravityCdpHint(9223)}\`, then send a message to auto-connect.`,
             PHASE_COLORS.error,
         );
         await clearWatchingReaction();

--- a/src/services/antigravityLauncher.ts
+++ b/src/services/antigravityLauncher.ts
@@ -1,5 +1,6 @@
 import { logger } from '../utils/logger';
 import { CDP_PORTS } from '../utils/cdpPorts';
+import { getAntigravityCdpHint } from '../utils/pathUtils';
 import * as http from 'http';
 
 /**
@@ -50,7 +51,7 @@ export async function ensureAntigravityRunning(): Promise<void> {
     logger.warn('  Please run AntigravityDebug.command before starting the Bot');
     logger.warn('');
     logger.warn('  Or manually:');
-    logger.warn('    open -a Antigravity --args --remote-debugging-port=9222');
+    logger.warn(`    ${getAntigravityCdpHint(9222)}`);
     logger.warn('='.repeat(70));
     logger.warn('');
 }

--- a/src/services/cdpConnectionPool.ts
+++ b/src/services/cdpConnectionPool.ts
@@ -1,4 +1,5 @@
 import { logger } from '../utils/logger';
+import { extractProjectNameFromPath } from '../utils/pathUtils';
 import { CdpService, CdpServiceOptions } from './cdpService';
 import { ApprovalDetector } from './approvalDetector';
 import { ErrorPopupDetector } from './errorPopupDetector';
@@ -212,7 +213,7 @@ export class CdpConnectionPool {
      * Extract the project name from a workspace path.
      */
     extractProjectName(workspacePath: string): string {
-        return workspacePath.split('/').filter(Boolean).pop() || workspacePath;
+        return extractProjectNameFromPath(workspacePath) || workspacePath;
     }
 
     /**

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -31,10 +31,27 @@ export function getAntigravityCliPath(): string {
 /**
  * Helper to extract the project name from a full workspace path.
  * Handles both Windows (backslash) and POSIX (forward slash) paths.
- * 
+ *
  * @param workspacePath The full path to the workspace directory
  * @returns The final folder name
  */
 export function extractProjectNameFromPath(workspacePath: string): string {
     return workspacePath.split(/[/\\]/).filter(Boolean).pop() || '';
+}
+
+/**
+ * Get a platform-appropriate hint for starting Antigravity with CDP.
+ *
+ * Used in user-facing messages (Discord embeds, CLI doctor, logs).
+ */
+export function getAntigravityCdpHint(port: number = 9222): string {
+    const APP_NAME = 'Antigravity';
+    switch (process.platform) {
+        case 'darwin':
+            return `open -a ${APP_NAME} --args --remote-debugging-port=${port}`;
+        case 'win32':
+            return `${APP_NAME}.exe --remote-debugging-port=${port}`;
+        default:
+            return `${APP_NAME.toLowerCase()} --remote-debugging-port=${port}`;
+    }
 }

--- a/tests/commands/chatCommandHandler.test.ts
+++ b/tests/commands/chatCommandHandler.test.ts
@@ -28,7 +28,7 @@ describe('ChatCommandHandler', () => {
             getConnected: jest.fn(),
             getActiveWorkspaceNames: jest.fn().mockReturnValue([]),
             getApprovalDetector: jest.fn(),
-            extractProjectName: jest.fn((path: string) => path.split('/').filter(Boolean).pop() || path),
+            extractProjectName: jest.fn((path: string) => path.split(/[/\\]/).filter(Boolean).pop() || path),
         } as any;
 
         db = new Database(':memory:');

--- a/tests/commands/joinCommandHandler.test.ts
+++ b/tests/commands/joinCommandHandler.test.ts
@@ -57,7 +57,7 @@ describe('JoinCommandHandler', () => {
             getApprovalDetector: jest.fn(),
             getUserMessageDetector: jest.fn(),
             registerUserMessageDetector: jest.fn(),
-            extractProjectName: jest.fn((path: string) => path.split('/').filter(Boolean).pop() || path),
+            extractProjectName: jest.fn((path: string) => path.split(/[/\\]/).filter(Boolean).pop() || path),
         } as any;
 
         mockWorkspaceService = {

--- a/tests/services/cdpConnectionPool.test.ts
+++ b/tests/services/cdpConnectionPool.test.ts
@@ -28,6 +28,18 @@ describe('CdpConnectionPool', () => {
         it('returns a simple name as-is', () => {
             expect(pool.extractProjectName('MyProject')).toBe('MyProject');
         });
+
+        it('handles Windows backslash paths', () => {
+            expect(pool.extractProjectName('D:\\Code\\MyProject')).toBe('MyProject');
+        });
+
+        it('handles Windows drive root paths', () => {
+            expect(pool.extractProjectName('D:\\categorizer')).toBe('categorizer');
+        });
+
+        it('handles mixed separators', () => {
+            expect(pool.extractProjectName('C:\\Users\\test/Code/MyProject')).toBe('MyProject');
+        });
     });
 
     describe('getOrConnect()', () => {

--- a/tests/utils/pathUtils.test.ts
+++ b/tests/utils/pathUtils.test.ts
@@ -1,0 +1,86 @@
+import { extractProjectNameFromPath, getAntigravityCdpHint } from '../../src/utils/pathUtils';
+
+// Helper to temporarily override process.platform
+function withPlatform(platform: string, fn: () => void): void {
+    const original = Object.getOwnPropertyDescriptor(process, 'platform')!;
+    Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+    try {
+        fn();
+    } finally {
+        Object.defineProperty(process, 'platform', original);
+    }
+}
+
+describe('pathUtils', () => {
+    describe('extractProjectNameFromPath()', () => {
+        it('extracts name from POSIX path', () => {
+            expect(extractProjectNameFromPath('/home/user/Code/MyProject')).toBe('MyProject');
+        });
+
+        it('extracts name from Windows path', () => {
+            expect(extractProjectNameFromPath('D:\\Code\\MyProject')).toBe('MyProject');
+        });
+
+        it('extracts name from Windows drive root', () => {
+            expect(extractProjectNameFromPath('D:\\categorizer')).toBe('categorizer');
+        });
+
+        it('handles trailing slash', () => {
+            expect(extractProjectNameFromPath('/home/user/Code/MyProject/')).toBe('MyProject');
+        });
+
+        it('handles trailing backslash', () => {
+            expect(extractProjectNameFromPath('C:\\Code\\MyProject\\')).toBe('MyProject');
+        });
+
+        it('handles mixed separators', () => {
+            expect(extractProjectNameFromPath('C:\\Users\\test/Code/MyProject')).toBe('MyProject');
+        });
+
+        it('returns empty string for empty input', () => {
+            expect(extractProjectNameFromPath('')).toBe('');
+        });
+
+        it('returns name as-is for simple name', () => {
+            expect(extractProjectNameFromPath('MyProject')).toBe('MyProject');
+        });
+    });
+
+    describe('getAntigravityCdpHint()', () => {
+        it('returns open -a hint on macOS', () => {
+            withPlatform('darwin', () => {
+                expect(getAntigravityCdpHint(9222)).toBe(
+                    'open -a Antigravity --args --remote-debugging-port=9222',
+                );
+            });
+        });
+
+        it('returns exe hint on Windows', () => {
+            withPlatform('win32', () => {
+                expect(getAntigravityCdpHint(9222)).toBe(
+                    'Antigravity.exe --remote-debugging-port=9222',
+                );
+            });
+        });
+
+        it('returns lowercase hint on Linux', () => {
+            withPlatform('linux', () => {
+                expect(getAntigravityCdpHint(9222)).toBe(
+                    'antigravity --remote-debugging-port=9222',
+                );
+            });
+        });
+
+        it('uses default port 9222', () => {
+            withPlatform('darwin', () => {
+                expect(getAntigravityCdpHint()).toContain('9222');
+            });
+        });
+
+        it('uses custom port', () => {
+            withPlatform('darwin', () => {
+                expect(getAntigravityCdpHint(9333)).toContain('9333');
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Follow-up to PR #43 by @bstag. Addresses two remaining gaps in Windows/cross-platform support:

- **`cdpConnectionPool.extractProjectName()`** used `split('/')` which failed on Windows backslash paths (e.g. `D:\categorizer` was cached as the full path instead of `categorizer`). Now delegates to `extractProjectNameFromPath()` from `pathUtils.ts`
- **Hardcoded `open -a Antigravity` hints** in `doctor.ts`, `antigravityLauncher.ts`, and `bot/index.ts` now use `getAntigravityCdpHint()` to show the correct command per platform (macOS/Windows/Linux)

## Changes

| File | Change |
|------|--------|
| `src/utils/pathUtils.ts` | Add `getAntigravityCdpHint()` |
| `src/services/cdpConnectionPool.ts` | Use `extractProjectNameFromPath()` instead of `split('/')` |
| `src/bin/commands/doctor.ts` | Use `getAntigravityCdpHint()` |
| `src/services/antigravityLauncher.ts` | Use `getAntigravityCdpHint()` |
| `src/bot/index.ts` | Use `getAntigravityCdpHint()` |
| `tests/utils/pathUtils.test.ts` | New: 13 tests for `extractProjectNameFromPath` and `getAntigravityCdpHint` |
| `tests/services/cdpConnectionPool.test.ts` | Add Windows path test cases |
| `tests/commands/*.test.ts` | Update mocks to handle backslash paths |

## Test plan

- [x] All 644 tests pass
- [x] TypeScript build succeeds
- [x] New `pathUtils.test.ts` covers POSIX, Windows, mixed, edge cases
- [x] `cdpConnectionPool.test.ts` includes Windows path assertions

closes #44