### PR TITLE
ci: switch npm auth to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,10 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: 22.x
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## Summary

- Switch from `NPM_TOKEN` to OIDC trusted publishing for npm authentication
- Remove `@semantic-release/git` and `@semantic-release/changelog` plugins (incompatible with branch protection)
- Pin release job to Node 22.x (npm 11.5.1+ required for OIDC)
- Add `registry-url` to `actions/setup-node`

## Setup required (manual)

Configure trusted publisher on npmjs.com:
1. Go to https://www.npmjs.com/package/lazy-gravity/settings
2. Select **Trusted Publisher** → **GitHub Actions**
3. Owner: `tokyoweb3`
4. Repository: `LazyGravity`
5. Workflow filename: `release.yml`
6. Environment: (leave empty)

After this is configured and the PR is merged, semantic-release will publish v0.4.0 via OIDC.

## Test plan

- [ ] Trusted publisher configured on npmjs.com
- [ ] After merge: verify Release workflow publishes v0.4.0 successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow infrastructure for improved build consistency and deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->