### PR TITLE
fix: recover from Antigravity session title changes during routing

### DIFF
--- a/src/events/messageCreateHandler.ts
+++ b/src/events/messageCreateHandler.ts
@@ -294,14 +294,18 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
                                         );
 
                                         if (!ownedByOther) {
-                                            logger.info(
-                                                `[SessionRecovery] Adopting renamed title: ` +
-                                                `"${session.displayName}" -> "${currentInfo.title}" ` +
-                                                `(channel: ${message.channelId})`,
-                                            );
-                                            deps.chatSessionRepo.updateDisplayName(message.channelId, currentInfo.title);
-                                            registerApprovalSessionChannel(deps.bridge, projectName, currentInfo.title, platformChannel);
-                                            activationResult = await deps.chatSessionService.activateSessionByTitle(cdp, currentInfo.title);
+                                            const recoveredTitle = currentInfo.title;
+                                            const retryResult = await deps.chatSessionService.activateSessionByTitle(cdp, recoveredTitle);
+                                            if (retryResult.ok) {
+                                                logger.info(
+                                                    `[SessionRecovery] Adopting renamed title: ` +
+                                                    `"${session.displayName}" -> "${recoveredTitle}" ` +
+                                                    `(channel: ${message.channelId})`,
+                                                );
+                                                deps.chatSessionRepo.updateDisplayName(message.channelId, recoveredTitle);
+                                                registerApprovalSessionChannel(deps.bridge, projectName, recoveredTitle, platformChannel);
+                                            }
+                                            activationResult = retryResult;
                                         }
                                     }
 

--- a/tests/events/messageCreateHandler.test.ts
+++ b/tests/events/messageCreateHandler.test.ts
@@ -193,6 +193,39 @@ describe('messageCreateHandler', () => {
         expect(reply).toHaveBeenCalled();
     });
 
+    it('does not persist title when retry activation also fails', async () => {
+        const sendPromptToAntigravity = jest.fn();
+        const reply = jest.fn().mockResolvedValue(undefined);
+        const updateDisplayName = jest.fn();
+
+        const handler = createMessageCreateHandler(buildDeps({
+            sendPromptToAntigravity,
+            chatSessionService: {
+                activateSessionByTitle: jest.fn().mockResolvedValue({ ok: false, error: 'still fails' }),
+                getCurrentSessionInfo: jest.fn().mockResolvedValue({
+                    title: 'Renamed Title',
+                    hasActiveChat: true,
+                }),
+            },
+            chatSessionRepo: {
+                findByChannelId: jest.fn().mockReturnValue({
+                    isRenamed: true,
+                    displayName: 'Original Title',
+                    categoryId: 'cat-1',
+                    channelId: 'ch-1',
+                }),
+                findByCategoryId: jest.fn().mockReturnValue([]),
+                updateDisplayName,
+            },
+        }));
+
+        await handler(buildMessage({ reply }));
+
+        expect(updateDisplayName).not.toHaveBeenCalled();
+        expect(sendPromptToAntigravity).not.toHaveBeenCalled();
+        expect(reply).toHaveBeenCalled();
+    });
+
     it('does not adopt title when no active chat exists during recovery', async () => {
         const sendPromptToAntigravity = jest.fn();
         const reply = jest.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary

- Add recovery logic when `activateSessionByTitle` fails due to Antigravity renaming the session
- Recovery checks `getCurrentSessionInfo` for the actual active session title
- Adopts the new title only if: active chat exists, title differs from stored name, and no sibling channel owns it
- Updates DB `displayName` and re-registers approval routing with the new title

closes #90

## Test plan

- [x] Recovery succeeds: session title changed by Antigravity → auto-adopts new title, continues routing
- [x] Sibling guard: new title belongs to another channel → does NOT adopt, shows error
- [x] No active chat: recovery not attempted when no active chat exists
- [x] All 1330 existing tests pass
- [x] Build (`tsc`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust session activation when session titles change, with automatic recovery attempts to realign session state and reduce manual fixes
  * Preserves clear error messaging and early exits when recovery cannot succeed

* **Tests**
  * Added tests covering session-rename recovery, adoption refusal when title belongs to a sibling, retry-failure behavior, and no-active-chat recovery cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->