### PR TITLE
fix: auto-open chat panel when no workbench target found

### DIFF
--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -128,6 +128,20 @@ export class CdpService extends EventEmitter {
             );
         }
 
+        // No workbench page found — try to open the chat panel automatically
+        // before falling back to Launchpad
+        if (!target) {
+            const anyPage = allPages.find(t => t.webSocketDebuggerUrl);
+            if (anyPage) {
+                logger.debug('[CdpService] No workbench page found. Attempting to open chat panel via Cmd+L / Ctrl+L...');
+                await this.openChatPanelViaKeyboard(anyPage.webSocketDebuggerUrl);
+
+                // Re-scan after opening chat panel
+                target = await this.findWorkbenchTarget();
+            }
+        }
+
+        // Last resort: accept Launchpad as target
         if (!target) {
             target = allPages.find(t =>
                 t.webSocketDebuggerUrl &&
@@ -145,20 +159,6 @@ export class CdpService extends EventEmitter {
                 }
             }
             return target.webSocketDebuggerUrl;
-        }
-
-        // No workbench page found — try to open the chat panel automatically
-        const anyPage = allPages.find(t => t.webSocketDebuggerUrl);
-        if (anyPage) {
-            logger.debug('[CdpService] No workbench page found. Attempting to open chat panel via Cmd+L / Ctrl+L...');
-            await this.openChatPanelViaKeyboard(anyPage.webSocketDebuggerUrl);
-
-            // Re-scan after opening chat panel
-            const retryTarget = await this.findWorkbenchTarget();
-            if (retryTarget) {
-                this.targetUrl = retryTarget.webSocketDebuggerUrl;
-                return retryTarget.webSocketDebuggerUrl;
-            }
         }
 
         throw new Error('CDP target not found on any port.');
@@ -749,8 +749,14 @@ export class CdpService extends EventEmitter {
                 nativeVirtualKeyCode: 76,
             });
 
-            // Wait for the chat panel to initialize
-            await new Promise(r => setTimeout(r, 3000));
+            // Wait until a workbench target appears, up to a bounded timeout
+            const deadline = Date.now() + 10000;
+            while (Date.now() < deadline) {
+                await new Promise(r => setTimeout(r, 500));
+                if (await this.findWorkbenchTarget()) {
+                    break;
+                }
+            }
         } catch (e) {
             logger.debug(`[CdpService] Failed to open chat panel automatically: ${e}`);
         } finally {


### PR DESCRIPTION
## Summary

- When `discoverTarget()` finds no workbench page but Antigravity is running (e.g. only Launchpad page exists), automatically sends Cmd+L / Ctrl+L via CDP to open the chat panel, then retries discovery
- Eliminates the manual workaround reported by LINE community users ("open chat panel and send a message first")

## Changes

| File | Change |
|------|--------|
| `src/services/cdpService.ts` | Added `findWorkbenchTarget()` helper to re-scan ports after auto-open; Added `openChatPanelViaKeyboard()` that temporarily connects to any available page and sends keyboard shortcut; Updated `discoverTarget()` to attempt auto-open before throwing |

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 1327 tests pass (`npm test`)
- [ ] Manual: start bot without chat panel open → verify it auto-opens via Cmd+L/Ctrl+L and connects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discovery reliability by automatically attempting to open the chat panel and retrying discovery when the workbench isn't initially found.
  * Broadened page scanning to better identify relevant targets while excluding unrelated pages, and included an additional fallback target option to increase success rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->