### PR TITLE
fix: prevent ResponseMonitor false timeout on long-running agentic tasks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,11 @@ AUTO_APPROVE_FILE_EDITS=false
 # Response extraction mode (legacy/structured, default: structured)
 # EXTRACTION_MODE=structured
 
+# Response monitor inactivity timeout in milliseconds (default: 900000 = 15 minutes)
+# How long the monitor waits without any DOM activity before timing out.
+# Set to 0 to disable the timeout entirely (useful for very long agentic tasks).
+# RESPONSE_TIMEOUT_MS=900000
+
 # (Optional) Override path to the Antigravity CLI binary
 # ANTIGRAVITY_PATH=/usr/local/bin/antigravity
 

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -182,6 +182,7 @@ async function sendPromptToAntigravity(
         userPrefRepo?: UserPreferenceRepository;
         onFullCompletion?: () => void;
         extractionMode?: ExtractionMode;
+        responseTimeoutMs?: number;
     }
 ): Promise<void> {
     // Completion signal — called exactly once when the entire prompt lifecycle ends
@@ -606,7 +607,7 @@ async function sendPromptToAntigravity(
         const monitor = new ResponseMonitor({
             cdpService: cdp,
             pollIntervalMs: 2000,
-            maxDurationMs: 300000,
+            maxDurationMs: options?.responseTimeoutMs,
             stopGoneConfirmCount: 3,
             extractionMode: options?.extractionMode,
 
@@ -818,9 +819,10 @@ async function sendPromptToAntigravity(
                         : lastProgressText;
                     const separated = splitOutputAndLogs(timeoutText || '');
                     const sanitizedTimeoutLogs = lastActivityLogText || processLogBuffer.snapshot();
+                    const timeoutMinutes = Math.round((options?.responseTimeoutMs ?? 900000) / 60000);
                     const payload = separated.output && separated.output.trim().length > 0
-                        ? t(`${separated.output}\n\n[Monitor Ended] Timeout after 5 minutes.`)
-                        : 'Monitor ended after 5 minutes. No text was retrieved.';
+                        ? t(`${separated.output}\n\n[Monitor Ended] Timeout after ${timeoutMinutes} minutes of inactivity.`)
+                        : `Monitor ended after ${timeoutMinutes} minutes of inactivity. No text was retrieved.`;
 
                     liveResponseUpdateVersion += 1;
                     const responseVersion = liveResponseUpdateVersion;
@@ -965,7 +967,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         ]
     });
 
-    const joinHandler = new JoinCommandHandler(chatSessionService, chatSessionRepo, workspaceBindingRepo, channelManager, bridge.pool, workspaceService, client, config.extractionMode);
+    const joinHandler = new JoinCommandHandler(chatSessionService, chatSessionRepo, workspaceBindingRepo, channelManager, bridge.pool, workspaceService, client, config.extractionMode, config.responseTimeoutMs);
 
     client.once(Events.ClientReady, async (readyClient) => {
         logger.info(`Ready! Logged in as ${readyClient.user.tag} | extractionMode=${config.extractionMode}`);
@@ -1218,6 +1220,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                 botToken: config.telegramToken,
                 botApi: telegramBot.api as any,
                 chatSessionService,
+                responseTimeoutMs: config.responseTimeoutMs,
             });
 
             // Compose select handlers: project select + mode select

--- a/src/bot/telegramMessageHandler.ts
+++ b/src/bot/telegramMessageHandler.ts
@@ -47,6 +47,8 @@ export interface TelegramMessageHandlerDeps {
     /** Bot API object for getFile calls. */
     readonly botApi?: import('../platform/telegram/wrappers').TelegramBotLike['api'];
     readonly chatSessionService?: ChatSessionService;
+    /** Response monitor inactivity timeout in ms. Defaults to ResponseMonitor default (900000). */
+    readonly responseTimeoutMs?: number;
 }
 
 /**
@@ -253,7 +255,7 @@ export function createTelegramMessageHandler(deps: TelegramMessageHandlerDeps) {
             statusMsg = await channel.send({ text: 'Processing...' }).catch(() => null);
 
             await new Promise<void>((resolve) => {
-                const TIMEOUT_MS = 300_000;
+                const TIMEOUT_MS = deps.responseTimeoutMs ?? 900_000;
 
                 let settled = false;
                 const settle = () => {

--- a/src/commands/joinCommandHandler.ts
+++ b/src/commands/joinCommandHandler.ts
@@ -40,6 +40,7 @@ export class JoinCommandHandler {
     private readonly workspaceService: WorkspaceService;
     private readonly client: Client;
     private readonly extractionMode?: ExtractionMode;
+    private readonly responseTimeoutMs?: number;
 
     /** Active ResponseMonitors per workspace (for AI response mirroring) */
     private readonly activeResponseMonitors = new Map<string, ResponseMonitor>();
@@ -53,6 +54,7 @@ export class JoinCommandHandler {
         workspaceService: WorkspaceService,
         client: Client,
         extractionMode?: ExtractionMode,
+        responseTimeoutMs?: number,
     ) {
         this.chatSessionService = chatSessionService;
         this.chatSessionRepo = chatSessionRepo;
@@ -62,6 +64,7 @@ export class JoinCommandHandler {
         this.workspaceService = workspaceService;
         this.client = client;
         this.extractionMode = extractionMode;
+        this.responseTimeoutMs = responseTimeoutMs;
     }
 
     /**
@@ -370,7 +373,7 @@ export class JoinCommandHandler {
         const monitor = new ResponseMonitor({
             cdpService: cdp,
             pollIntervalMs: 2000,
-            maxDurationMs: 300000,
+            maxDurationMs: this.responseTimeoutMs,
             extractionMode: this.extractionMode,
             onComplete: (finalText: string) => {
                 this.activeResponseMonitors.delete(projectName);

--- a/src/events/messageCreateHandler.ts
+++ b/src/events/messageCreateHandler.ts
@@ -33,7 +33,7 @@ import {
 import { logger } from '../utils/logger';
 
 export interface MessageCreateHandlerDeps {
-    config: { allowedUserIds: string[]; extractionMode?: import('../utils/config').ExtractionMode };
+    config: { allowedUserIds: string[]; extractionMode?: import('../utils/config').ExtractionMode; responseTimeoutMs?: number };
     bridge: CdpBridge;
     modeService: ModeService;
     modelService: ModelService;
@@ -201,6 +201,7 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
                         titleGenerator: deps.titleGenerator,
                         userPrefRepo: deps.userPrefRepo,
                         extractionMode: deps.config.extractionMode,
+                        responseTimeoutMs: deps.config.responseTimeoutMs,
                     });
                 } else {
                     await message.reply('Not connected to CDP. Send a message first to connect to a project.');
@@ -377,6 +378,7 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
                                     titleGenerator: deps.titleGenerator,
                                     userPrefRepo: deps.userPrefRepo,
                                     extractionMode: deps.config.extractionMode,
+                                    responseTimeoutMs: deps.config.responseTimeoutMs,
                                     onFullCompletion: settle,
                                 }).catch((err: any) => {
                                     // sendPromptToAntigravity rejected before onFullCompletion fired

--- a/src/services/responseMonitor.ts
+++ b/src/services/responseMonitor.ts
@@ -445,7 +445,7 @@ export interface ResponseMonitorOptions {
     cdpService: CdpService;
     /** Poll interval in ms (default: 2000) */
     pollIntervalMs?: number;
-    /** Max monitoring duration in ms (default: 300000) */
+    /** Max inactivity duration in ms (default: 900000 = 15 min). Set 0 to disable. */
     maxDurationMs?: number;
     /** Consecutive stop-gone confirmations needed (default: 3) */
     stopGoneConfirmCount?: number;
@@ -506,7 +506,7 @@ export class ResponseMonitor {
     constructor(options: ResponseMonitorOptions) {
         this.cdpService = options.cdpService;
         this.pollIntervalMs = options.pollIntervalMs ?? 2000;
-        this.maxDurationMs = options.maxDurationMs ?? 300000;
+        this.maxDurationMs = options.maxDurationMs ?? 900000;
         this.stopGoneConfirmCount = options.stopGoneConfirmCount ?? 3;
         this.extractionMode = options.extractionMode ?? 'structured';
         this.onProgress = options.onProgress;
@@ -958,7 +958,10 @@ export class ResponseMonitor {
             }
 
             // Activity-based inactivity timeout (#49)
-            if (this.maxDurationMs > 0 && Date.now() - this.lastActivityTime >= this.maxDurationMs) {
+            // Guard: never timeout while the stop button is visible — it means
+            // Antigravity is still actively generating (extended thinking, long
+            // shell commands, large file operations, etc.).
+            if (this.maxDurationMs > 0 && !isGenerating && Date.now() - this.lastActivityTime >= this.maxDurationMs) {
                 const lastText = this.lastText ?? '';
                 this.setPhase('timeout', lastText);
                 await this.stop();

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -21,6 +21,8 @@ export interface AppConfig {
     telegramAllowedUserIds?: string[];
     /** Active platforms. Defaults to ['discord']. */
     platforms: PlatformType[];
+    /** Response monitor inactivity timeout in ms. 0 = disabled. Default: 900000 (15 min). */
+    responseTimeoutMs: number;
 }
 
 export type ResponseDeliveryMode = 'stream';

--- a/src/utils/configLoader.ts
+++ b/src/utils/configLoader.ts
@@ -30,6 +30,7 @@ export interface PersistedConfig {
     telegramToken?: string;
     telegramAllowedUserIds?: string[];
     platforms?: PlatformType[];
+    responseTimeoutMs?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -116,6 +117,12 @@ function mergeConfig(persisted: PersistedConfig): AppConfig {
         persisted.extractionMode,
     );
 
+    const responseTimeoutMs = resolvePositiveInt(
+        process.env.RESPONSE_TIMEOUT_MS,
+        persisted.responseTimeoutMs,
+        900000,
+    );
+
     // Telegram credentials — only required when Telegram is an active platform
     const telegramToken = process.env.TELEGRAM_BOT_TOKEN ?? persisted.telegramToken ?? undefined;
     const telegramAllowedUserIds = resolveTelegramAllowedUserIds(persisted);
@@ -135,6 +142,7 @@ function mergeConfig(persisted: PersistedConfig): AppConfig {
         autoApproveFileEdits,
         logLevel,
         extractionMode,
+        responseTimeoutMs,
         telegramToken,
         telegramAllowedUserIds,
         platforms,
@@ -220,6 +228,23 @@ function resolveBoolean(
 ): boolean {
     if (envValue !== undefined) return envValue.toLowerCase() === 'true';
     if (persistedValue !== undefined) return persistedValue;
+    return defaultValue;
+}
+
+/**
+ * Resolve a non-negative integer value from env var > persisted config > default.
+ * Returns the default if the env/persisted value is not a valid non-negative integer.
+ */
+function resolvePositiveInt(
+    envValue: string | undefined,
+    persistedValue: number | undefined,
+    defaultValue: number,
+): number {
+    if (envValue !== undefined) {
+        const parsed = parseInt(envValue, 10);
+        if (!isNaN(parsed) && parsed >= 0) return parsed;
+    }
+    if (persistedValue !== undefined && persistedValue >= 0) return persistedValue;
     return defaultValue;
 }
 


### PR DESCRIPTION
## Summary
Fixes false timeouts during long-running agentic tasks by adding a stop button guard to the timeout condition and making the timeout duration configurable.

Changes:
- **Stop button guard**: Never timeout while the stop button is visible (`!isGenerating`)
- **Configurable timeout**: New `RESPONSE_TIMEOUT_MS` env var and `responseTimeoutMs` in config.json
- **Raised default**: 5 min → 15 min (set `0` to disable entirely)
- **All call sites updated**: Discord, Telegram, and join/mirror handlers

## Linked Issues
Closes #107

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
