### PR TITLE
feat(bot): prefer general channel for startup dashboard

### DIFF
--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -106,14 +106,21 @@ import { createModelButtonAction } from '../handlers/modelButtonAction';
 import { createAutoAcceptButtonAction } from '../handlers/autoAcceptButtonAction';
 import { createTemplateButtonAction } from '../handlers/templateButtonAction';
 import { createModeSelectAction } from '../handlers/modeSelectAction';
+import { DEFAULT_CHANNEL_NAME } from '../services/channelManager';
 
+/**
+ * Normalize a candidate startup channel name for preference checks.
+ */
 function normalizeStartupChannelName(name: string): string {
     return name.trim().replace(/^#/, '').toLowerCase();
 }
 
+/**
+ * Prefer the shared default channel name plus the localized 常规 variant.
+ */
 function isPreferredDiscordStartupChannel(name: string): boolean {
     const normalized = normalizeStartupChannelName(name);
-    return normalized === 'general' || normalized === '常规';
+    return normalized === DEFAULT_CHANNEL_NAME || normalized === '常规';
 }
 
 // =============================================================================

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -107,6 +107,15 @@ import { createAutoAcceptButtonAction } from '../handlers/autoAcceptButtonAction
 import { createTemplateButtonAction } from '../handlers/templateButtonAction';
 import { createModeSelectAction } from '../handlers/modeSelectAction';
 
+function normalizeStartupChannelName(name: string): string {
+    return name.trim().replace(/^#/, '').toLowerCase();
+}
+
+function isPreferredDiscordStartupChannel(name: string): boolean {
+    const normalized = normalizeStartupChannelName(name);
+    return normalized === 'general' || normalized === '常规';
+}
+
 // =============================================================================
 // Embed color palette (color-coded by phase)
 // =============================================================================
@@ -1007,12 +1016,17 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                 .setFooter({ text: `Started at ${new Date().toLocaleString()}` })
                 .setTimestamp();
 
-            // Send to the first available text channel in the guild
+            // Prefer the guild's general text channel, then fall back to the first sendable text channel.
             const guild = readyClient.guilds.cache.first();
             if (guild) {
-                const channel = guild.channels.cache.find(
-                    (ch) => ch.isTextBased() && !ch.isVoiceBased() && ch.permissionsFor(readyClient.user)?.has('SendMessages'),
+                const sendableTextChannels = guild.channels.cache.filter(
+                    (ch) =>
+                        ch.isTextBased()
+                        && !ch.isVoiceBased()
+                        && ch.permissionsFor(readyClient.user)?.has('SendMessages'),
                 );
+                const channel = sendableTextChannels.find((ch) => isPreferredDiscordStartupChannel(ch.name))
+                    ?? sendableTextChannels.first();
                 if (channel && channel.isTextBased()) {
                     await channel.send({ embeds: [dashboardEmbed] });
                     logger.info('Startup dashboard embed sent.');

--- a/src/services/channelManager.ts
+++ b/src/services/channelManager.ts
@@ -30,7 +30,7 @@ export interface CreateSessionChannelResult {
 /** Category name prefix emoji */
 const CATEGORY_PREFIX = '🗂️-';
 /** Default channel name under the category */
-const DEFAULT_CHANNEL_NAME = 'general';
+export const DEFAULT_CHANNEL_NAME = 'general';
 
 /**
  * Class that manages Discord categories and channels corresponding to workspace paths.


### PR DESCRIPTION
## Description
Split from #94 to isolate the Discord startup dashboard channel preference tweak.

## Included
- prefer an existing `general` / `常规` text channel when choosing the startup dashboard target

## Verification (March 30, 2026)
- `npm run build` ✅
- No focused automated test exists for this small startup-target preference change.

## Notes
- Separate from the larger Telegram/forum/multi-account work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Discord startup dashboard message delivery with smarter channel selection. The bot now filters to channels that can receive text messages, prioritizes preferred channel names (including localized defaults), and falls back to the next available sendable channel when needed. This reduces missed or misrouted startup embeds and increases reliability of initial notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->