### PR TITLE
feat: add /logs slash command to view bot logs from Discord

### DIFF
--- a/src/commands/registerSlashCommands.ts
+++ b/src/commands/registerSlashCommands.ts
@@ -150,6 +150,31 @@ const mirrorCommand = new SlashCommandBuilder()
     .setName('mirror')
     .setDescription(t('Toggle PC-to-Discord message mirroring for the current session'));
 
+/** /logs command definition */
+const logsCommand = new SlashCommandBuilder()
+    .setName('logs')
+    .setDescription(t('View recent bot logs'))
+    .addIntegerOption((option) =>
+        option
+            .setName('lines')
+            .setDescription(t('Number of recent log lines (default: 50)'))
+            .setRequired(false)
+            .setMinValue(1)
+            .setMaxValue(100)
+    )
+    .addStringOption((option) =>
+        option
+            .setName('level')
+            .setDescription(t('Filter by log level'))
+            .setRequired(false)
+            .addChoices(
+                { name: 'debug', value: 'debug' },
+                { name: 'info', value: 'info' },
+                { name: 'warn', value: 'warn' },
+                { name: 'error', value: 'error' },
+            )
+    );
+
 /** /ping command definition */
 const pingCommand = new SlashCommandBuilder()
     .setName('ping')
@@ -172,6 +197,7 @@ export const slashCommands = [
     joinCommand,
     mirrorCommand,
     pingCommand,
+    logsCommand,
 ];
 
 /**

--- a/src/events/interactionCreateHandler.ts
+++ b/src/events/interactionCreateHandler.ts
@@ -654,7 +654,11 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
         }
 
         try {
-            await commandInteraction.deferReply();
+            if (commandInteraction.commandName === 'logs') {
+                await commandInteraction.deferReply({ flags: MessageFlags.Ephemeral });
+            } else {
+                await commandInteraction.deferReply();
+            }
         } catch (deferError: any) {
             if (deferError?.code === 10062) {
                 logger.warn('[SlashCommand] Interaction expired (deferReply failed). Skipping.');

--- a/src/utils/logBuffer.ts
+++ b/src/utils/logBuffer.ts
@@ -1,0 +1,60 @@
+import type { LogLevel } from './logger';
+
+export interface LogEntry {
+    timestamp: string;
+    level: LogLevel;
+    message: string;
+}
+
+const MAX_ENTRIES = 200;
+
+// Strip ANSI escape codes for clean buffer storage
+const ANSI_REGEX = /\x1b\[[0-9;]*m/g;
+
+function stripAnsi(text: string): string {
+    return text.replace(ANSI_REGEX, '');
+}
+
+export class LogBuffer {
+    private readonly buffer: LogEntry[] = [];
+    private head = 0;
+    private count = 0;
+
+    append(level: LogLevel, message: string): void {
+        const entry: LogEntry = {
+            timestamp: new Date().toISOString(),
+            level,
+            message: stripAnsi(message),
+        };
+
+        if (this.count < MAX_ENTRIES) {
+            this.buffer.push(entry);
+            this.count++;
+        } else {
+            this.buffer[this.head] = entry;
+        }
+        this.head = (this.head + 1) % MAX_ENTRIES;
+    }
+
+    getRecent(count: number, levelFilter?: LogLevel): readonly LogEntry[] {
+        const all: LogEntry[] = [];
+        for (let i = 0; i < this.count; i++) {
+            const idx = (this.head - this.count + i + MAX_ENTRIES * 2) % MAX_ENTRIES;
+            all.push(this.buffer[idx]);
+        }
+
+        const filtered = levelFilter
+            ? all.filter((e) => e.level === levelFilter)
+            : all;
+
+        return filtered.slice(-count);
+    }
+
+    clear(): void {
+        this.buffer.length = 0;
+        this.head = 0;
+        this.count = 0;
+    }
+}
+
+export const logBuffer = new LogBuffer();

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,3 +1,5 @@
+import { logBuffer } from './logBuffer';
+
 export const COLORS = {
     red: '\x1b[31m',
     yellow: '\x1b[33m',
@@ -46,34 +48,46 @@ export function createLogger(initialLevel: LogLevel = 'info'): Logger {
     return {
         info(...args: any[]) {
             if (shouldLog('info')) {
-                console.info(`${getTimestamp()} ${COLORS.cyan}[INFO]${COLORS.reset}`, ...args);
+                const formatted = `${getTimestamp()} ${COLORS.cyan}[INFO]${COLORS.reset}`;
+                console.info(formatted, ...args);
+                logBuffer.append('info', `[INFO] ${args.join(' ')}`);
             }
         },
         warn(...args: any[]) {
             if (shouldLog('warn')) {
-                console.warn(`${getTimestamp()} ${COLORS.yellow}[WARN]${COLORS.reset}`, ...args);
+                const formatted = `${getTimestamp()} ${COLORS.yellow}[WARN]${COLORS.reset}`;
+                console.warn(formatted, ...args);
+                logBuffer.append('warn', `[WARN] ${args.join(' ')}`);
             }
         },
         error(...args: any[]) {
             if (shouldLog('error')) {
-                console.error(`${getTimestamp()} ${COLORS.red}[ERROR]${COLORS.reset}`, ...args);
+                const formatted = `${getTimestamp()} ${COLORS.red}[ERROR]${COLORS.reset}`;
+                console.error(formatted, ...args);
+                logBuffer.append('error', `[ERROR] ${args.join(' ')}`);
             }
         },
         debug(...args: any[]) {
             if (shouldLog('debug')) {
-                console.debug(`${getTimestamp()} ${COLORS.dim}[DEBUG]${COLORS.reset}`, ...args);
+                const formatted = `${getTimestamp()} ${COLORS.dim}[DEBUG]${COLORS.reset}`;
+                console.debug(formatted, ...args);
+                logBuffer.append('debug', `[DEBUG] ${args.join(' ')}`);
             }
         },
         /** Important state transitions - stands out in logs */
         phase(...args: any[]) {
             if (shouldLog('info')) {
-                console.info(`${getTimestamp()} ${COLORS.magenta}[PHASE]${COLORS.reset}`, ...args);
+                const formatted = `${getTimestamp()} ${COLORS.magenta}[PHASE]${COLORS.reset}`;
+                console.info(formatted, ...args);
+                logBuffer.append('info', `[PHASE] ${args.join(' ')}`);
             }
         },
         /** Completion-related events - green for success */
         done(...args: any[]) {
             if (shouldLog('info')) {
-                console.info(`${getTimestamp()} ${COLORS.green}[DONE]${COLORS.reset}`, ...args);
+                const formatted = `${getTimestamp()} ${COLORS.green}[DONE]${COLORS.reset}`;
+                console.info(formatted, ...args);
+                logBuffer.append('info', `[DONE] ${args.join(' ')}`);
             }
         },
         /** Section divider with optional label for structured output */

