### PR TITLE
fix: improve onboarding UX for first-time users

### DIFF
--- a/src/bin/commands/open.ts
+++ b/src/bin/commands/open.ts
@@ -1,4 +1,5 @@
 import * as net from 'net';
+import * as http from 'http';
 import * as os from 'os';
 import { execFile, spawn } from 'child_process';
 import { CDP_PORTS } from '../../utils/cdpPorts';
@@ -11,6 +12,7 @@ const C = {
     dim: '\x1b[2m',
     cyan: '\x1b[36m',
     green: '\x1b[32m',
+    yellow: '\x1b[33m',
     red: '\x1b[31m',
 } as const;
 
@@ -81,6 +83,46 @@ function openLinux(port: number): Promise<void> {
     });
 }
 
+/**
+ * Poll CDP endpoint until it responds or timeout is reached.
+ */
+function waitForCdp(port: number, timeoutMs: number = 15000, intervalMs: number = 1000): Promise<boolean> {
+    const start = Date.now();
+    return new Promise((resolve) => {
+        const check = (): void => {
+            const req = http.get(`http://127.0.0.1:${port}/json/list`, (res) => {
+                let data = '';
+                res.on('data', (chunk) => (data += chunk));
+                res.on('end', () => {
+                    try {
+                        const parsed = JSON.parse(data);
+                        if (Array.isArray(parsed)) {
+                            resolve(true);
+                            return;
+                        }
+                    } catch { /* not ready */ }
+                    retry();
+                });
+            });
+            req.on('error', () => retry());
+            req.setTimeout(2000, () => {
+                req.destroy();
+                retry();
+            });
+        };
+
+        const retry = (): void => {
+            if (Date.now() - start >= timeoutMs) {
+                resolve(false);
+                return;
+            }
+            setTimeout(check, intervalMs);
+        };
+
+        check();
+    });
+}
+
 export async function openAction(): Promise<void> {
     const platform = os.platform();
 
@@ -107,7 +149,15 @@ export async function openAction(): Promise<void> {
             await openLinux(port);
         }
 
-        console.log(`  ${C.green}${APP_NAME} opened on CDP port ${port}${C.reset}`);
+        console.log(`  ${C.dim}Waiting for CDP to respond on port ${port}...${C.reset}`);
+
+        const ready = await waitForCdp(port);
+        if (ready) {
+            console.log(`  ${C.green}${APP_NAME} is ready on CDP port ${port}${C.reset}`);
+        } else {
+            console.log(`  ${C.yellow}${APP_NAME} launched but CDP not yet responding on port ${port}${C.reset}`);
+            console.log(`  ${C.dim}It may still be starting up. Try running start in a few seconds.${C.reset}`);
+        }
         console.log(`  ${C.dim}Run ${C.reset}${C.cyan}lazy-gravity start${C.reset}${C.dim} to connect the bot.${C.reset}\n`);
     } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);

--- a/src/services/antigravityLauncher.ts
+++ b/src/services/antigravityLauncher.ts
@@ -48,10 +48,14 @@ export async function ensureAntigravityRunning(): Promise<void> {
     logger.warn('='.repeat(70));
     logger.warn('  Antigravity CDP ports are not responding');
     logger.warn('');
-    logger.warn('  Please run AntigravityDebug.command before starting the Bot');
+    logger.warn('  Run the following command to open Antigravity with CDP enabled:');
+    logger.warn('');
+    logger.warn('    lazy-gravity open');
     logger.warn('');
     logger.warn('  Or manually:');
     logger.warn(`    ${getAntigravityCdpHint(9222)}`);
+    logger.warn('');
+    logger.warn('  Then run:  lazy-gravity start');
     logger.warn('='.repeat(70));
     logger.warn('');
 }

--- a/src/ui/projectListUi.ts
+++ b/src/ui/projectListUi.ts
@@ -74,6 +74,10 @@ export function buildProjectListPayload(
     );
 
     if (workspaces.length === 0) {
+        rc = withDescription(
+            rc,
+            t('No projects found.\nCreate a project directory in your workspace base folder, then try again.'),
+        );
         return { richContent: rc, components: [] };
     }
 
@@ -146,6 +150,9 @@ export function buildProjectListUI(
         .setTimestamp();
 
     if (workspaces.length === 0) {
+        embed.setDescription(
+            t('No projects found.\nCreate a project directory in your workspace base folder, then try again.'),
+        );
         return { embeds: [embed], components: [] };
     }
 


### PR DESCRIPTION
## Summary

Addresses friction reported by a Reddit user during first-time setup:

- **Misleading CDP error message**: Warning referenced `AntigravityDebug.command` instead of `lazy-gravity open`, confusing users who followed the documented setup flow
- **Timing issue between open and start**: `open` now polls CDP (up to 15s) and reports whether Antigravity is ready, so users know when to run `start`
- **Empty /project list with no guidance**: Discord embed now shows "No projects found. Create a project directory..." instead of a silent empty list

## Changes

| File | Change |
|------|--------|
| `src/services/antigravityLauncher.ts` | Updated warning to reference `lazy-gravity open` and `lazy-gravity start` |
| `src/bin/commands/open.ts` | Added `waitForCdp()` polling after launch; added `yellow` to color constants |
| `src/ui/projectListUi.ts` | Both `buildProjectListPayload` and `buildProjectListUI` show guidance when workspace list is empty |

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 1327 tests pass (`npm test`)
- [ ] Manual: run `lazy-gravity open` and verify CDP readiness message appears
- [ ] Manual: run `lazy-gravity start` without Antigravity and verify updated warning
- [ ] Manual: run `/project` with empty workspace dir and verify guidance message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added readiness verification to confirm app startup completion.

* **Improvements**
  * Enhanced setup guidance with clearer step-by-step instructions for configuration.
  * Improved messaging when no projects are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->