### PR TITLE
fix: remove .exe extension from Windows open command for PATH resolution

### DIFF
--- a/src/bin/commands/open.ts
+++ b/src/bin/commands/open.ts
@@ -51,7 +51,7 @@ function openMacOS(port: number): Promise<void> {
 
 function openWindows(port: number): Promise<void> {
     return new Promise((resolve, reject) => {
-        execFile(`${APP_NAME}.exe`, [`--remote-debugging-port=${port}`], { shell: true }, (err) => {
+        execFile(APP_NAME, [`--remote-debugging-port=${port}`], { shell: true }, (err) => {
             if (err) {
                 reject(new Error(`Failed to open ${APP_NAME}: ${err.message}`));
                 return;


### PR DESCRIPTION
## Summary
- Remove hardcoded `.exe` extension from `openWindows()` in `src/bin/commands/open.ts`
- On Windows with `shell: true`, cmd.exe resolves executables via `PATHEXT` automatically — hardcoding `.exe` can fail when the installed executable name doesn't exactly match

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 1287 tests pass (`npm test`)
- [ ] Manual verification on Windows: `lazy-gravity open` launches Antigravity successfully

closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows application launch reliability through refined execution flow, ensuring more consistent behavior across different Windows environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->