--- a/tests/commands/registerSlashCommands.test.ts
+++ b/tests/commands/registerSlashCommands.test.ts
@@ -18,6 +18,7 @@ jest.mock('discord.js', () => {
                 setName: jest.fn().mockReturnThis(),
                 setDescription: jest.fn().mockReturnThis(),
                 setRequired: jest.fn().mockReturnThis(),
+                addChoices: jest.fn().mockReturnThis(),
             };
             fn(option);
             return this;

--- a/tests/utils/logBuffer.test.ts
+++ b/tests/utils/logBuffer.test.ts
@@ -1,0 +1,158 @@
+import { LogBuffer } from '../../src/utils/logBuffer';
+
+describe('LogBuffer', () => {
+    let buffer: LogBuffer;
+
+    beforeEach(() => {
+        buffer = new LogBuffer();
+    });
+
+    describe('append and getRecent', () => {
+        it('returns empty array when no entries exist', () => {
+            expect(buffer.getRecent(10)).toEqual([]);
+        });
+
+        it('stores and retrieves a single entry', () => {
+            buffer.append('info', 'hello');
+
+            const entries = buffer.getRecent(10);
+            expect(entries).toHaveLength(1);
+            expect(entries[0].level).toBe('info');
+            expect(entries[0].message).toBe('hello');
+            expect(entries[0].timestamp).toBeDefined();
+        });
+
+        it('returns entries in chronological order', () => {
+            buffer.append('info', 'first');
+            buffer.append('warn', 'second');
+            buffer.append('error', 'third');
+
+            const entries = buffer.getRecent(10);
+            expect(entries).toHaveLength(3);
+            expect(entries[0].message).toBe('first');
+            expect(entries[1].message).toBe('second');
+            expect(entries[2].message).toBe('third');
+        });
+
+        it('limits returned entries to requested count', () => {
+            buffer.append('info', 'a');
+            buffer.append('info', 'b');
+            buffer.append('info', 'c');
+
+            const entries = buffer.getRecent(2);
+            expect(entries).toHaveLength(2);
+            expect(entries[0].message).toBe('b');
+            expect(entries[1].message).toBe('c');
+        });
+
+        it('returns all entries when count exceeds total', () => {
+            buffer.append('info', 'only');
+
+            const entries = buffer.getRecent(100);
+            expect(entries).toHaveLength(1);
+            expect(entries[0].message).toBe('only');
+        });
+    });
+
+    describe('circular buffer eviction', () => {
+        it('evicts oldest entries when exceeding max capacity (200)', () => {
+            for (let i = 0; i < 210; i++) {
+                buffer.append('info', `msg-${i}`);
+            }
+
+            const entries = buffer.getRecent(200);
+            expect(entries).toHaveLength(200);
+            expect(entries[0].message).toBe('msg-10');
+            expect(entries[199].message).toBe('msg-209');
+        });
+
+        it('maintains correct order after wrap-around', () => {
+            for (let i = 0; i < 205; i++) {
+                buffer.append('info', `entry-${i}`);
+            }
+
+            const entries = buffer.getRecent(5);
+            expect(entries).toHaveLength(5);
+            expect(entries[0].message).toBe('entry-200');
+            expect(entries[4].message).toBe('entry-204');
+        });
+    });
+
+    describe('level filter', () => {
+        it('filters entries by level', () => {
+            buffer.append('info', 'info1');
+            buffer.append('warn', 'warn1');
+            buffer.append('error', 'error1');
+            buffer.append('info', 'info2');
+
+            const warnOnly = buffer.getRecent(10, 'warn');
+            expect(warnOnly).toHaveLength(1);
+            expect(warnOnly[0].message).toBe('warn1');
+        });
+
+        it('returns empty array when no entries match filter', () => {
+            buffer.append('info', 'hello');
+            buffer.append('info', 'world');
+
+            expect(buffer.getRecent(10, 'error')).toEqual([]);
+        });
+
+        it('applies count limit after filtering', () => {
+            buffer.append('info', 'a');
+            buffer.append('error', 'b');
+            buffer.append('info', 'c');
+            buffer.append('info', 'd');
+
+            const entries = buffer.getRecent(2, 'info');
+            expect(entries).toHaveLength(2);
+            expect(entries[0].message).toBe('c');
+            expect(entries[1].message).toBe('d');
+        });
+    });
+
+    describe('clear', () => {
+        it('removes all entries', () => {
+            buffer.append('info', 'a');
+            buffer.append('info', 'b');
+            buffer.clear();
+
+            expect(buffer.getRecent(10)).toEqual([]);
+        });
+
+        it('allows new entries after clearing', () => {
+            buffer.append('info', 'before');
+            buffer.clear();
+            buffer.append('warn', 'after');
+
+            const entries = buffer.getRecent(10);
+            expect(entries).toHaveLength(1);
+            expect(entries[0].message).toBe('after');
+        });
+    });
+
+    describe('ANSI stripping', () => {
+        it('strips ANSI escape codes from stored messages', () => {
+            buffer.append('info', '\x1b[31mred text\x1b[0m');
+
+            const entries = buffer.getRecent(1);
+            expect(entries[0].message).toBe('red text');
+        });
+
+        it('strips complex ANSI sequences', () => {
+            buffer.append('info', '\x1b[2m[12:00:00]\x1b[0m \x1b[36m[INFO]\x1b[0m hello');
+
+            const entries = buffer.getRecent(1);
+            expect(entries[0].message).toBe('[12:00:00] [INFO] hello');
+        });
+    });
+
+    describe('timestamp', () => {
+        it('generates ISO timestamps', () => {
+            buffer.append('info', 'test');
+
+            const entries = buffer.getRecent(1);
+            expect(() => new Date(entries[0].timestamp)).not.toThrow();
+            expect(new Date(entries[0].timestamp).toISOString()).toBe(entries[0].timestamp);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Add `LogBuffer` class (`src/utils/logBuffer.ts`) — in-memory circular buffer (200 entries max) that stores log entries with ANSI codes stripped
- Integrate `logBuffer.append()` into every log method in `src/utils/logger.ts` so entries are captured alongside console output
- Register `/logs` slash command with `lines` (1–100, default 50) and `level` (debug/info/warn/error) options
- Handle `/logs` in `handleSlashInteraction` — formats entries as a mobile-friendly code block, truncates at 1900 chars
- Make `/logs` responses ephemeral (only visible to the requester) via conditional `deferReply`
- Add `/logs` to the `/help` embed under the System section
- 15 unit tests for `LogBuffer` covering basic ops, circular eviction, level filtering, ANSI stripping, and clear

## Test plan

- [x] `npm run build` — compiles without errors
- [x] `npm test` — 67 suites, 663 tests all pass (including 15 new logBuffer tests)
- [x] Manual: start bot, generate logs, run `/logs` in Discord
- [x] Manual: verify `/logs level:error` filters correctly
- [x] Manual: verify response is ephemeral (only requester sees it)

closes #51