### PR TITLE
feat: split CDP multi-account reopen flow from PR 94

### DIFF
--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -7,6 +7,7 @@ import { startAction } from './commands/start';
 import { doctorAction } from './commands/doctor';
 import { setupAction } from './commands/setup';
 import { openAction } from './commands/open';
+import { exportConversationAction, importConversationAction } from './commands/conversationTransfer';
 import { ConfigLoader } from '../utils/configLoader';
 
 const program = new Command()
@@ -47,5 +48,20 @@ program
     .command('open')
     .description('Open Antigravity with CDP enabled (auto-selects available port)')
     .action(openAction);
+
+program
+    .command('conversation-export')
+    .description('Export a single Antigravity conversation bundle by profile and title')
+    .requiredOption('--profile <name>', 'Source Antigravity profile name')
+    .requiredOption('--title <title>', 'Conversation title as shown in Antigravity history')
+    .requiredOption('--out <dir>', 'Output directory for the exported bundle')
+    .action((opts) => exportConversationAction(opts.profile, opts.title, opts.out));
+
+program
+    .command('conversation-import')
+    .description('Import a previously exported conversation bundle into another Antigravity profile')
+    .requiredOption('--profile <name>', 'Target Antigravity profile name')
+    .requiredOption('--bundle <dir>', 'Conversation bundle directory created by conversation-export')
+    .action((opts) => importConversationAction(opts.profile, opts.bundle));
 
 program.parse();

--- a/src/bin/commands/conversationTransfer.ts
+++ b/src/bin/commands/conversationTransfer.ts
@@ -1,0 +1,13 @@
+import { exportConversationBundleByTitle, importConversationBundleToProfile } from '../../services/conversationTransferService';
+import { COLORS } from '../../utils/logger';
+
+export function exportConversationAction(profile: string, title: string, outDir: string): void {
+    const bundleDir = exportConversationBundleByTitle(profile, title, outDir);
+    console.log(`${COLORS.green}Exported conversation bundle:${COLORS.reset} ${bundleDir}`);
+}
+
+export function importConversationAction(profile: string, bundleDir: string): void {
+    const result = importConversationBundleToProfile(bundleDir, profile);
+    console.log(`${COLORS.green}Imported conversation:${COLORS.reset} ${result.conversationId}`);
+    console.log(`${COLORS.dim}DB backup:${COLORS.reset} ${result.dbBackupPath}`);
+}

--- a/src/bin/commands/open.ts
+++ b/src/bin/commands/open.ts
@@ -2,7 +2,7 @@ import * as net from 'net';
 import * as http from 'http';
 import * as os from 'os';
 import { execFile, spawn } from 'child_process';
-import { CDP_PORTS } from '../../utils/cdpPorts';
+import { getConfiguredCdpPorts } from '../../utils/cdpPorts';
 
 const APP_NAME = 'Antigravity';
 
@@ -31,7 +31,8 @@ function isPortAvailable(port: number): Promise<boolean> {
 }
 
 async function findAvailablePort(): Promise<number | null> {
-    for (const port of CDP_PORTS) {
+    const ports = getConfiguredCdpPorts(process.env.ANTIGRAVITY_ACCOUNTS);
+    for (const port of ports) {
         if (await isPortAvailable(port)) {
             return port;
         }
@@ -125,13 +126,14 @@ function waitForCdp(port: number, timeoutMs: number = 15000, intervalMs: number 
 
 export async function openAction(): Promise<void> {
     const platform = os.platform();
+    const ports = getConfiguredCdpPorts(process.env.ANTIGRAVITY_ACCOUNTS);
 
     console.log(`\n  ${C.cyan}Searching for an available CDP port...${C.reset}`);
 
     const port = await findAvailablePort();
     if (port === null) {
         console.log(`  ${C.red}No available CDP ports found.${C.reset}`);
-        console.log(`  ${C.dim}All candidate ports are in use: ${CDP_PORTS.join(', ')}${C.reset}`);
+        console.log(`  ${C.dim}All candidate ports are in use: ${ports.join(', ')}${C.reset}`);
         console.log(`  ${C.dim}Close an application using one of these ports and try again.${C.reset}\n`);
         process.exitCode = 1;
         return;

--- a/src/bin/commands/setup.ts
+++ b/src/bin/commands/setup.ts
@@ -19,8 +19,18 @@ async function getSelect(): Promise<SelectFn> {
 }
 import { ConfigLoader } from '../../utils/configLoader';
 import type { PersistedConfig } from '../../utils/configLoader';
+import type { AppConfig } from '../../utils/config';
 import { CDP_PORTS } from '../../utils/cdpPorts';
+import {
+    normalizeAntigravityAccounts,
+    parseAntigravityAccounts,
+    serializeAntigravityAccounts,
+} from '../../utils/cdpPorts';
 import type { PlatformType } from '../../platform/types';
+import {
+    discoverAntigravityAccounts,
+    hasCockpitSettings,
+} from '../../services/antigravityAccountDiscovery';
 
 // ---------------------------------------------------------------------------
 // ANSI colors
@@ -233,6 +243,21 @@ function buildInviteUrl(clientId: string): string {
     return `https://discord.com/api/oauth2/authorize?client_id=${clientId}&permissions=${permissions}&scope=bot%20applications.commands`;
 }
 
+function renderSetupScreen(envFileStatus?: string): void {
+    if (process.stdout.isTTY) {
+        console.clear();
+    }
+    console.log(SETUP_LOGO);
+    if (envFileStatus) {
+        console.log(`  ${C.dim}.env: ${envFileStatus}${C.reset}\n`);
+    }
+}
+
+function renderSetupSubMenu(envFileStatus: string | undefined, title: string, status: string): void {
+    renderSetupScreen(envFileStatus);
+    console.log(`✔ ${C.cyan}${title}${C.reset} ${status}`);
+}
+
 // ---------------------------------------------------------------------------
 // Status detection (pure functions)
 // ---------------------------------------------------------------------------
@@ -245,49 +270,135 @@ function isTelegramConfigured(p: PersistedConfig): boolean {
     return !!(p.telegramToken && p.telegramAllowedUserIds && p.telegramAllowedUserIds.length > 0);
 }
 
-function workspaceLabel(p: PersistedConfig): string {
-    return p.workspaceBaseDir ?? (path.join(os.homedir(), 'Code') + ' (default)');
+function resolveWorkspaceLabel(p: PersistedConfig): { label: string; source: ConfigSource } {
+    const envValue = process.env.WORKSPACE_BASE_DIR?.trim();
+    if (envValue) {
+        return { label: expandTilde(envValue), source: 'env' };
+    }
+
+    if (p.workspaceBaseDir && p.workspaceBaseDir.trim().length > 0) {
+        return { label: p.workspaceBaseDir, source: 'persisted' };
+    }
+
+    return { label: path.join(os.homedir(), 'Code') + ' (default)', source: 'none' };
+}
+
+function getPersistedAntigravityAccounts(p: PersistedConfig) {
+    if (typeof p.antigravityAccounts === 'string') {
+        return parseAntigravityAccounts(p.antigravityAccounts);
+    }
+    return normalizeAntigravityAccounts(p.antigravityAccounts);
 }
 
 function isValidTelegramTokenFormat(token: string): boolean {
     return /^\d+:[A-Za-z0-9_-]+$/.test(token);
 }
 
-/**
- * Recompute platforms from the current persisted state and save.
- * Called after each individual setup flow so Ctrl+C mid-session
- * still leaves a valid platforms array.
- */
-function savePlatformsFromState(): void {
-    const current = ConfigLoader.readPersisted();
+function savePlatformsFromState(current: PersistedConfig): void {
     const platforms: PlatformType[] = [];
     if (isDiscordConfigured(current)) platforms.push('discord');
     if (isTelegramConfigured(current)) platforms.push('telegram');
-    ConfigLoader.save({ platforms });
+    current.platforms = platforms;
 }
 
-/**
- * Add a platform to the persisted platforms list (idempotent).
- */
-function addPlatform(platform: PlatformType): void {
-    const current = ConfigLoader.readPersisted();
+function addPlatform(current: PersistedConfig, platform: PlatformType): void {
     const platforms = current.platforms ?? [];
     if (!platforms.includes(platform)) {
-        ConfigLoader.save({ platforms: [...platforms, platform] });
+        current.platforms = [...platforms, platform];
     }
 }
 
-/**
- * Remove a platform from the persisted platforms list (idempotent).
- * Credentials are preserved — only the enabled flag changes.
- */
-function removePlatform(platform: PlatformType): void {
-    const current = ConfigLoader.readPersisted();
-    const platforms = (current.platforms ?? []).filter((p) => p !== platform);
-    ConfigLoader.save({ platforms });
+function removePlatform(current: PersistedConfig, platform: PlatformType): void {
+    current.platforms = (current.platforms ?? []).filter((p) => p !== platform);
 }
 
 type PlatformStatus = 'enabled' | 'disabled' | 'not_configured';
+type ConfigSource = 'env' | 'persisted' | 'both' | 'none';
+
+function resolvePlatformsForDisplay(persisted: PersistedConfig): PlatformType[] {
+    const envValue = process.env.PLATFORMS;
+    if (envValue) {
+        const parsed = envValue
+            .split(',')
+            .map((p) => p.trim().toLowerCase())
+            .filter((p): p is PlatformType => p === 'discord' || p === 'telegram');
+        if (parsed.length > 0) return parsed;
+    }
+    if (persisted.platforms && persisted.platforms.length > 0) {
+        return persisted.platforms;
+    }
+    return ['discord'];
+}
+
+function resolveConfigSource(envConfigured: boolean, persistedConfigured: boolean): ConfigSource {
+    if (envConfigured && persistedConfigured) return 'both';
+    if (envConfigured) return 'env';
+    if (persistedConfigured) return 'persisted';
+    return 'none';
+}
+
+function formatMenuLabel(left: string, right: string): string {
+    return `${left.padEnd(22, ' ')} ${right}`;
+}
+
+function isDiscordConfiguredFromEnv(): boolean {
+    return !!(process.env.DISCORD_BOT_TOKEN && process.env.CLIENT_ID && process.env.ALLOWED_USER_IDS);
+}
+
+function isTelegramConfiguredFromEnv(): boolean {
+    return !!(process.env.TELEGRAM_BOT_TOKEN && process.env.TELEGRAM_ALLOWED_USER_IDS);
+}
+
+function getMultiInstanceRawValue(p: PersistedConfig): { value: string; source: ConfigSource } {
+    if (typeof p.antigravityAccounts === 'string' && p.antigravityAccounts.trim().length > 0) {
+        return { value: p.antigravityAccounts.trim(), source: 'persisted' };
+    }
+
+    if (Array.isArray(p.antigravityAccounts) && p.antigravityAccounts.length > 0) {
+        return { value: serializeAntigravityAccounts(p.antigravityAccounts), source: 'persisted' };
+    }
+
+    const envValue = process.env.ANTIGRAVITY_ACCOUNTS?.trim() ?? '';
+    if (envValue) {
+        return { value: envValue, source: 'env' };
+    }
+
+    return { value: '', source: 'none' };
+}
+
+function abbreviateUserDataDir(userDataDir: string | undefined): string {
+    const trimmed = (userDataDir ?? '').trim();
+    if (!trimmed) {
+        return '';
+    }
+
+    if (trimmed.length <= 16) {
+        return trimmed;
+    }
+
+    return `...${trimmed.slice(-12)}`;
+}
+
+function formatMultiInstanceSummary(rawValue: string): string {
+    const accounts = parseAntigravityAccounts(rawValue);
+    if (accounts.length === 0) {
+        return '[not configured]';
+    }
+
+    const preview = accounts
+        .slice(0, 3)
+        .map((account) => {
+            const suffix = abbreviateUserDataDir(account.userDataDir);
+            return suffix
+                ? `${account.name}:${account.cdpPort}@${suffix}`
+                : `${account.name}:${account.cdpPort}`;
+        })
+        .join(',');
+
+    const remainder = accounts.length > 3 ? ',...' : '';
+    const label = accounts.length === 1 ? 'instance' : 'instances';
+    return `${accounts.length} ${label} => ${preview}${remainder}`;
+}
 
 function platformStatus(
     hasCredentials: boolean,
@@ -363,8 +474,11 @@ async function promptAllowedUserIds(rl: readline.Interface): Promise<string[]> {
     }
 }
 
-async function promptWorkspaceDir(rl: readline.Interface): Promise<string> {
-    const defaultDir = path.join(os.homedir(), 'Code');
+async function promptWorkspaceDir(rl: readline.Interface, current: PersistedConfig): Promise<string> {
+    const configured = resolveWorkspaceLabel(current).label;
+    const defaultDir = configured.endsWith(' (default)')
+        ? path.join(os.homedir(), 'Code')
+        : configured;
 
     while (true) {
         const raw = await ask(rl, `  ${C.yellow}>${C.reset} [${C.dim}${defaultDir}${C.reset}] `);
@@ -384,21 +498,122 @@ async function promptWorkspaceDir(rl: readline.Interface): Promise<string> {
     }
 }
 
+async function confirm(
+    rl: readline.Interface,
+    prompt: string,
+    defaultAnswer: 'y' | 'n' = 'y',
+): Promise<boolean> {
+    while (true) {
+        const suffix = defaultAnswer === 'y' ? ' [Y/n]' : ' [y/N]';
+        const raw = (await ask(rl, `  ${C.yellow}${prompt}${suffix}:${C.reset} `)).trim().toLowerCase();
+        if (!raw) return defaultAnswer === 'y';
+        if (raw === 'y' || raw === 'yes') return true;
+        if (raw === 'n' || raw === 'no') return false;
+        errMsg('Please answer y or n.');
+    }
+}
+
+function validateAntigravityAccountsInput(raw: string): string | null {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+        return null;
+    }
+
+    const accounts = parseAntigravityAccounts(trimmed);
+    if (accounts.length === 0) {
+        return 'Invalid format. Use comma-separated entries like default:9222@/path/to/profile';
+    }
+
+    const seenNames = new Set<string>();
+    const seenPorts = new Set<number>();
+
+    for (const account of accounts) {
+        if (seenNames.has(account.name)) {
+            return `Duplicate account name: "${account.name}".`;
+        }
+        seenNames.add(account.name);
+
+        if (seenPorts.has(account.cdpPort)) {
+            return `Duplicate CDP port: ${account.cdpPort}.`;
+        }
+        seenPorts.add(account.cdpPort);
+    }
+
+    return null;
+}
+
+function findMissingUserDataDirs(raw: string): string[] {
+    return parseAntigravityAccounts(raw)
+        .map((account) => account.userDataDir?.trim() ?? '')
+        .filter((dir): dir is string => dir.length > 0)
+        .filter((dir) => !fs.existsSync(dir));
+}
+
+function saveAntigravityAccountsToState(current: PersistedConfig, raw: string): void {
+    const trimmed = raw.trim();
+    current.antigravityAccounts = trimmed
+        ? parseAntigravityAccounts(trimmed)
+        : undefined;
+}
+
+function savePersistedConfig(config: PersistedConfig): void {
+    ConfigLoader.save({
+        discordToken: config.discordToken,
+        clientId: config.clientId,
+        guildId: config.guildId,
+        allowedUserIds: config.allowedUserIds,
+        workspaceBaseDir: config.workspaceBaseDir,
+        autoApproveFileEdits: config.autoApproveFileEdits,
+        logLevel: config.logLevel,
+        extractionMode: config.extractionMode,
+        telegramToken: config.telegramToken,
+        telegramAllowedUserIds: config.telegramAllowedUserIds,
+        platforms: config.platforms,
+        antigravityAccounts: config.antigravityAccounts,
+    });
+}
+
+function toWorkingConfig(): PersistedConfig {
+    const loaded: AppConfig = ConfigLoader.load();
+
+    return {
+        discordToken: loaded.discordToken,
+        clientId: loaded.clientId,
+        guildId: loaded.guildId,
+        allowedUserIds: loaded.allowedUserIds,
+        workspaceBaseDir: loaded.workspaceBaseDir,
+        autoApproveFileEdits: loaded.autoApproveFileEdits,
+        logLevel: loaded.logLevel,
+        extractionMode: loaded.extractionMode,
+        telegramToken: loaded.telegramToken,
+        telegramAllowedUserIds: loaded.telegramAllowedUserIds,
+        platforms: loaded.platforms,
+        antigravityAccounts: loaded.antigravityAccounts,
+    };
+}
+
 // ---------------------------------------------------------------------------
 // Platform sub-menu (enable / reconfigure / disable / back)
 // ---------------------------------------------------------------------------
 
-type PlatformAction = 'enable' | 'reconfigure' | 'disable' | 'back';
+type PlatformAction = 'configure' | 'enable' | 'reconfigure' | 'disable' | 'back';
 
 async function platformSubMenu(
     rl: readline.Interface,
+    envFileStatus: string | undefined,
     platformName: string,
+    platformStatusLabel: string,
     status: PlatformStatus,
 ): Promise<PlatformAction> {
     const select = await getSelect();
 
     const choices: Array<{ name: string; value: PlatformAction }> =
-        status === 'disabled'
+        status === 'not_configured'
+            ? [
+                  { name: 'Configure', value: 'configure' as const },
+                  { name: 'Back', value: 'back' as const },
+              ]
+            : status === 'disabled'
             ? [
                   { name: 'Enable', value: 'enable' as const },
                   { name: 'Reconfigure', value: 'reconfigure' as const },
@@ -412,6 +627,7 @@ async function platformSubMenu(
 
     rl.pause();
     try {
+        renderSetupSubMenu(envFileStatus, platformName, platformStatusLabel);
         return await select<PlatformAction>({
             message: `${platformName}:`,
             choices,
@@ -422,10 +638,10 @@ async function platformSubMenu(
 }
 
 // ---------------------------------------------------------------------------
-// Individual setup flows (each saves immediately)
+// Individual setup flows
 // ---------------------------------------------------------------------------
 
-async function runDiscordSetup(rl: readline.Interface): Promise<void> {
+async function runDiscordSetup(rl: readline.Interface, current: PersistedConfig): Promise<void> {
     sectionHeader('Discord Bot Token');
     hint('1. Go to https://discord.com/developers/applications and log in');
     hint('2. Click "New Application" (top-right), enter a name (e.g. LazyGravity), and create it');
@@ -458,15 +674,18 @@ async function runDiscordSetup(rl: readline.Interface): Promise<void> {
     const allowedUserIds = await promptAllowedUserIds(rl);
     console.log('');
 
-    ConfigLoader.save({ discordToken, clientId, guildId, allowedUserIds });
-    savePlatformsFromState();
+    current.discordToken = discordToken;
+    current.clientId = clientId;
+    current.guildId = guildId;
+    current.allowedUserIds = allowedUserIds;
+    savePlatformsFromState(current);
 
     const inviteUrl = buildInviteUrl(clientId);
     console.log(`  ${C.green}Discord saved!${C.reset}`);
     console.log(`  ${C.dim}Invite URL:${C.reset} ${inviteUrl}\n`);
 }
 
-async function runTelegramSetup(rl: readline.Interface): Promise<void> {
+async function runTelegramSetup(rl: readline.Interface, current: PersistedConfig): Promise<void> {
     sectionHeader('Telegram Bot Token');
     hint('1. Open Telegram and message @BotFather');
     hint('2. Send /newbot and follow the prompts to create a bot');
@@ -498,21 +717,192 @@ async function runTelegramSetup(rl: readline.Interface): Promise<void> {
     const telegramAllowedUserIds = await promptAllowedUserIds(rl);
     console.log('');
 
-    ConfigLoader.save({ telegramToken, telegramAllowedUserIds });
-    savePlatformsFromState();
+    current.telegramToken = telegramToken;
+    current.telegramAllowedUserIds = telegramAllowedUserIds;
+    savePlatformsFromState(current);
     console.log(`  ${C.green}Telegram saved!${C.reset}\n`);
 }
 
-async function runWorkspaceSetup(rl: readline.Interface): Promise<void> {
+async function runWorkspaceSetup(
+    rl: readline.Interface,
+    envFileStatus: string | undefined,
+    workspaceStatusLabel: string,
+    current: PersistedConfig,
+): Promise<void> {
+    renderSetupSubMenu(envFileStatus, 'Workspace Directory', workspaceStatusLabel);
     sectionHeader('Workspace Base Directory');
     hint('The parent directory where your coding projects live.');
     hint('LazyGravity will scan subdirectories as workspaces.');
     hintBlank();
-    const workspaceBaseDir = await promptWorkspaceDir(rl);
+    const workspaceBaseDir = await promptWorkspaceDir(rl, current);
     console.log('');
 
-    ConfigLoader.save({ workspaceBaseDir });
+    current.workspaceBaseDir = workspaceBaseDir;
     console.log(`  ${C.green}Workspace saved!${C.reset}\n`);
+}
+
+type AntigravitySetupAction = 'auto_detect' | 'manual' | 'clear' | 'back';
+type WorkspaceSetupAction = 'reconfigure' | 'back';
+
+async function antigravitySubMenu(): Promise<AntigravitySetupAction> {
+    const select = await getSelect();
+    return select<AntigravitySetupAction>({
+        message: 'AG Multi-instance:',
+        choices: [
+            { name: 'Auto-detect from cockpit-tools / running Antigravity', value: 'auto_detect' },
+            { name: 'Enter manually (name:port@path)', value: 'manual' },
+            { name: 'Clear saved Antigravity instances', value: 'clear' },
+            { name: 'Back', value: 'back' },
+        ],
+    });
+}
+
+async function workspaceSubMenu(): Promise<WorkspaceSetupAction> {
+    const select = await getSelect();
+    return select<WorkspaceSetupAction>({
+        message: 'Workspace Directory:',
+        choices: [
+            { name: 'Reconfigure', value: 'reconfigure' },
+            { name: 'Back', value: 'back' },
+        ],
+    });
+}
+
+async function runManualAntigravitySetup(rl: readline.Interface, current: PersistedConfig): Promise<void> {
+    sectionHeader('AG Multi-instance');
+    hint('Format: name:cdpPort@user-data-dir');
+    hint('Examples:');
+    hint('  default:9222');
+    hint('  work:9333@/Users/you/Library/Application Support/Antigravity/work');
+    hint('Multiple instances: separate with commas');
+    hintBlank();
+
+    const existing = typeof current.antigravityAccounts === 'string'
+        ? current.antigravityAccounts
+        : serializeAntigravityAccounts(current.antigravityAccounts);
+    const raw = await ask(
+        rl,
+        `  ${C.yellow}>${C.reset} [${C.dim}${existing || 'default:9222'}${C.reset}] `,
+    );
+    const nextValue = raw.trim() || existing || 'default:9222';
+
+    const validationError = validateAntigravityAccountsInput(nextValue);
+    if (validationError) {
+        errMsg(validationError);
+        return;
+    }
+
+    const missingDirs = findMissingUserDataDirs(nextValue);
+    if (missingDirs.length > 0) {
+        console.log(`  ${C.yellow}These user-data-dir paths do not exist:${C.reset}`);
+        for (const dir of missingDirs) {
+            console.log(`    ${dir}`);
+        }
+        console.log('');
+        const keep = await confirm(rl, 'Save them anyway', 'n');
+        if (!keep) {
+            console.log('');
+            return;
+        }
+    }
+
+    saveAntigravityAccountsToState(current, nextValue);
+    console.log(`\n  ${C.green}Antigravity instances saved!${C.reset}\n`);
+}
+
+async function runAutoDetectAntigravitySetup(rl: readline.Interface, current: PersistedConfig): Promise<void> {
+    sectionHeader('Detect Antigravity Instances');
+    hint('Scanning cockpit-tools app data and running Antigravity processes...');
+    hintBlank();
+
+    const existingAccounts = getPersistedAntigravityAccounts(current);
+    const result = await discoverAntigravityAccounts(existingAccounts);
+    const discovered = result.accounts;
+
+    if (discovered.length === 0) {
+        errMsg('No Antigravity instances were detected.');
+        return;
+    }
+
+    console.log(`  ${C.cyan}Detected:${C.reset}`);
+    for (const account of discovered) {
+        const userDataDir = account.userDataDir ?? '(not detected)';
+        console.log(`  - ${account.name}: ${account.cdpPort}@${userDataDir}`);
+        const source = (account as { source?: string }).source;
+        if (source) {
+            console.log(`    ${C.dim}${source}${C.reset}`);
+        }
+    }
+    console.log('');
+
+    if (result.warnings.length > 0) {
+        console.log(`  ${C.yellow}Warnings:${C.reset}`);
+        for (const warning of result.warnings) {
+            console.log(`  - ${warning}`);
+        }
+        console.log('');
+    }
+
+    const missingDirs = discovered
+        .map((account) => account.userDataDir?.trim() ?? '')
+        .filter((dir): dir is string => dir.length > 0)
+        .filter((dir) => !fs.existsSync(dir));
+
+    if (missingDirs.length > 0) {
+        console.log(`  ${C.yellow}Warning:${C.reset} some detected user-data-dir paths do not exist.`);
+        for (const dir of missingDirs) {
+            console.log(`    ${dir}`);
+        }
+        console.log('');
+    }
+
+    const shouldImport = await confirm(rl, 'Import these instances into setup', 'y');
+    if (!shouldImport) {
+        console.log('');
+        return;
+    }
+
+    saveAntigravityAccountsToState(current, serializeAntigravityAccounts(discovered));
+    console.log(`\n  ${C.green}Imported ${discovered.length} Antigravity instance(s).${C.reset}\n`);
+}
+
+async function runAntigravitySetup(
+    rl: readline.Interface,
+    envFileStatus: string | undefined,
+    current: PersistedConfig,
+): Promise<void> {
+    if (!hasCockpitSettings()) {
+        sectionHeader('AG Multi-instance');
+        hint('Cockpit Tools was not detected on this machine.');
+        hint('Install it first, then configure your Antigravity multi-instances there.');
+        hint('Download: https://github.com/jlcodes99/cockpit-tools/releases');
+        hintBlank();
+        return;
+    }
+
+    rl.pause();
+    renderSetupSubMenu(envFileStatus, 'AG Multi-instance', '');
+    const action = await antigravitySubMenu();
+    rl.resume();
+
+    switch (action) {
+        case 'auto_detect':
+            await runAutoDetectAntigravitySetup(rl, current);
+            return;
+        case 'manual':
+            await runManualAntigravitySetup(rl, current);
+            return;
+        case 'clear':
+            if (await confirm(rl, 'Clear saved Antigravity instances', 'n')) {
+                current.antigravityAccounts = undefined;
+                console.log(`\n  ${C.green}Cleared saved Antigravity instances.${C.reset}\n`);
+            } else {
+                console.log('');
+            }
+            return;
+        case 'back':
+            return;
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -521,45 +911,58 @@ async function runWorkspaceSetup(rl: readline.Interface): Promise<void> {
 
 export async function setupAction(): Promise<void> {
     const rl = createInterface();
+    const envFilePath = path.resolve('.env');
+    const envFileStatus = fs.existsSync(envFilePath) ? envFilePath : undefined;
+    const workingConfig: PersistedConfig = toWorkingConfig();
 
     try {
-        console.log(SETUP_LOGO);
-
         while (true) {
-            const config = ConfigLoader.readPersisted();
-            const discordSt = platformStatus(isDiscordConfigured(config), config.platforms, 'discord');
-            const telegramSt = platformStatus(isTelegramConfigured(config), config.platforms, 'telegram');
-            const wsLabel = `${C.dim}${workspaceLabel(config)}${C.reset}`;
+            renderSetupScreen(envFileStatus);
+            const platforms = resolvePlatformsForDisplay(workingConfig);
+            const discordSource = resolveConfigSource(isDiscordConfiguredFromEnv(), isDiscordConfigured(workingConfig));
+            const telegramSource = resolveConfigSource(isTelegramConfiguredFromEnv(), isTelegramConfigured(workingConfig));
+            const multiInstance = getMultiInstanceRawValue(workingConfig);
+            const discordSt = platformStatus(discordSource !== 'none', platforms, 'discord');
+            const telegramSt = platformStatus(telegramSource !== 'none', platforms, 'telegram');
+            const workspace = resolveWorkspaceLabel(workingConfig);
+            const wsLabel = `${C.dim}${workspace.label}${C.reset}`;
+            const multiInstanceLabel = multiInstance.value
+                ? `${C.dim}${formatMultiInstanceSummary(multiInstance.value)}${C.reset}`
+                : `${C.dim}[not configured]${C.reset}`;
+            const discordRight = `${statusBadge(discordSt)}`;
+            const telegramRight = `${statusBadge(telegramSt)}`;
+            const multiInstanceRight = `${multiInstanceLabel}`;
 
             const select = await getSelect();
             rl.pause();
             const choice = await select({
                 message: 'Configure:',
                 choices: [
-                    { name: `Discord                ${statusBadge(discordSt)}`, value: 'discord' as const },
-                    { name: `Telegram               ${statusBadge(telegramSt)}`, value: 'telegram' as const },
-                    { name: `Workspace Directory    ${wsLabel}`, value: 'workspace' as const },
+                    { name: formatMenuLabel('Discord', discordRight), value: 'discord' as const },
+                    { name: formatMenuLabel('Telegram', telegramRight), value: 'telegram' as const },
+                    { name: formatMenuLabel('Workspace Directory', wsLabel), value: 'workspace' as const },
+                    { name: formatMenuLabel('AG Multi-instance', multiInstanceRight), value: 'antigravity' as const },
                     { name: `Done — save & exit`, value: 'done' as const },
+                    { name: `Exit without save`, value: 'cancel' as const },
                 ],
             });
             rl.resume();
 
             switch (choice) {
                 case 'discord':
-                    if (discordSt === 'not_configured') {
-                        await runDiscordSetup(rl);
-                    } else {
-                        const action = await platformSubMenu(rl, 'Discord', discordSt);
+                    {
+                        const action = await platformSubMenu(rl, envFileStatus, 'Discord', discordRight, discordSt);
                         switch (action) {
+                            case 'configure':
+                            case 'reconfigure':
+                                await runDiscordSetup(rl, workingConfig);
+                                break;
                             case 'enable':
-                                addPlatform('discord');
+                                addPlatform(workingConfig, 'discord');
                                 console.log(`  ${C.green}Discord enabled.${C.reset}\n`);
                                 break;
-                            case 'reconfigure':
-                                await runDiscordSetup(rl);
-                                break;
                             case 'disable':
-                                removePlatform('discord');
+                                removePlatform(workingConfig, 'discord');
                                 console.log(`  ${C.yellow}Discord disabled.${C.reset} Credentials kept.\n`);
                                 break;
                             case 'back':
@@ -568,20 +971,19 @@ export async function setupAction(): Promise<void> {
                     }
                     break;
                 case 'telegram':
-                    if (telegramSt === 'not_configured') {
-                        await runTelegramSetup(rl);
-                    } else {
-                        const action = await platformSubMenu(rl, 'Telegram', telegramSt);
+                    {
+                        const action = await platformSubMenu(rl, envFileStatus, 'Telegram', telegramRight, telegramSt);
                         switch (action) {
+                            case 'configure':
+                            case 'reconfigure':
+                                await runTelegramSetup(rl, workingConfig);
+                                break;
                             case 'enable':
-                                addPlatform('telegram');
+                                addPlatform(workingConfig, 'telegram');
                                 console.log(`  ${C.green}Telegram enabled.${C.reset}\n`);
                                 break;
-                            case 'reconfigure':
-                                await runTelegramSetup(rl);
-                                break;
                             case 'disable':
-                                removePlatform('telegram');
+                                removePlatform(workingConfig, 'telegram');
                                 console.log(`  ${C.yellow}Telegram disabled.${C.reset} Credentials kept.\n`);
                                 break;
                             case 'back':
@@ -590,27 +992,40 @@ export async function setupAction(): Promise<void> {
                     }
                     break;
                 case 'workspace':
-                    await runWorkspaceSetup(rl);
+                    rl.pause();
+                    renderSetupSubMenu(envFileStatus, 'Workspace Directory', wsLabel);
+                    const workspaceAction = await workspaceSubMenu();
+                    rl.resume();
+                    if (workspaceAction === 'reconfigure') {
+                        await runWorkspaceSetup(rl, envFileStatus, wsLabel, workingConfig);
+                    }
+                    break;
+                case 'antigravity':
+                    await runAntigravitySetup(rl, envFileStatus, workingConfig);
                     break;
                 case 'done': {
-                    const finalConfig = ConfigLoader.readPersisted();
-                    const platforms = finalConfig.platforms ?? [];
+                    const platforms = workingConfig.platforms ?? [];
 
                     if (platforms.length === 0) {
                         errMsg('No platforms enabled yet. Please enable at least one platform.');
                         break;
                     }
 
+                    savePersistedConfig(workingConfig);
                     const configPath = ConfigLoader.getConfigFilePath();
                     console.log(`\n  ${C.green}Setup complete!${C.reset} Platforms: ${platforms.join(', ')}\n`);
                     console.log(`  ${C.dim}Saved to${C.reset} ${configPath}\n`);
+                    if (envFileStatus) {
+                        console.log(`  ${C.dim}Detected .env at${C.reset} ${envFileStatus}\n`);
+                        console.log(`  ${C.dim}Values shown in setup may come from .env, but setup saves to config.json.${C.reset}\n`);
+                    }
 
-                    if (platforms.includes('discord') && finalConfig.clientId) {
-                        const inviteUrl = buildInviteUrl(finalConfig.clientId);
+                    if (platforms.includes('discord') && workingConfig.clientId) {
+                        const inviteUrl = buildInviteUrl(workingConfig.clientId);
                         console.log(`  ${C.cyan}Discord:${C.reset}`);
                         console.log(`  ${C.bold}1.${C.reset} ${C.yellow}Verify Privileged Gateway Intents are enabled${C.reset} in the Bot tab:`);
                         console.log(`     ${C.dim}Required: PRESENCE INTENT, SERVER MEMBERS INTENT, MESSAGE CONTENT INTENT${C.reset}`);
-                        console.log(`     https://discord.com/developers/applications/${finalConfig.clientId}/bot\n`);
+                        console.log(`     https://discord.com/developers/applications/${workingConfig.clientId}/bot\n`);
                         console.log(`  ${C.bold}2.${C.reset} Add the bot to your server:`);
                         console.log(`     ${inviteUrl}\n`);
                     }
@@ -628,6 +1043,8 @@ export async function setupAction(): Promise<void> {
 
                     return;
                 }
+                case 'cancel':
+                    return;
             }
         }
     } finally {

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1,3 +1,5 @@
+import { SESSION_SELECT_ID } from '../ui/sessionPickerUi';
+import { handleTelegramJoinSelect } from './telegramJoinCommand';
 import { t } from "../utils/i18n";
 import { logger } from '../utils/logger';
 import type { LogLevel } from '../utils/logger';
@@ -10,11 +12,13 @@ import {
     StringSelectMenuBuilder, MessageFlags,
 } from 'discord.js';
 import Database from 'better-sqlite3';
+import fs from 'fs';
 
 import { wrapDiscordChannel } from '../platform/discord/wrappers';
 import type { PlatformType } from '../platform/types';
 import { loadConfig, resolveResponseDeliveryMode } from '../utils/config';
 import type { ExtractionMode } from '../utils/config';
+import type { AntigravityAccountConfig } from '../utils/configLoader';
 import { parseMessageContent } from '../commands/messageParser';
 import { SlashCommandHandler } from '../commands/slashCommandHandler';
 import { registerSlashCommands } from '../commands/registerSlashCommands';
@@ -23,7 +27,9 @@ import { ModeService, AVAILABLE_MODES, MODE_DISPLAY_NAMES, MODE_DESCRIPTIONS, MO
 import { ModelService } from '../services/modelService';
 import { applyDefaultModel } from '../services/defaultModelApplicator';
 import { TemplateRepository } from '../database/templateRepository';
+import { AccountPreferenceRepository } from '../database/accountPreferenceRepository';
 import { WorkspaceBindingRepository } from '../database/workspaceBindingRepository';
+import { ChannelPreferenceRepository } from '../database/channelPreferenceRepository';
 import { ChatSessionRepository } from '../database/chatSessionRepository';
 import { WorkspaceService } from '../services/workspaceService';
 import {
@@ -46,7 +52,7 @@ import { isSessionSelectId } from '../ui/sessionPickerUi';
 // CDP integration services
 import { CdpService } from '../services/cdpService';
 import { ChatSessionService } from '../services/chatSessionService';
-import { ResponseMonitor, RESPONSE_SELECTORS } from '../services/responseMonitor';
+import { ResponseMonitor, RESPONSE_SELECTORS, captureResponseMonitorBaseline } from '../services/responseMonitor';
 import { ensureAntigravityRunning } from '../services/antigravityLauncher';
 import { getAntigravityCdpHint } from '../utils/pathUtils';
 import { AutoAcceptService } from '../services/autoAcceptService';
@@ -82,12 +88,23 @@ import { sendModeUI } from '../ui/modeUi';
 import { sendModelsUI, buildModelsUI } from '../ui/modelsUi';
 import { sendTemplateUI } from '../ui/templateUi';
 import { sendAutoAcceptUI } from '../ui/autoAcceptUi';
+import { sendAccountUI } from '../ui/accountUi';
 import { sendOutputUI, OUTPUT_BTN_EMBED, OUTPUT_BTN_PLAIN } from '../ui/outputUi';
 import { handleScreenshot } from '../ui/screenshotUi';
 import { UserPreferenceRepository, OutputFormat } from '../database/userPreferenceRepository';
+import { inferParentScopeChannelId, listAccountNames, resolveScopedAccountName } from '../utils/accountUtils';
 import { formatAsPlainText, splitPlainText } from '../utils/plainTextFormatter';
 import { createInteractionCreateHandler } from '../events/interactionCreateHandler';
 import { createMessageCreateHandler } from '../events/messageCreateHandler';
+import {
+    findTrajectoryEntriesByTitle,
+    findLatestTrajectoryEntryByTitle,
+    transferConversationByConversationId,
+    transferConversationByTitle,
+    waitForConversationPersistence,
+    waitForConversationPersistenceByConversationId,
+} from '../services/conversationTransferService';
+import { quitAntigravityProfile } from '../services/antigravityProcessService';
 
 // Telegram platform support
 import { Bot, InputFile } from 'grammy';
@@ -106,6 +123,17 @@ import { createModelButtonAction } from '../handlers/modelButtonAction';
 import { createAutoAcceptButtonAction } from '../handlers/autoAcceptButtonAction';
 import { createTemplateButtonAction } from '../handlers/templateButtonAction';
 import { createModeSelectAction } from '../handlers/modeSelectAction';
+import { createAccountSelectAction } from '../handlers/accountSelectAction';
+import { selectTelegramStartupChatId } from './telegramStartupTarget';
+
+function normalizeStartupChannelName(name: string): string {
+    return name.trim().replace(/^#/, '').toLowerCase();
+}
+
+function isPreferredDiscordStartupChannel(name: string): boolean {
+    const normalized = normalizeStartupChannelName(name);
+    return normalized === 'general' || normalized === '常规';
+}
 
 // =============================================================================
 // Embed color palette (color-coded by phase)
@@ -206,6 +234,11 @@ async function sendPromptToAntigravity(
     const enqueueResponse = createSerialTaskQueueForTest('response', monitorTraceId);
     const enqueueActivity = createSerialTaskQueueForTest('activity', monitorTraceId);
 
+    const logDeliveryError = (scope: string, error: unknown): void => {
+        const messageText = error instanceof Error ? error.message : String(error);
+        logger.warn(`[DiscordDelivery:${monitorTraceId}] ${scope} failed: ${messageText}`);
+    };
+
     const sendEmbed = (
         title: string,
         description: string,
@@ -218,7 +251,9 @@ async function sendPromptToAntigravity(
         if (outputFormat === 'plain') {
             const chunks = formatAsPlainText({ title, description, fields, footerText });
             for (const chunk of chunks) {
-                await channel.send({ content: chunk }).catch(() => { });
+                await channel.send({ content: chunk }).catch((error: unknown) => {
+                    logDeliveryError('sendEmbed/plain/send', error);
+                });
             }
             return;
         }
@@ -234,7 +269,9 @@ async function sendPromptToAntigravity(
         if (footerText) {
             embed.setFooter({ text: footerText });
         }
-        await channel.send({ embeds: [embed] }).catch(() => { });
+        await channel.send({ embeds: [embed] }).catch((error: unknown) => {
+            logDeliveryError('sendEmbed/embed/send', error);
+        });
     }, 'send-embed');
 
     const shouldTryGeneratedImages = (inputPrompt: string, responseText: string): boolean => {
@@ -266,7 +303,9 @@ async function sendPromptToAntigravity(
             await channel.send({
                 content: t(`🖼️ Detected generated images (${files.length})`),
                 files,
-            }).catch(() => { });
+            }).catch((error: unknown) => {
+                logDeliveryError('sendGeneratedImages/send', error);
+            });
         }, 'send-generated-images');
     };
 
@@ -357,7 +396,9 @@ async function sendPromptToAntigravity(
     // Apply default model preference on CDP connect
     const defaultModelResult = await applyDefaultModel(cdp, modelService);
     if (defaultModelResult.stale && defaultModelResult.staleMessage && channel) {
-        await channel.send(defaultModelResult.staleMessage).catch(() => {});
+        await channel.send(defaultModelResult.staleMessage).catch((error: unknown) => {
+            logDeliveryError('defaultModelResult/send', error);
+        });
     }
 
     const localMode = modeService.getCurrentMode();
@@ -438,11 +479,18 @@ async function sendPromptToAntigravity(
 
             for (let i = 0; i < plainChunks.length; i++) {
                 if (!liveResponseMessages[i]) {
-                    liveResponseMessages[i] = await channel.send({ content: plainChunks[i] }).catch(() => null);
+                    liveResponseMessages[i] = await channel.send({ content: plainChunks[i] }).catch((error: unknown) => {
+                        logDeliveryError('liveResponse/plain/send', error);
+                        return null;
+                    });
                     continue;
                 }
-                await liveResponseMessages[i].edit({ content: plainChunks[i] }).catch(async () => {
-                    liveResponseMessages[i] = await channel.send({ content: plainChunks[i] }).catch(() => null);
+                await liveResponseMessages[i].edit({ content: plainChunks[i] }).catch(async (error: unknown) => {
+                    logDeliveryError('liveResponse/plain/edit', error);
+                    liveResponseMessages[i] = await channel.send({ content: plainChunks[i] }).catch((sendError: unknown) => {
+                        logDeliveryError('liveResponse/plain/resend', sendError);
+                        return null;
+                    });
                 });
             }
             while (liveResponseMessages.length > plainChunks.length) {
@@ -469,12 +517,19 @@ async function sendPromptToAntigravity(
                 .setTimestamp();
 
             if (!liveResponseMessages[i]) {
-                liveResponseMessages[i] = await channel.send({ embeds: [embed] }).catch(() => null);
+                liveResponseMessages[i] = await channel.send({ embeds: [embed] }).catch((error: unknown) => {
+                    logDeliveryError('liveResponse/embed/send', error);
+                    return null;
+                });
                 continue;
             }
 
-            await liveResponseMessages[i].edit({ embeds: [embed] }).catch(async () => {
-                liveResponseMessages[i] = await channel.send({ embeds: [embed] }).catch(() => null);
+            await liveResponseMessages[i].edit({ embeds: [embed] }).catch(async (error: unknown) => {
+                logDeliveryError('liveResponse/embed/edit', error);
+                liveResponseMessages[i] = await channel.send({ embeds: [embed] }).catch((sendError: unknown) => {
+                    logDeliveryError('liveResponse/embed/resend', sendError);
+                    return null;
+                });
             });
         }
 
@@ -511,11 +566,18 @@ async function sendPromptToAntigravity(
 
             for (let i = 0; i < plainChunks.length; i++) {
                 if (!liveActivityMessages[i]) {
-                    liveActivityMessages[i] = await channel.send({ content: plainChunks[i] }).catch(() => null);
+                    liveActivityMessages[i] = await channel.send({ content: plainChunks[i] }).catch((error: unknown) => {
+                        logDeliveryError('liveActivity/plain/send', error);
+                        return null;
+                    });
                     continue;
                 }
-                await liveActivityMessages[i].edit({ content: plainChunks[i] }).catch(async () => {
-                    liveActivityMessages[i] = await channel.send({ content: plainChunks[i] }).catch(() => null);
+                await liveActivityMessages[i].edit({ content: plainChunks[i] }).catch(async (error: unknown) => {
+                    logDeliveryError('liveActivity/plain/edit', error);
+                    liveActivityMessages[i] = await channel.send({ content: plainChunks[i] }).catch((sendError: unknown) => {
+                        logDeliveryError('liveActivity/plain/resend', sendError);
+                        return null;
+                    });
                 });
             }
             while (liveActivityMessages.length > plainChunks.length) {
@@ -542,12 +604,19 @@ async function sendPromptToAntigravity(
                 .setTimestamp();
 
             if (!liveActivityMessages[i]) {
-                liveActivityMessages[i] = await channel.send({ embeds: [embed] }).catch(() => null);
+                liveActivityMessages[i] = await channel.send({ embeds: [embed] }).catch((error: unknown) => {
+                    logDeliveryError('liveActivity/embed/send', error);
+                    return null;
+                });
                 continue;
             }
 
-            await liveActivityMessages[i].edit({ embeds: [embed] }).catch(async () => {
-                liveActivityMessages[i] = await channel.send({ embeds: [embed] }).catch(() => null);
+            await liveActivityMessages[i].edit({ embeds: [embed] }).catch(async (error: unknown) => {
+                logDeliveryError('liveActivity/embed/edit', error);
+                liveActivityMessages[i] = await channel.send({ embeds: [embed] }).catch((sendError: unknown) => {
+                    logDeliveryError('liveActivity/embed/resend', sendError);
+                    return null;
+                });
             });
         }
 
@@ -560,6 +629,7 @@ async function sendPromptToAntigravity(
 
 
     try {
+        const baseline = await captureResponseMonitorBaseline(cdp);
 
         logger.prompt(prompt);
 
@@ -610,6 +680,8 @@ async function sendPromptToAntigravity(
             maxDurationMs: options?.responseTimeoutMs,
             stopGoneConfirmCount: 3,
             extractionMode: options?.extractionMode,
+            initialBaselineText: baseline.text,
+            initialSeenProcessLogKeys: baseline.processLogKeys,
 
             onPhaseChange: (_phase, _text) => {
                 // Phase transitions are already logged inside ResponseMonitor.setPhase()
@@ -698,7 +770,9 @@ async function sendPromptToAntigravity(
                         try {
                             const modelsPayload = await buildModelsUI(cdp, () => bridge.quota.fetchQuota());
                             if (modelsPayload && channel) {
-                                await channel.send({ ...modelsPayload });
+                                await channel.send({ ...modelsPayload }).catch((error: unknown) => {
+                                    logDeliveryError('quota/modelsPayload/send', error);
+                                });
                             }
                         } catch (e) {
                             logger.error('[Quota] Failed to send model selection UI:', e);
@@ -910,6 +984,8 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
     const modelService = new ModelService();
     const templateRepo = new TemplateRepository(db);
     const userPrefRepo = new UserPreferenceRepository(db);
+    const accountPrefRepo = new AccountPreferenceRepository(db);
+    const channelPrefRepo = new ChannelPreferenceRepository(db);
 
     // Eagerly load default model from DB (single-user bot optimization)
     try {
@@ -930,7 +1006,15 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
     await ensureAntigravityRunning();
 
     // Initialize CDP bridge (lazy connection: pool creation only)
-    const bridge = initCdpBridge(config.autoApproveFileEdits);
+    const accountPorts = Object.fromEntries(
+        (config.antigravityAccounts ?? []).map((account) => [account.name, account.cdpPort]),
+    );
+    const accountUserDataDirs = Object.fromEntries(
+        (config.antigravityAccounts ?? [])
+            .filter((account) => typeof account.userDataDir === 'string' && account.userDataDir.trim().length > 0)
+            .map((account) => [account.name, account.userDataDir!.trim()]),
+    );
+    const bridge = initCdpBridge(config.autoApproveFileEdits, accountPorts, accountUserDataDirs);
 
     // Initialize CDP-dependent services (constructor CDP dependency removed)
     const chatSessionService = new ChatSessionService();
@@ -943,8 +1027,63 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
     });
 
     // Initialize command handlers (joinHandler is created after client, see below)
-    const wsHandler = new WorkspaceCommandHandler(workspaceBindingRepo, chatSessionRepo, workspaceService, channelManager);
-    const chatHandler = new ChatCommandHandler(chatSessionService, chatSessionRepo, workspaceBindingRepo, channelManager, workspaceService, bridge.pool);
+    const wsHandler = new WorkspaceCommandHandler(
+        workspaceBindingRepo,
+        chatSessionRepo,
+        workspaceService,
+        channelManager,
+        async (workspaceName, newChannelId, sourceChannelId, userId) => {
+            const workspacePath = workspaceService.getWorkspacePath(workspaceName);
+            const selectedAccount = resolveScopedAccountName({
+                channelId: sourceChannelId,
+                userId,
+                sessionAccountName: chatSessionRepo.findByChannelId(sourceChannelId)?.activeAccountName ?? null,
+                parentChannelId: null,
+                selectedAccountByChannel: bridge.selectedAccountByChannel,
+                channelPrefRepo,
+                accountPrefRepo,
+                accounts: config.antigravityAccounts,
+            });
+
+            chatSessionRepo.setActiveAccountName(newChannelId, selectedAccount);
+            bridge.selectedAccountByChannel?.set(newChannelId, selectedAccount);
+            bridge.pool.setPreferredAccountForWorkspace(workspacePath, selectedAccount);
+
+            const cdp = new CdpService({
+                accountName: selectedAccount,
+                accountPorts,
+                accountUserDataDirs,
+                cdpCallTimeout: 15000,
+                maxReconnectAttempts: 0,
+            });
+
+            try {
+                await cdp.openWorkspace(workspacePath);
+            } finally {
+                await cdp.disconnect().catch(() => {});
+            }
+
+            await bridge.pool.getOrConnect(workspacePath, { name: selectedAccount });
+        },
+    );
+    const chatHandler = new ChatCommandHandler(
+        chatSessionService,
+        chatSessionRepo,
+        workspaceBindingRepo,
+        channelManager,
+        workspaceService,
+        bridge.pool,
+        (channelId, userId) => resolveScopedAccountName({
+            channelId,
+            userId,
+            sessionAccountName: chatSessionRepo.findByChannelId(channelId)?.activeAccountName ?? null,
+            parentChannelId: null,
+            selectedAccountByChannel: bridge.selectedAccountByChannel,
+            channelPrefRepo,
+            accountPrefRepo,
+            accounts: config.antigravityAccounts,
+        }),
+    );
     const cleanupHandler = new CleanupCommandHandler(chatSessionRepo, workspaceBindingRepo);
 
     const slashCommandHandler = new SlashCommandHandler(templateRepo);
@@ -967,7 +1106,27 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         ]
     });
 
-    const joinHandler = new JoinCommandHandler(chatSessionService, chatSessionRepo, workspaceBindingRepo, channelManager, bridge.pool, workspaceService, client, config.extractionMode, config.responseTimeoutMs);
+    const joinHandler = new JoinCommandHandler(
+        chatSessionService,
+        chatSessionRepo,
+        workspaceBindingRepo,
+        channelManager,
+        bridge.pool,
+        workspaceService,
+        client,
+        config.extractionMode,
+        config.responseTimeoutMs,
+        (channelId, userId) => resolveScopedAccountName({
+            channelId,
+            userId,
+            sessionAccountName: chatSessionRepo.findByChannelId(channelId)?.activeAccountName ?? null,
+            parentChannelId: null,
+            selectedAccountByChannel: bridge.selectedAccountByChannel,
+            channelPrefRepo,
+            accountPrefRepo,
+            accounts: config.antigravityAccounts,
+        }),
+    );
 
     client.once(Events.ClientReady, async (readyClient) => {
         logger.info(`Ready! Logged in as ${readyClient.user.tag} | extractionMode=${config.extractionMode}`);
@@ -1007,12 +1166,17 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                 .setFooter({ text: `Started at ${new Date().toLocaleString()}` })
                 .setTimestamp();
 
-            // Send to the first available text channel in the guild
+            // Prefer the guild's general text channel, then fall back to the first sendable text channel.
             const guild = readyClient.guilds.cache.first();
             if (guild) {
-                const channel = guild.channels.cache.find(
-                    (ch) => ch.isTextBased() && !ch.isVoiceBased() && ch.permissionsFor(readyClient.user)?.has('SendMessages'),
+                const sendableTextChannels = guild.channels.cache.filter(
+                    (ch) =>
+                        ch.isTextBased()
+                        && !ch.isVoiceBased()
+                        && ch.permissionsFor(readyClient.user)?.has('SendMessages'),
                 );
+                const channel = sendableTextChannels.find((ch) => isPreferredDiscordStartupChannel(ch.name))
+                    ?? sendableTextChannels.first();
                 if (channel && channel.isTextBased()) {
                     await channel.send({ embeds: [dashboardEmbed] });
                     logger.info('Startup dashboard embed sent.');
@@ -1044,6 +1208,11 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         parseRunCommandCustomId,
         joinHandler,
         userPrefRepo,
+        accountPrefRepo,
+        channelPrefRepo,
+        chatSessionRepo,
+        chatSessionService,
+        antigravityAccounts: config.antigravityAccounts,
         handleSlashInteraction: async (
             interaction,
             handler,
@@ -1055,6 +1224,9 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             modelServiceArg,
             autoAcceptServiceArg,
             clientArg,
+            accountPrefRepoArg,
+            channelPrefRepoArg,
+            antigravityAccountsArg,
         ) => handleSlashInteraction(
             interaction,
             handler,
@@ -1062,6 +1234,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             wsHandlerArg,
             chatHandlerArg,
             cleanupHandlerArg,
+            chatSessionService,
             modeServiceArg,
             modelServiceArg,
             autoAcceptServiceArg,
@@ -1070,6 +1243,10 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             templateRepo,
             joinHandler,
             userPrefRepo,
+            accountPrefRepoArg,
+            channelPrefRepoArg,
+            antigravityAccountsArg,
+            chatSessionRepo,
         ),
         handleTemplateUse: async (interaction, templateId) => {
             const template = templateRepo.findById(templateId);
@@ -1088,7 +1265,22 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             let cdp: CdpService | null = null;
             if (workspacePath) {
                 try {
-                    cdp = await bridge.pool.getOrConnect(workspacePath);
+                    const selectedAccount = resolveScopedAccountName({
+                        channelId,
+                        userId: interaction.user.id,
+                        sessionAccountName: chatSessionRepo.findByChannelId(channelId)?.activeAccountName ?? null,
+                        parentChannelId: inferParentScopeChannelId(
+                            channelId,
+                            (interaction.channel as any)?.parentId ?? null,
+                        ),
+                        selectedAccountByChannel: bridge.selectedAccountByChannel,
+                        channelPrefRepo,
+                        accountPrefRepo,
+                        accounts: config.antigravityAccounts,
+                    });
+                    bridge.selectedAccountByChannel?.set(channelId, selectedAccount);
+
+                    cdp = await bridge.pool.getOrConnect(workspacePath, { name: selectedAccount });
                     const projectName = bridge.pool.extractProjectName(workspacePath);
                     bridge.lastActiveWorkspace = projectName;
                     const platformCh = wrapDiscordChannel(interaction.channel as any);
@@ -1098,10 +1290,10 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                     if (session?.displayName) {
                         registerApprovalSessionChannel(bridge, projectName, session.displayName, platformCh);
                     }
-                    ensureApprovalDetector(bridge, cdp, projectName);
-                    ensureErrorPopupDetector(bridge, cdp, projectName);
-                    ensurePlanningDetector(bridge, cdp, projectName);
-                    ensureRunCommandDetector(bridge, cdp, projectName);
+                    ensureApprovalDetector(bridge, cdp, projectName, selectedAccount);
+                    ensureErrorPopupDetector(bridge, cdp, projectName, selectedAccount);
+                    ensurePlanningDetector(bridge, cdp, projectName, selectedAccount);
+                    ensureRunCommandDetector(bridge, cdp, projectName, selectedAccount);
                 } catch (e: any) {
                     await interaction.followUp({
                         content: `Failed to connect to workspace: ${e.message}`,
@@ -1110,7 +1302,22 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                     return;
                 }
             } else {
-                cdp = getCurrentCdp(bridge);
+                const selectedAccount = resolveScopedAccountName({
+                    channelId,
+                    userId: interaction.user.id,
+                    sessionAccountName: chatSessionRepo.findByChannelId(channelId)?.activeAccountName ?? null,
+                    parentChannelId: inferParentScopeChannelId(
+                        channelId,
+                        (interaction.channel as any)?.parentId ?? null,
+                    ),
+                    selectedAccountByChannel: bridge.selectedAccountByChannel,
+                    channelPrefRepo,
+                    accountPrefRepo,
+                    accounts: config.antigravityAccounts,
+                });
+                cdp = bridge.lastActiveWorkspace
+                    ? bridge.pool.getConnected(bridge.lastActiveWorkspace, selectedAccount)
+                    : null;
             }
 
             if (!cdp) {
@@ -1176,6 +1383,9 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         autoRenameChannel,
         handleScreenshot,
         userPrefRepo,
+        accountPrefRepo,
+        channelPrefRepo,
+        antigravityAccounts: config.antigravityAccounts,
     }));
 
     await client.login(discordToken);
@@ -1221,22 +1431,55 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                 botApi: telegramBot.api as any,
                 chatSessionService,
                 responseTimeoutMs: config.responseTimeoutMs,
+                accountPrefRepo,
+                channelPrefRepo,
+                antigravityAccounts: config.antigravityAccounts,
             });
 
             // Compose select handlers: project select + mode select
             const projectSelectHandler = createTelegramSelectHandler({
+                botApi: telegramBot.api as any,
+                bridge,
                 workspaceService,
                 telegramBindingRepo,
             });
             const modeSelectAction = createModeSelectAction({ bridge, modeService });
+            const accountSelectAction = createAccountSelectAction({
+                bridge,
+                accountPrefRepo,
+                channelPrefRepo,
+                chatSessionRepo,
+                antigravityAccounts: config.antigravityAccounts,
+                getWorkspacePathForChannel: (channelId: string) => {
+                    const binding = telegramBindingRepo.findByChatId(channelId);
+                    if (!binding) return null;
+                    return workspaceService
+                        ? workspaceService.getWorkspacePath(binding.workspacePath)
+                        : binding.workspacePath;
+                },
+            });
             const telegramSelectHandler = createPlatformSelectHandler({
                 actions: [
                     modeSelectAction,
+                    accountSelectAction,
                 ],
             });
             // Composite handler that routes to the right handler
             const compositeSelectHandler = async (interaction: import('../platform/types').PlatformSelectInteraction) => {
-                if (interaction.customId === 'mode_select') {
+                if (interaction.customId === SESSION_SELECT_ID) {
+                    await handleTelegramJoinSelect({
+                        bridge,
+                        botApi: telegramBot.api as any,
+                        telegramBindingRepo,
+                        workspaceService,
+                        chatSessionService,
+                        accountPrefRepo,
+                        channelPrefRepo,
+                        antigravityAccounts: config.antigravityAccounts,
+                    }, interaction);
+                    return;
+                }
+                if (interaction.customId === 'mode_select' || interaction.customId === 'account_select') {
                     await telegramSelectHandler(interaction);
                     return;
                 }
@@ -1256,7 +1499,48 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                     createPlanningButtonAction({ bridge }),
                     createErrorPopupButtonAction({ bridge }),
                     createRunCommandButtonAction({ bridge }),
-                    createModelButtonAction({ bridge, fetchQuota: () => bridge.quota.fetchQuota(), modelService, userPrefRepo }),
+                    createModelButtonAction({
+                        bridge,
+                        fetchQuota: () => bridge.quota.fetchQuota(),
+                        modelService,
+                        userPrefRepo,
+                        ensureSessionActivated: async (channelId, userId, cdp) => {
+                            const savedTitle = chatSessionRepo.findByChannelId(channelId)?.displayName?.trim() || '';
+                            if (!savedTitle || savedTitle === t('(Untitled)')) {
+                                return { ok: true };
+                            }
+
+                            const current = await chatSessionService.getCurrentSessionInfo(cdp);
+                            if (current.title.trim() === savedTitle) {
+                                return { ok: true };
+                            }
+
+                            logger.info(
+                                `[ModelCommand] source=button channel=${channelId} user=${userId} ` +
+                                `restoringSession target="${savedTitle}" current="${current.title.trim() || '(unknown)'}"`,
+                            );
+                            const activation = await chatSessionService.activateSessionByTitle(cdp, savedTitle, {
+                                maxWaitMs: 8000,
+                                retryIntervalMs: 300,
+                                allowVisibilityWarmupMs: 1000,
+                            });
+                            if (!activation.ok) {
+                                return {
+                                    ok: false as const,
+                                    error: `Failed to activate saved session "${savedTitle}" before model action: ${activation.error || 'unknown'}`,
+                                };
+                            }
+
+                            const refresh = await chatSessionService.refreshSessionViewIfStuck(cdp, savedTitle);
+                            if (!refresh.ok) {
+                                logger.warn(
+                                    `[ModelCommand] source=button channel=${channelId} user=${userId} ` +
+                                    `sessionRefreshWarning target="${savedTitle}" error="${refresh.error || 'unknown'}"`,
+                                );
+                            }
+                            return { ok: true as const };
+                        },
+                    }),
                     createAutoAcceptButtonAction({ autoAcceptService: bridge.autoAccept }),
                     createTemplateButtonAction({ bridge, templateRepo }),
                 ],
@@ -1279,11 +1563,15 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                 { command: 'model', description: 'Switch LLM model' },
                 { command: 'screenshot', description: 'Capture Antigravity screenshot' },
                 { command: 'autoaccept', description: 'Toggle auto-accept mode' },
+                { command: 'account', description: 'Switch Antigravity account' },
+                { command: 'project_reopen', description: 'Reopen bound project in account' },
                 { command: 'template', description: 'List prompt templates' },
                 { command: 'template_add', description: 'Add a prompt template' },
                 { command: 'template_delete', description: 'Delete a prompt template' },
                 { command: 'project_create', description: 'Create a new workspace' },
                 { command: 'new', description: 'Start a new chat session' },
+                { command: 'join', description: 'Take over an existing session' },
+                { command: 'mirror', description: 'Toggle PC-to-Telegram message mirroring' },
                 { command: 'logs', description: 'Show recent log entries' },
                 { command: 'stop', description: 'Interrupt active LLM generation' },
                 { command: 'help', description: 'Show available commands' },
@@ -1297,7 +1585,8 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
 
             logger.info(`Telegram bot started: @${botInfo.username} (${config.telegramAllowedUserIds?.length ?? 0} allowed users)`);
 
-            // Send startup message to all bound Telegram chats
+            // Send startup message to one Telegram target:
+            // prefer a group named "general", otherwise the first private chat.
             const bindings = telegramBindingRepo.findAll();
             if (bindings.length > 0) {
                 const os = await import('os');
@@ -1340,14 +1629,14 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                     }
                 };
 
-                const results = await Promise.allSettled(
-                    bindings.map((binding) => sendWithRetry(binding.chatId, startupText)),
-                );
-                const failed = results.filter((r) => r.status === 'rejected');
-                if (failed.length > 0) {
-                    logger.warn(`[Telegram] Startup message failed for ${failed.length}/${bindings.length} chat(s) after retries: ${(failed[0] as PromiseRejectedResult).reason?.message ?? 'unknown error'}`);
-                } else {
-                    logger.info(`Telegram startup message sent to ${bindings.length} bound chat(s).`);
+                const targetChatId = await selectTelegramStartupChatId(telegramBot.api, bindings);
+                if (targetChatId) {
+                    try {
+                        await sendWithRetry(targetChatId, startupText);
+                        logger.info(`Telegram startup message sent to chat ${targetChatId}.`);
+                    } catch (error: any) {
+                        logger.warn(`[Telegram] Startup message failed for chat ${targetChatId} after retries: ${error?.message ?? 'unknown error'}`);
+                    }
                 }
             }
         } catch (e: unknown) {
@@ -1386,13 +1675,14 @@ async function autoRenameChannel(
 /**
  * Handle Discord Interactions API slash commands
  */
-async function handleSlashInteraction(
+export async function handleSlashInteraction(
     interaction: ChatInputCommandInteraction,
     handler: SlashCommandHandler,
     bridge: CdpBridge,
     wsHandler: WorkspaceCommandHandler,
     chatHandler: ChatCommandHandler,
     cleanupHandler: CleanupCommandHandler,
+    chatSessionService: ChatSessionService,
     modeService: ModeService,
     modelService: ModelService,
     autoAcceptService: AutoAcceptService,
@@ -1401,8 +1691,98 @@ async function handleSlashInteraction(
     templateRepo: TemplateRepository,
     joinHandler?: JoinCommandHandler,
     userPrefRepo?: UserPreferenceRepository,
+    accountPrefRepo?: AccountPreferenceRepository,
+    channelPrefRepo?: ChannelPreferenceRepository,
+    antigravityAccounts: AntigravityAccountConfig[] = [{ name: 'default', cdpPort: 9222 }],
+    chatSessionRepo?: ChatSessionRepository,
 ): Promise<void> {
     const commandName = interaction.commandName;
+    const getAccountPort = (accountName: string): number | null => {
+        const match = antigravityAccounts.find((account) => account.name === accountName);
+        return match ? match.cdpPort : null;
+    };
+    const parentChannelId = inferParentScopeChannelId(
+        interaction.channelId,
+        (interaction.channel as any)?.parentId ?? null,
+    );
+    const getSessionAccountName = (): string | null =>
+        chatSessionRepo?.findByChannelId(interaction.channelId)?.activeAccountName ?? null;
+    const resolveSelectedAccount = (): string =>
+        resolveScopedAccountName({
+            channelId: interaction.channelId,
+            userId: interaction.user.id,
+            sessionAccountName: getSessionAccountName(),
+            parentChannelId,
+            selectedAccountByChannel: bridge.selectedAccountByChannel,
+            channelPrefRepo,
+            accountPrefRepo,
+            accounts: antigravityAccounts,
+        });
+    const getChannelWorkspacePath = (): string | undefined =>
+        wsHandler.getWorkspaceForChannel(interaction.channelId);
+    const getChannelCdp = (): CdpService | null =>
+        (() => {
+            const workspacePath = getChannelWorkspacePath();
+            if (workspacePath) {
+                const projectName = bridge.pool.extractProjectName(workspacePath);
+                return bridge.pool.getConnected(projectName, resolveSelectedAccount());
+            }
+
+            return bridge.lastActiveWorkspace
+                ? bridge.pool.getConnected(bridge.lastActiveWorkspace, resolveSelectedAccount())
+                : null;
+        })();
+    const ensureChannelCdp = async (): Promise<CdpService | null> => {
+        const existing = getChannelCdp();
+        if (existing) return existing;
+
+        const workspacePath = getChannelWorkspacePath();
+        if (!workspacePath) return null;
+
+        try {
+            return await bridge.pool.getOrConnect(workspacePath, { name: resolveSelectedAccount() });
+        } catch {
+            return null;
+        }
+    };
+    const ensureBoundSessionActive = async (
+        cdp: CdpService,
+    ): Promise<{ ok: true } | { ok: false; error: string }> => {
+        const savedTitle = chatSessionRepo?.findByChannelId(interaction.channelId)?.displayName?.trim() || '';
+        if (!savedTitle || savedTitle === t('(Untitled)')) {
+            return { ok: true };
+        }
+
+        const current = await chatSessionService.getCurrentSessionInfo(cdp);
+        if (current.title.trim() === savedTitle) {
+            return { ok: true };
+        }
+
+        logger.info(
+            `[ModelCommand] source=slash channel=${interaction.channelId} user=${interaction.user.id} ` +
+            `restoringSession target="${savedTitle}" current="${current.title.trim() || '(unknown)'}"`,
+        );
+        const activation = await chatSessionService.activateSessionByTitle(cdp, savedTitle, {
+            maxWaitMs: 8000,
+            retryIntervalMs: 300,
+            allowVisibilityWarmupMs: 1000,
+        });
+        if (!activation.ok) {
+            return {
+                ok: false,
+                error: `Failed to activate saved session "${savedTitle}" before model action: ${activation.error || 'unknown'}`,
+            };
+        }
+
+        const refresh = await chatSessionService.refreshSessionViewIfStuck(cdp, savedTitle);
+        if (!refresh.ok) {
+            logger.warn(
+                `[ModelCommand] source=slash channel=${interaction.channelId} user=${interaction.user.id} ` +
+                `sessionRefreshWarning target="${savedTitle}" error="${refresh.error || 'unknown'}"`,
+            );
+        }
+        return { ok: true };
+    };
 
     switch (commandName) {
         case 'help': {
@@ -1422,6 +1802,7 @@ async function handleSlashInteraction(
                 {
                     name: '⏹️ Control', value: [
                         '`/stop` — Interrupt active LLM generation',
+                        '`/project reopen` — Reopen the bound project in the selected account',
                         '`/screenshot` — Capture Antigravity screen',
                     ].join('\n')
                 },
@@ -1436,6 +1817,7 @@ async function handleSlashInteraction(
                     name: '📁 Projects', value: [
                         '`/project` — Display project list',
                         '`/project create <name>` — Create a new project',
+                        '`/project reopen` — Reopen the bound project in the selected account',
                     ].join('\n')
                 },
                 {
@@ -1449,6 +1831,7 @@ async function handleSlashInteraction(
                     name: '🔧 System', value: [
                         '`/status` — Display overall bot status',
                         '`/autoaccept` — Toggle auto-approve mode for approval dialogs via buttons',
+                        '`/account` — Show and switch Antigravity account',
                         '`/logs [lines] [level]` — View recent bot logs',
                         '`/cleanup [days]` — Clean up unused channels/categories',
                         '`/help` — Show this help',
@@ -1480,24 +1863,51 @@ async function handleSlashInteraction(
         }
 
         case 'mode': {
-            await sendModeUI(interaction, modeService, { getCurrentCdp: () => getCurrentCdp(bridge) });
+            await sendModeUI(interaction, modeService, { getCurrentCdp: () => getChannelCdp() });
             break;
         }
 
         case 'model': {
             const modelName = interaction.options.getString('name');
+            logger.info(
+                `[ModelCommand] source=slash channel=${interaction.channelId} user=${interaction.user.id} ` +
+                `requested=${modelName ? `"${modelName}"` : 'ui'}`,
+            );
             if (!modelName) {
-                await sendModelsUI(interaction, {
-                    getCurrentCdp: () => getCurrentCdp(bridge),
-                    fetchQuota: async () => bridge.quota.fetchQuota(),
-                });
-            } else {
-                const cdp = getCurrentCdp(bridge);
+                const cdp = await ensureChannelCdp();
                 if (!cdp) {
+                    logger.warn(`[ModelCommand] source=slash channel=${interaction.channelId} user=${interaction.user.id} cdp=unavailable`);
                     await interaction.editReply({ content: 'Not connected to CDP.' });
                     break;
                 }
+                const sessionReady = await ensureBoundSessionActive(cdp);
+                if (!sessionReady.ok) {
+                    await interaction.editReply({ content: sessionReady.error });
+                    break;
+                }
+                await sendModelsUI(interaction, {
+                    getCurrentCdp: () => cdp,
+                    fetchQuota: async () => bridge.quota.fetchQuota(),
+                });
+            } else {
+                const cdp = await ensureChannelCdp();
+                if (!cdp) {
+                    logger.warn(`[ModelCommand] source=slash channel=${interaction.channelId} user=${interaction.user.id} target="${modelName}" cdp=unavailable`);
+                    await interaction.editReply({ content: 'Not connected to CDP.' });
+                    break;
+                }
+                const sessionReady = await ensureBoundSessionActive(cdp);
+                if (!sessionReady.ok) {
+                    await interaction.editReply({ content: sessionReady.error });
+                    break;
+                }
                 const res = await cdp.setUiModel(modelName);
+                logger.info(
+                    `[ModelCommand] source=slash channel=${interaction.channelId} user=${interaction.user.id} ` +
+                    `target="${modelName}" ok=${res.ok} applied=${res.model ? `"${res.model}"` : 'null'} ` +
+                    `verified=${res.verified === true} alreadySelected=${res.alreadySelected === true} ` +
+                    `error=${res.error ? `"${res.error}"` : 'null'}`,
+                );
                 if (res.ok) {
                     await interaction.editReply({ content: `Model changed to **${res.model}**.` });
                 } else {
@@ -1541,10 +1951,11 @@ async function handleSlashInteraction(
         case 'status': {
             const activeNames = bridge.pool.getActiveWorkspaceNames();
             const currentModel = (() => {
-                const cdp = getCurrentCdp(bridge);
+                const cdp = getChannelCdp();
                 return cdp ? 'CDP Connected' : 'Disconnected';
             })();
             const currentMode = modeService.getCurrentMode();
+            const session = chatSessionRepo?.findByChannelId(interaction.channelId);
 
             const mirroringWorkspaces = activeNames.filter(
                 (name) => bridge.pool.getUserMessageDetector(name)?.isActive(),
@@ -1552,12 +1963,18 @@ async function handleSlashInteraction(
             const mirrorStatus = mirroringWorkspaces.length > 0
                 ? `📡 ON (${mirroringWorkspaces.join(', ')})`
                 : '⚪ OFF';
+            const currentAccount = resolveSelectedAccount();
+            const originalAccount = session?.originAccountName ?? '(unset)';
+            const conversationTitle = session?.displayName ?? '(New chat / no saved title)';
 
             const statusFields = [
                 { name: 'CDP Connection', value: activeNames.length > 0 ? `🟢 ${activeNames.length} project(s) connected` : '⚪ Disconnected', inline: true },
                 { name: 'Mode', value: MODE_DISPLAY_NAMES[currentMode] || currentMode, inline: true },
                 { name: 'Auto Approve', value: autoAcceptService.isEnabled() ? '🟢 ON' : '⚪ OFF', inline: true },
                 { name: 'Mirroring', value: mirrorStatus, inline: true },
+                { name: 'Active Account', value: currentAccount, inline: true },
+                { name: 'Original Account', value: originalAccount, inline: true },
+                { name: 'Conversation Title', value: conversationTitle, inline: false },
             ];
 
             let statusDescription = '';
@@ -1608,6 +2025,46 @@ async function handleSlashInteraction(
             break;
         }
 
+        case 'account': {
+            if (!accountPrefRepo) {
+                await interaction.editReply({ content: 'Account preference service not available.' });
+                break;
+            }
+
+            const requested = interaction.options.getString('name');
+            if (!requested) {
+                const current = resolveSelectedAccount();
+                const names = listAccountNames(antigravityAccounts);
+                await sendAccountUI(interaction, current, names);
+                break;
+            }
+
+            if (!listAccountNames(antigravityAccounts).includes(requested)) {
+                await interaction.editReply({ content: `⚠️ Unknown account: **${requested}**` });
+                break;
+            }
+
+            bridge.selectedAccountByChannel?.set(interaction.channelId, requested);
+            const currentSession = chatSessionRepo?.findByChannelId(interaction.channelId);
+            if (currentSession) {
+                chatSessionRepo?.setActiveAccountName(interaction.channelId, requested);
+            } else {
+                accountPrefRepo.setAccountName(interaction.user.id, requested);
+                channelPrefRepo?.setAccountName(interaction.channelId, requested);
+            }
+
+            const channelWorkspace = wsHandler.getWorkspaceForChannel(interaction.channelId);
+
+            logger.info(
+                `[AccountSwitch] source=slash channel=${interaction.channelId} user=${interaction.user.id} ` +
+                `account=${requested} port=${getAccountPort(requested) ?? 'unknown'} ` +
+                `workspace=${channelWorkspace ?? 'unbound'}`,
+            );
+
+            await interaction.editReply({ content: `✅ Switched session account to **${requested}**.` });
+            break;
+        }
+
         case 'output': {
             if (!userPrefRepo) {
                 await interaction.editReply({ content: 'Output preference service not available.' });
@@ -1629,12 +2086,12 @@ async function handleSlashInteraction(
         }
 
         case 'screenshot': {
-            await handleScreenshot(interaction, getCurrentCdp(bridge));
+            await handleScreenshot(interaction, getChannelCdp());
             break;
         }
 
         case 'stop': {
-            const cdp = getCurrentCdp(bridge);
+            const cdp = getChannelCdp();
             if (!cdp) {
                 await interaction.editReply({ content: '⚠️ Not connected to CDP. Please connect to a project first.' });
                 break;
@@ -1684,6 +2141,296 @@ async function handleSlashInteraction(
                     break;
                 }
                 await wsHandler.handleCreate(interaction, interaction.guild);
+            } else if (wsSub === 'account') {
+                const requested = interaction.options.getString('name');
+                const names = listAccountNames(antigravityAccounts);
+                const currentProjectAccount = channelPrefRepo?.getAccountName(interaction.channelId) ?? null;
+
+                if (!requested) {
+                    await interaction.editReply({
+                        content: `Project channel account: **${currentProjectAccount ?? 'unset'}**\nAvailable: ${names.join(', ')}`,
+                    });
+                    break;
+                }
+
+                if (!names.includes(requested)) {
+                    await interaction.editReply({ content: `⚠️ Unknown account: **${requested}**` });
+                    break;
+                }
+
+                channelPrefRepo?.setAccountName(interaction.channelId, requested);
+                bridge.selectedAccountByChannel?.set(interaction.channelId, requested);
+
+                const channelWorkspace = wsHandler.getWorkspaceForChannel(interaction.channelId);
+                logger.info(
+                    `[ProjectAccountSwitch] source=slash channel=${interaction.channelId} user=${interaction.user.id} ` +
+                    `account=${requested} port=${getAccountPort(requested) ?? 'unknown'} ` +
+                    `workspace=${channelWorkspace ?? 'unbound'}`,
+                );
+
+                await interaction.editReply({ content: `✅ Bound this project channel to account **${requested}**.` });
+                break;
+            } else if (wsSub === 'reopen') {
+                const workspacePath = wsHandler.getWorkspaceForChannel(interaction.channelId);
+                if (!workspacePath) {
+                    await interaction.editReply({
+                        content: '⚠️ No project is bound to this channel. Use `/project` first.',
+                    });
+                    break;
+                }
+
+                if (!fs.existsSync(workspacePath) || !fs.statSync(workspacePath).isDirectory()) {
+                    await interaction.editReply({
+                        content: `❌ Project folder does not exist: \`${workspacePath}\``,
+                    });
+                    break;
+                }
+
+                const requestedReopenAccount = interaction.options.getString('account');
+                const availableAccountNames = listAccountNames(antigravityAccounts);
+                if (requestedReopenAccount && !availableAccountNames.includes(requestedReopenAccount)) {
+                    await interaction.editReply({ content: `⚠️ Unknown account: **${requestedReopenAccount}**` });
+                    break;
+                }
+
+                const selectedAccount = requestedReopenAccount || resolveSelectedAccount();
+                const port = getAccountPort(selectedAccount);
+                const accountPorts = Object.fromEntries(
+                    antigravityAccounts.map((account) => [account.name, account.cdpPort]),
+                );
+                const accountUserDataDirs = Object.fromEntries(
+                    antigravityAccounts
+                        .filter((account) => typeof account.userDataDir === 'string' && account.userDataDir.trim().length > 0)
+                        .map((account) => [account.name, account.userDataDir!.trim()]),
+                );
+                const projectName = bridge.pool.extractProjectName(workspacePath);
+                const previousPreferredAccount = bridge.pool.getPreferredAccountForWorkspace(workspacePath);
+                const session = chatSessionRepo?.findByChannelId(interaction.channelId);
+                const savedConversationTitle = session?.displayName?.trim() || '';
+                const savedConversationId = session?.conversationId?.trim() || '';
+                const originAccountName = session?.originAccountName?.trim() || '';
+
+                logger.info(
+                    `[ProjectReopenCommand] channel=${interaction.channelId} user=${interaction.user.id} ` +
+                    `project=${projectName} account=${selectedAccount} ` +
+                    `port=${port ?? 'unknown'} workspacePath=${workspacePath}`,
+                );
+
+                try {
+                    const inspectWorkspaceRuntime = async (
+                        accountName: string,
+                    ): Promise<{ isOpen: boolean; isGenerating: boolean; sessionTitle: string; hasActiveChat: boolean }> => {
+                        const cdp = new CdpService({
+                            accountName,
+                            accountPorts,
+                            accountUserDataDirs,
+                            cdpCallTimeout: 15000,
+                            maxReconnectAttempts: 0,
+                        });
+
+                        try {
+                            const connected = await cdp.discoverAndConnectForWorkspace(workspacePath).catch(() => false);
+                            if (!connected) {
+                                return {
+                                    isOpen: false,
+                                    isGenerating: false,
+                                    sessionTitle: '',
+                                    hasActiveChat: false,
+                                };
+                            }
+
+                            const runtimeState = await cdp.inspectWorkspaceRuntimeState();
+                            return {
+                                isOpen: true,
+                                isGenerating: runtimeState.isGenerating,
+                                sessionTitle: runtimeState.sessionTitle,
+                                hasActiveChat: runtimeState.hasActiveChat,
+                            };
+                        } finally {
+                            await cdp.disconnect().catch(() => {});
+                        }
+                    };
+
+                    const quitAccountInstanceGracefully = async (
+                        accountName: string,
+                        role: 'origin' | 'target',
+                    ): Promise<void> => {
+                        const closed = await quitAntigravityProfile(accountName).catch(() => false);
+                        if (!closed) {
+                            throw new Error(
+                                `Could not quit the ${role} account **${accountName}** cleanly. ` +
+                                `Use Cmd+Q on that Antigravity instance, then rerun \`/project reopen\`.`,
+                            );
+                        }
+
+                        logger.info(
+                            `[ProjectReopenCommand] Quit ${role} Antigravity account before reopen for channel=${interaction.channelId} ` +
+                            `account=${accountName} project=${projectName} closed=${closed}`,
+                        );
+                    };
+
+                    const accountsToInspect = Array.from(
+                        new Set([
+                            selectedAccount,
+                            ...(savedConversationTitle && originAccountName && originAccountName !== selectedAccount
+                                ? [originAccountName]
+                                : []),
+                        ]),
+                    );
+                    const busySessions: string[] = [];
+                    for (const accountName of accountsToInspect) {
+                        const runtime = await inspectWorkspaceRuntime(accountName);
+                        if (!runtime.isOpen || !runtime.isGenerating) {
+                            continue;
+                        }
+
+                        const sessionTitle = runtime.hasActiveChat
+                            ? runtime.sessionTitle
+                            : (savedConversationTitle || '(Untitled)');
+                        const role = accountName === selectedAccount ? 'target' : 'origin';
+                        busySessions.push(`${role} account **${accountName}** is still running session **${sessionTitle}**`);
+                    }
+
+                    if (busySessions.length > 0) {
+                        throw new Error(
+                            `${busySessions.join(' and ')}. Use \`/stop\` in that session, close the workspace, then rerun \`/project reopen\`.`,
+                        );
+                    }
+
+                    if (
+                        savedConversationTitle
+                        && originAccountName
+                        && originAccountName !== selectedAccount
+                    ) {
+                        let transferResult;
+                        let resolvedConversationId = savedConversationId;
+
+                        await quitAccountInstanceGracefully(originAccountName, 'origin');
+
+                        if (resolvedConversationId) {
+                            await waitForConversationPersistenceByConversationId(originAccountName, resolvedConversationId, {
+                                timeoutMs: 20000,
+                                pollIntervalMs: 500,
+                            });
+                        } else {
+                            const persistedEntry = await waitForConversationPersistence(originAccountName, savedConversationTitle, {
+                                timeoutMs: 20000,
+                                pollIntervalMs: 500,
+                            });
+                            const latestEntry = findLatestTrajectoryEntryByTitle(originAccountName, savedConversationTitle);
+                            resolvedConversationId = latestEntry?.conversationId ?? persistedEntry.conversationId;
+
+                            if (resolvedConversationId && chatSessionRepo) {
+                                chatSessionRepo.setConversationId(interaction.channelId, resolvedConversationId);
+                            }
+                        }
+
+                        await quitAccountInstanceGracefully(selectedAccount, 'target');
+
+                        transferResult = resolvedConversationId
+                            ? transferConversationByConversationId(
+                                originAccountName,
+                                selectedAccount,
+                                resolvedConversationId,
+                            )
+                            : transferConversationByTitle(
+                                originAccountName,
+                                selectedAccount,
+                                savedConversationTitle,
+                            );
+                        logger.info(
+                            `[ProjectReopenCommand] Imported conversation for channel=${interaction.channelId} ` +
+                            `title="${savedConversationTitle}" sourceAccount=${originAccountName} ` +
+                            `targetAccount=${selectedAccount} conversationId=${transferResult.conversationId}`,
+                        );
+
+                        if (chatSessionRepo && transferResult.conversationId) {
+                            chatSessionRepo.setConversationId(interaction.channelId, transferResult.conversationId);
+                        }
+                    } else {
+                        await quitAccountInstanceGracefully(selectedAccount, 'target');
+                    }
+
+                    const cdp = new CdpService({
+                        accountName: selectedAccount,
+                        accountPorts,
+                        accountUserDataDirs,
+                        cdpCallTimeout: 15000,
+                        maxReconnectAttempts: 0,
+                    });
+
+                    try {
+                        await cdp.openWorkspace(workspacePath);
+
+                        if (savedConversationTitle) {
+                            const reopenSessionService = new ChatSessionService();
+                            const activationResult = await reopenSessionService.activateSessionByTitle(
+                                cdp,
+                                savedConversationTitle,
+                                {
+                                    maxWaitMs: 15000,
+                                    retryIntervalMs: 500,
+                                    allowVisibilityWarmupMs: 4000,
+                                },
+                            );
+
+                            if (!activationResult.ok) {
+                                throw new Error(
+                                    `Workspace reopened in account "${selectedAccount}", but failed to activate session ` +
+                                    `"${savedConversationTitle}" in Antigravity: ${activationResult.error || 'unknown error'}`,
+                                );
+                            }
+
+                            const reopenAgainResult = await reopenSessionService.recoverSessionViewWithNewConversationBounce(
+                                cdp,
+                                savedConversationTitle,
+                                {
+                                    maxAttempts: 4,
+                                    newChatDelayMs: 400,
+                                    reopenDelayMs: 1000,
+                                },
+                            );
+                            if (!reopenAgainResult.ok) {
+                                throw new Error(
+                                    `Workspace reopened in account "${selectedAccount}", but failed to stabilize session ` +
+                                    `"${savedConversationTitle}" after repeated new-conversation retries: ` +
+                                    `${reopenAgainResult.error || 'unknown error'}`,
+                                );
+                            }
+                        }
+                    } finally {
+                        await cdp.disconnect().catch(() => {});
+                    }
+
+                    bridge.selectedAccountByChannel?.set(interaction.channelId, selectedAccount);
+                    bridge.pool.setPreferredAccountForWorkspace(workspacePath, selectedAccount);
+
+                    if (chatSessionRepo && session) {
+                        chatSessionRepo.setActiveAccountName(interaction.channelId, selectedAccount);
+                        logger.info(
+                            `[ProjectReopenCommand] Updated session routing for channel=${interaction.channelId} ` +
+                            `project=${projectName} oldAccount=${session.activeAccountName ?? previousPreferredAccount ?? 'unknown'} ` +
+                            `newAccount=${selectedAccount} title="${savedConversationTitle || '(unset)'}"`,
+                        );
+                    }
+
+                    const finalOriginAccount = chatSessionRepo?.findByChannelId(interaction.channelId)?.originAccountName
+                        ?? session?.originAccountName
+                        ?? '(unset)';
+                    await interaction.editReply({
+                        content: [
+                            `✅ Reopened **${projectName}** in account **${selectedAccount}**${port ? ` (CDP ${port})` : ''}.`,
+                            `Active Account: **${selectedAccount}**`,
+                            `Origin Account: **${finalOriginAccount}**`,
+                            `Conversation Title: **${savedConversationTitle || '(New chat / no saved title)'}**`,
+                        ].join('\n'),
+                    });
+                } catch (error: any) {
+                    logger.error('[ProjectReopenCommand] Failed to reopen workspace:', error);
+                    await interaction.editReply({
+                        content: `❌ Failed to reopen project in account **${selectedAccount}**: ${error?.message || String(error)}`,
+                    });
+                }
             } else {
                 // /project list or /project (default)
                 await wsHandler.handleShow(interaction);

--- a/src/bot/telegramCommands.ts
+++ b/src/bot/telegramCommands.ts
@@ -1,3 +1,4 @@
+import { handleJoin, handleMirror } from './telegramJoinCommand';
 /**
  * Telegram command parser and handlers.
  *
@@ -33,15 +34,21 @@ import { buildModelsPayload } from '../ui/modelsUi';
 import { buildAutoAcceptPayload } from '../ui/autoAcceptUi';
 import { buildTemplatePayload } from '../ui/templateUi';
 import { buildScreenshotPayload } from '../ui/screenshotUi';
+import { buildAccountPayload } from '../ui/accountUi';
 import { logBuffer } from '../utils/logBuffer';
 import { escapeHtml } from '../platform/telegram/telegramFormatter';
 import { logger } from '../utils/logger';
+import { tryCreateTopicAndBind } from './telegramProjectCommand';
+import { listAccountNames, resolveScopedAccountName } from '../utils/accountUtils';
+import type { AccountPreferenceRepository } from '../database/accountPreferenceRepository';
+import type { ChannelPreferenceRepository } from '../database/channelPreferenceRepository';
+import type { AntigravityAccountConfig } from '../utils/configLoader';
 
 // ---------------------------------------------------------------------------
 // Known commands (used by both parser and /help output)
 // ---------------------------------------------------------------------------
 
-const KNOWN_COMMANDS = ['start', 'help', 'status', 'stop', 'ping', 'mode', 'model', 'screenshot', 'autoaccept', 'template', 'template_add', 'template_delete', 'project_create', 'logs', 'new'] as const;
+const KNOWN_COMMANDS = ['start', 'help', 'status', 'stop', 'ping', 'mode', 'model', 'screenshot', 'autoaccept', 'account', 'project_reopen', 'template', 'template_add', 'template_delete', 'project_create', 'logs', 'new', 'join', 'mirror'] as const;
 type KnownCommand = typeof KNOWN_COMMANDS[number];
 
 // ---------------------------------------------------------------------------
@@ -85,6 +92,7 @@ export function parseTelegramCommand(text: string): ParsedTelegramCommand | null
 
 export interface TelegramCommandDeps {
     readonly bridge: CdpBridge;
+    readonly botApi?: any;
     readonly modeService?: ModeService;
     readonly modelService?: ModelService;
     readonly telegramBindingRepo?: TelegramBindingRepository;
@@ -95,6 +103,9 @@ export interface TelegramCommandDeps {
     /** Shared map of active ResponseMonitors keyed by project name.
      *  Used by /stop to halt monitoring and prevent stale re-sends. */
     readonly activeMonitors?: Map<string, ResponseMonitor>;
+    readonly accountPrefRepo?: AccountPreferenceRepository;
+    readonly channelPrefRepo?: ChannelPreferenceRepository;
+    readonly antigravityAccounts?: AntigravityAccountConfig[];
 }
 
 // ---------------------------------------------------------------------------
@@ -141,6 +152,12 @@ export async function handleTelegramCommand(
         case 'autoaccept':
             await handleAutoAccept(deps, message, parsed.args);
             break;
+        case 'account':
+            await handleAccount(deps, message, parsed.args);
+            break;
+        case 'project_reopen':
+            await handleProjectReopen(deps, message);
+            break;
         case 'template':
             await handleTemplate(deps, message);
             break;
@@ -158,6 +175,12 @@ export async function handleTelegramCommand(
             break;
         case 'new':
             await handleNew(deps, message);
+            break;
+        case 'join':
+            await handleJoin(deps, message);
+            break;
+        case 'mirror':
+            await handleMirror(deps, message);
             break;
         default:
             // Should not happen — parser filters unknowns
@@ -195,11 +218,15 @@ async function handleHelp(message: PlatformMessage): Promise<void> {
         '/model — Switch LLM model',
         '/screenshot — Capture Antigravity screenshot',
         '/autoaccept — Toggle auto-accept mode',
+        '/account — Show and switch Antigravity account',
+        '/project_reopen — Reopen the bound project in the selected Antigravity account',
         '/template — List prompt templates',
         '/template_add — Add a prompt template',
         '/template_delete — Delete a prompt template',
         '/project_create — Create a new workspace',
         '/new — Start a new chat session',
+        '/join — Take over an existing Antigravity session',
+        '/mirror — Toggle PC-to-Telegram message mirroring',
         '/logs — Show recent log entries',
         '/stop — Interrupt active LLM generation',
         '/ping — Check bot latency',
@@ -351,6 +378,63 @@ async function handleAutoAccept(deps: TelegramCommandDeps, message: PlatformMess
     await message.reply(payload).catch(logger.error);
 }
 
+async function handleAccount(deps: TelegramCommandDeps, message: PlatformMessage, args: string): Promise<void> {
+    if (!deps.accountPrefRepo) {
+        await message.reply({ text: 'Account preference service not available.' }).catch(logger.error);
+        return;
+    }
+
+    const names = listAccountNames(deps.antigravityAccounts);
+    const chatId = message.channel.id;
+    const userId = message.author.id;
+
+    const applySelection = (selectedAccount: string): void => {
+        deps.accountPrefRepo?.setAccountName(userId, selectedAccount);
+        deps.channelPrefRepo?.setAccountName(chatId, selectedAccount);
+        deps.bridge.selectedAccountByChannel?.set(chatId, selectedAccount);
+
+        const channelBinding = deps.telegramBindingRepo?.findByChatId(chatId);
+        const workspacePath = channelBinding
+            ? (deps.workspaceService
+                ? deps.workspaceService.getWorkspacePath(channelBinding.workspacePath)
+                : channelBinding.workspacePath)
+            : null;
+
+        const selectedPort = deps.antigravityAccounts?.find((a) => a.name === selectedAccount)?.cdpPort;
+        logger.info(
+            `[AccountSwitch] source=telegram_command channel=${chatId} user=${userId} ` +
+            `account=${selectedAccount} port=${selectedPort ?? 'unknown'} ` +
+            `workspace=${workspacePath ?? 'unbound'}`,
+        );
+    };
+
+    const requested = args.trim();
+    if (requested) {
+        if (!names.includes(requested)) {
+            await message.reply({
+                text: `⚠️ Unknown account: <b>${escapeHtml(requested)}</b>\nAvailable: ${names.map(escapeHtml).join(', ')}`,
+            }).catch(logger.error);
+            return;
+        }
+
+        applySelection(requested);
+        await message.reply({ text: `✅ Switched account to <b>${escapeHtml(requested)}</b>.` }).catch(logger.error);
+        return;
+    }
+
+    const current = resolveScopedAccountName({
+        channelId: chatId,
+        userId,
+        selectedAccountByChannel: deps.bridge.selectedAccountByChannel,
+        channelPrefRepo: deps.channelPrefRepo,
+        accountPrefRepo: deps.accountPrefRepo,
+        accounts: deps.antigravityAccounts,
+    });
+
+    const payload = buildAccountPayload(current, names);
+    await message.reply(payload).catch(logger.error);
+}
+
 async function handleTemplate(deps: TelegramCommandDeps, message: PlatformMessage): Promise<void> {
     if (!deps.templateRepo) {
         await message.reply({ text: 'Template service not available.' }).catch(logger.error);
@@ -467,48 +551,62 @@ async function handleLogs(message: PlatformMessage, args: string): Promise<void>
 }
 
 async function handleNew(deps: TelegramCommandDeps, message: PlatformMessage): Promise<void> {
-    if (!deps.chatSessionService) {
-        await message.reply({ text: 'Chat session service not available.' }).catch(logger.error);
-        return;
-    }
+    const originalChannelId = message.channel.id;
+    const binding = deps.telegramBindingRepo?.findByChatIdWithParentFallback(originalChannelId);
 
-    // Resolve workspace binding for this chat
-    const chatId = message.channel.id;
-    const binding = deps.telegramBindingRepo?.findByChatId(chatId);
     if (!binding) {
-        await message.reply({
-            text: 'No project is linked to this chat. Use /project to bind a workspace first.',
-        }).catch(logger.error);
+        await message.reply({ text: '⚠️ No project is linked to this chat. Use /project first, or /project_reopen if this is a previously used session.' }).catch(logger.error);
         return;
     }
 
-    // Resolve workspace path and connect to CDP
-    let cdp;
-    try {
-        const workspacePath = deps.workspaceService
-            ? deps.workspaceService.getWorkspacePath(binding.workspacePath)
-            : binding.workspacePath;
-        cdp = await deps.bridge.pool.getOrConnect(workspacePath);
-    } catch (err: any) {
-        logger.error('[TelegramCommand:new] CDP connection failed:', err?.message || err);
-        await message.reply({ text: 'Failed to connect to Antigravity.' }).catch(logger.error);
-        return;
+    const resolvedWorkspacePath = deps.workspaceService
+        ? deps.workspaceService.getWorkspacePath(binding.workspacePath)
+        : binding.workspacePath;
+
+    let targetChannelId = originalChannelId;
+    if (deps.botApi && deps.bridge && deps.telegramBindingRepo) {
+        targetChannelId = await tryCreateTopicAndBind(
+            deps.botApi,
+            originalChannelId,
+            binding.workspacePath,
+            deps.telegramBindingRepo,
+            deps.bridge.pool
+        );
     }
 
-    // Start a new chat session
+    if (targetChannelId !== originalChannelId) {
+        await message.reply({ text: `✅ Created a new topic for the session.` }).catch(() => {});
+    }
+
+    const selectedAccount = resolveScopedAccountName({
+        channelId: originalChannelId,
+        userId: message.author.id,
+        selectedAccountByChannel: deps.bridge.selectedAccountByChannel,
+        channelPrefRepo: deps.channelPrefRepo,
+        accountPrefRepo: deps.accountPrefRepo,
+        accounts: deps.antigravityAccounts,
+    });
+
     try {
+        const cdp = await deps.bridge.pool.getOrConnect(resolvedWorkspacePath, { name: selectedAccount });
+
+        if (!deps.chatSessionService) {
+            await message.reply({ text: 'Chat session service not available.' }).catch(logger.error);
+            return;
+        }
+
         const result = await deps.chatSessionService.startNewChat(cdp);
         if (result.ok) {
-            await message.reply({ text: 'New chat session started.' }).catch(logger.error);
+            if (targetChannelId === originalChannelId) {
+                await message.reply({ text: '✅ New chat session started.' }).catch(logger.error);
+            }
         } else {
             logger.warn('[TelegramCommand:new] startNewChat failed:', result.error);
-            await message.reply({
-                text: `Failed to start new chat: ${escapeHtml(result.error || 'unknown error')}`,
-            }).catch(logger.error);
+            await message.reply({ text: `❌ Failed to start new chat: ${result.error}` }).catch(logger.error);
         }
     } catch (err: any) {
         logger.error('[TelegramCommand:new] startNewChat threw:', err?.message || err);
-        await message.reply({ text: 'Failed to start new chat.' }).catch(logger.error);
+        await message.reply({ text: '❌ Failed to connect to Antigravity. Is it running?' }).catch(logger.error);
     }
 }
 
@@ -527,5 +625,81 @@ async function sendFilePayload(message: PlatformMessage, payload: MessagePayload
     } catch (err: unknown) {
         logger.warn('[TelegramCommand:screenshot] File sending failed:', err instanceof Error ? err.message : err);
         await message.reply({ text: 'Screenshot captured but file sending failed.' }).catch(logger.error);
+    }
+}
+
+
+async function handleProjectReopen(deps: TelegramCommandDeps, message: PlatformMessage): Promise<void> {
+    const chatId = message.channel.id;
+    const channelBinding = deps.telegramBindingRepo?.findByChatIdWithParentFallback(chatId);
+    
+    if (!channelBinding) {
+        await message.reply({ text: '⚠️ No project is bound to this chat. Use /project first, or /project_reopen if this is a previously used session.' }).catch(logger.error);
+        return;
+    }
+
+    const workspacePath = deps.workspaceService
+        ? deps.workspaceService.getWorkspacePath(channelBinding.workspacePath)
+        : channelBinding.workspacePath;
+
+    if (!fs.existsSync(workspacePath) || !fs.statSync(workspacePath).isDirectory()) {
+        await message.reply({ text: `❌ Project folder does not exist: <code>${escapeHtml(workspacePath)}</code>` }).catch(logger.error);
+        return;
+    }
+
+    const selectedAccount = resolveScopedAccountName({
+        channelId: chatId,
+        userId: message.author.id,
+        selectedAccountByChannel: deps.bridge.selectedAccountByChannel,
+        channelPrefRepo: deps.channelPrefRepo,
+        accountPrefRepo: deps.accountPrefRepo,
+        accounts: deps.antigravityAccounts,
+    });
+    
+    const accountPorts = Object.fromEntries(
+        (deps.antigravityAccounts ?? []).map((account) => [account.name, account.cdpPort]),
+    );
+    const accountUserDataDirs = Object.fromEntries(
+        (deps.antigravityAccounts ?? [])
+            .filter((account) => typeof account.userDataDir === 'string' && account.userDataDir.trim().length > 0)
+            .map((account) => [account.name, account.userDataDir!.trim()]),
+    );
+    
+    const port = accountPorts[selectedAccount] ?? null;
+    const projectName = deps.bridge.pool.extractProjectName(workspacePath);
+
+    logger.info(
+        `[ProjectReopenCommand] channel=${chatId} user=${message.author.id} ` +
+        `project=${projectName} account=${selectedAccount} ` +
+        `port=${port ?? 'unknown'} workspacePath=${workspacePath}`,
+    );
+
+    try {
+        const { CdpService } = await import('../services/cdpService');
+        const cdp = new CdpService({
+            accountName: selectedAccount,
+            accountPorts,
+            accountUserDataDirs,
+            cdpCallTimeout: 15000,
+            maxReconnectAttempts: 0,
+        });
+
+        try {
+            await cdp.openWorkspace(workspacePath);
+        } finally {
+            await cdp.disconnect().catch(() => {});
+        }
+
+        deps.bridge.selectedAccountByChannel?.set(chatId, selectedAccount);
+        deps.bridge.pool.setPreferredAccountForWorkspace(workspacePath, selectedAccount);
+
+        await message.reply({
+            text: `✅ Reopened <b>${escapeHtml(projectName)}</b> in account <b>${escapeHtml(selectedAccount)}</b>${port ? ` (CDP ${port})` : ''}.`,
+        }).catch(logger.error);
+    } catch (error: any) {
+        logger.error('[ProjectReopenCommand] Failed to reopen workspace:', error);
+        await message.reply({
+            text: `❌ Failed to reopen project in account <b>${escapeHtml(selectedAccount)}</b>: ${escapeHtml(error?.message || String(error))}`,
+        }).catch(logger.error);
     }
 }

--- a/src/bot/telegramJoinCommand.ts
+++ b/src/bot/telegramJoinCommand.ts
@@ -1,0 +1,232 @@
+import { CdpBridge, ensureUserMessageDetector, getCurrentChatTitle } from '../services/cdpBridgeManager';
+import { CdpService } from '../services/cdpService';
+import { ResponseMonitor } from '../services/responseMonitor';
+import type { ChatSessionService } from '../services/chatSessionService';
+import type { PlatformMessage, PlatformSelectInteraction, MessagePayload } from '../platform/types';
+import type { TelegramBindingRepository } from '../database/telegramBindingRepository';
+import { buildSessionPickerPayload, SESSION_SELECT_ID } from '../ui/sessionPickerUi';
+import { logger } from '../utils/logger';
+import { escapeHtml } from '../platform/telegram/telegramFormatter';
+import type { WorkspaceService } from '../services/workspaceService';
+import { tryCreateTopicAndBind } from './telegramProjectCommand';
+import { resolveScopedAccountName } from '../utils/accountUtils';
+import type { AccountPreferenceRepository } from '../database/accountPreferenceRepository';
+import type { ChannelPreferenceRepository } from '../database/channelPreferenceRepository';
+import type { AntigravityAccountConfig } from '../utils/configLoader';
+
+export interface TelegramJoinCommandDeps {
+    readonly bridge: CdpBridge;
+    readonly chatSessionService?: ChatSessionService;
+    readonly telegramBindingRepo?: TelegramBindingRepository;
+    readonly workspaceService?: WorkspaceService;
+    readonly botApi?: any;
+    readonly accountPrefRepo?: AccountPreferenceRepository;
+    readonly channelPrefRepo?: ChannelPreferenceRepository;
+    readonly antigravityAccounts?: AntigravityAccountConfig[];
+    readonly extractionMode?: import('../utils/config').ExtractionMode;
+}
+
+const activeResponseMonitors = new Map<string, ResponseMonitor>();
+
+function resolveAccount(deps: TelegramJoinCommandDeps, chatId: string, userId: string): string {
+    return resolveScopedAccountName({
+        channelId: chatId,
+        userId,
+        selectedAccountByChannel: deps.bridge.selectedAccountByChannel,
+        channelPrefRepo: deps.channelPrefRepo,
+        accountPrefRepo: deps.accountPrefRepo,
+        accounts: deps.antigravityAccounts,
+    });
+}
+
+export async function handleJoin(deps: TelegramJoinCommandDeps, message: PlatformMessage): Promise<void> {
+    const binding = deps.telegramBindingRepo?.findByChatIdWithParentFallback(message.channel.id);
+    if (!binding) {
+        await message.reply({ text: '⚠️ No project is linked to this chat. Use /project first, or /project_reopen if this is a previously used session.' }).catch(logger.error);
+        return;
+    }
+
+    const resolvedWorkspacePath = deps.workspaceService
+        ? deps.workspaceService.getWorkspacePath(binding.workspacePath)
+        : binding.workspacePath;
+
+    const account = resolveAccount(deps, message.channel.id, message.author.id);
+
+    try {
+        const cdp = await deps.bridge.pool.getOrConnect(resolvedWorkspacePath, { name: account });
+        if (!deps.chatSessionService) {
+            await message.reply({ text: 'Chat session service not available.' }).catch(logger.error);
+            return;
+        }
+
+        const sessions = await deps.chatSessionService.listAllSessions(cdp);
+        if (sessions.length === 0) {
+            await message.reply({ text: 'No active sessions found in this project.' }).catch(logger.error);
+            return;
+        }
+
+        const ui = buildSessionPickerPayload(sessions);
+        await message.reply(ui as MessagePayload).catch(logger.error);
+    } catch (e: any) {
+        await message.reply({ text: `⚠️ Failed to connect to project: ${e.message}` }).catch(logger.error);
+    }
+}
+
+export async function handleTelegramJoinSelect(deps: TelegramJoinCommandDeps, interaction: PlatformSelectInteraction): Promise<void> {
+    const selectedTitle = interaction.values[0];
+    const originalChannelId = interaction.channel.id;
+    const binding = deps.telegramBindingRepo?.findByChatId(originalChannelId);
+
+    if (!binding) {
+        await interaction.update({ text: '⚠️ No project is bound to this chat.' }).catch(logger.error);
+        return;
+    }
+
+    const resolvedWorkspacePath = deps.workspaceService
+        ? deps.workspaceService.getWorkspacePath(binding.workspacePath)
+        : binding.workspacePath;
+
+    const account = resolveAccount(deps, interaction.channel.id, interaction.user.id);
+
+    let cdp: CdpService;
+    try {
+        cdp = await deps.bridge.pool.getOrConnect(resolvedWorkspacePath, { name: account });
+    } catch (e: any) {
+        await interaction.update({ text: `⚠️ Failed to connect to project: ${e.message}` }).catch(logger.error);
+        return;
+    }
+
+    if (!deps.chatSessionService) {
+        await interaction.update({ text: 'Chat session service not available.' }).catch(logger.error);
+        return;
+    }
+
+    const activateResult = await deps.chatSessionService.activateSessionByTitle(cdp, selectedTitle);
+    if (!activateResult.ok) {
+        await interaction.update({ text: `⚠️ Failed to join session: ${activateResult.error}` }).catch(logger.error);
+        return;
+    }
+
+    let targetChannelId = originalChannelId;
+    if (deps.botApi && deps.bridge && deps.telegramBindingRepo) {
+        targetChannelId = await tryCreateTopicAndBind(
+            deps.botApi,
+            originalChannelId,
+            binding.workspacePath,
+            deps.telegramBindingRepo,
+            deps.bridge.pool
+        );
+    }
+
+    const replyMsg = targetChannelId !== originalChannelId 
+        ? `✅ Joined session in new topic: <b>${escapeHtml(selectedTitle)}</b>\nUse /mirror if you want to forward PC messages here.` 
+        : `✅ Joined session: <b>${escapeHtml(selectedTitle)}</b>\nUse /mirror if you want to forward PC messages here.`;
+
+    await interaction.update({ text: replyMsg }).catch(logger.error);
+}
+
+export async function handleMirror(deps: TelegramJoinCommandDeps, message: PlatformMessage): Promise<void> {
+    const binding = deps.telegramBindingRepo?.findByChatIdWithParentFallback(message.channel.id);
+    if (!binding) {
+        await message.reply({ text: '⚠️ No project is linked to this chat. Use /project first, or /project_reopen if this is a previously used session.' }).catch(logger.error);
+        return;
+    }
+
+    const resolvedWorkspacePath = deps.workspaceService
+        ? deps.workspaceService.getWorkspacePath(binding.workspacePath)
+        : binding.workspacePath;
+
+    const projectName = deps.bridge.pool.extractProjectName(resolvedWorkspacePath);
+    const account = resolveAccount(deps, message.channel.id, message.author.id);
+    const detector = deps.bridge.pool.getUserMessageDetector(projectName, account);
+
+    if (detector?.isActive()) {
+        detector.stop();
+        const responseMonitor = activeResponseMonitors.get(resolvedWorkspacePath);
+        if (responseMonitor?.isActive()) {
+            await responseMonitor.stop();
+            activeResponseMonitors.delete(resolvedWorkspacePath);
+        }
+
+        await message.reply({ text: '📡 Mirroring OFF\nPC-to-Telegram message mirroring has been stopped.' }).catch(logger.error);
+    } else {
+        let cdp: CdpService;
+        try {
+            cdp = await deps.bridge.pool.getOrConnect(resolvedWorkspacePath, { name: account });
+        } catch (e: any) {
+            await message.reply({ text: `⚠️ Failed to connect to project: ${e.message}` }).catch(logger.error);
+            return;
+        }
+
+        const existing = deps.bridge.pool.getUserMessageDetector(projectName, account);
+        if (existing?.isActive()) {
+            existing.stop();
+        }
+
+        ensureUserMessageDetector(deps.bridge, cdp, projectName, (info) => {
+            routeMirroredMessage(deps, cdp, resolvedWorkspacePath, info, message.channel).catch((err) => {
+                logger.error('[TelegramMirror] Error routing mirrored message:', err);
+            });
+        }, account);
+
+        await message.reply({ text: '📡 Mirroring ON\nMessages typed in Antigravity on your PC will now appear here.' }).catch(logger.error);
+    }
+}
+
+async function routeMirroredMessage(
+    deps: TelegramJoinCommandDeps,
+    cdp: CdpService,
+    workspacePath: string,
+    info: { text: string },
+    channel: any
+): Promise<void> {
+    const chatTitle = await getCurrentChatTitle(cdp);
+    
+    await channel.send({
+        text: `🖥️ <b>User typed in Antigravity:</b>\n<pre>${escapeHtml(info.text)}</pre>\n<i>Session: ${escapeHtml(chatTitle || 'Unknown')}</i>`
+    }).catch((err: any) => logger.error('[TelegramMirror] Failed to send user message:', err));
+
+    startResponseMirror(deps, cdp, workspacePath, channel, chatTitle || 'Unknown');
+}
+
+function startResponseMirror(
+    deps: TelegramJoinCommandDeps,
+    cdp: CdpService,
+    workspacePath: string,
+    channel: any,
+    chatTitle: string
+): void {
+    const prev = activeResponseMonitors.get(workspacePath);
+    if (prev?.isActive()) {
+        prev.stop().catch(() => {});
+    }
+
+    const monitor = new ResponseMonitor({
+        cdpService: cdp,
+        pollIntervalMs: 2000,
+        maxDurationMs: 300000,
+        extractionMode: deps.extractionMode,
+        onComplete: (finalText: string) => {
+            activeResponseMonitors.delete(workspacePath);
+            if (!finalText || finalText.trim().length === 0) return;
+
+            const maxLen = 3000;
+            const text = finalText.length > maxLen
+                ? finalText.slice(0, maxLen) + '\n...(truncated)'
+                : finalText;
+
+            channel.send({
+                text: `🤖 <b>Antigravity Response:</b>\n${escapeHtml(text)}\n\n<i>Session: ${escapeHtml(chatTitle)}</i>`
+            }).catch((err: any) => logger.error('[TelegramMirror] Failed to send AI response:', err));
+        },
+        onTimeout: () => {
+            activeResponseMonitors.delete(workspacePath);
+        },
+    });
+
+    activeResponseMonitors.set(workspacePath, monitor);
+    monitor.startPassive().catch((err) => {
+        logger.error('[TelegramMirror] Failed to start response monitor:', err);
+        activeResponseMonitors.delete(workspacePath);
+    });
+}

--- a/src/bot/telegramMessageHandler.ts
+++ b/src/bot/telegramMessageHandler.ts
@@ -14,7 +14,7 @@ import type { TelegramBindingRepository } from '../database/telegramBindingRepos
 import type { WorkspaceService } from '../services/workspaceService';
 import { CdpBridge, registerApprovalWorkspaceChannel, ensureApprovalDetector, ensureErrorPopupDetector, ensurePlanningDetector, ensureRunCommandDetector } from '../services/cdpBridgeManager';
 import { CdpService } from '../services/cdpService';
-import { ResponseMonitor } from '../services/responseMonitor';
+import { ResponseMonitor, captureResponseMonitorBaseline } from '../services/responseMonitor';
 import { ProcessLogBuffer } from '../utils/processLogBuffer';
 import { splitOutputAndLogs } from '../utils/discordFormatter';
 import { parseTelegramProjectCommand, handleTelegramProjectCommand } from './telegramProjectCommand';
@@ -29,6 +29,10 @@ import { cleanupInboundImageAttachments } from '../utils/imageHandler';
 import type { InboundImageAttachment } from '../utils/imageHandler';
 import type { ExtractionMode } from '../utils/config';
 import type { ChatSessionService } from '../services/chatSessionService';
+import type { AccountPreferenceRepository } from '../database/accountPreferenceRepository';
+import type { ChannelPreferenceRepository } from '../database/channelPreferenceRepository';
+import type { AntigravityAccountConfig } from '../utils/configLoader';
+import { resolveScopedAccountName } from '../utils/accountUtils';
 
 export interface TelegramMessageHandlerDeps {
     readonly bridge: CdpBridge;
@@ -49,6 +53,9 @@ export interface TelegramMessageHandlerDeps {
     readonly chatSessionService?: ChatSessionService;
     /** Response monitor inactivity timeout in ms. Defaults to ResponseMonitor default (900000). */
     readonly responseTimeoutMs?: number;
+    readonly accountPrefRepo?: AccountPreferenceRepository;
+    readonly channelPrefRepo?: ChannelPreferenceRepository;
+    readonly antigravityAccounts?: AntigravityAccountConfig[];
 }
 
 /**
@@ -58,6 +65,17 @@ export interface TelegramMessageHandlerDeps {
 export function createTelegramMessageHandler(deps: TelegramMessageHandlerDeps) {
     // Per-workspace prompt queue to serialize messages
     const workspaceQueues = new Map<string, Promise<void>>();
+
+    function resolveAccount(chatId: string, userId: string): string {
+        return resolveScopedAccountName({
+            channelId: chatId,
+            userId,
+            selectedAccountByChannel: deps.bridge.selectedAccountByChannel,
+            channelPrefRepo: deps.channelPrefRepo,
+            accountPrefRepo: deps.accountPrefRepo,
+            accounts: deps.antigravityAccounts,
+        });
+    }
 
     function enqueueForWorkspace(
         workspacePath: string,
@@ -101,6 +119,10 @@ export function createTelegramMessageHandler(deps: TelegramMessageHandlerDeps) {
                     fetchQuota: deps.fetchQuota,
                     activeMonitors: deps.activeMonitors,
                     chatSessionService: deps.chatSessionService,
+                    accountPrefRepo: deps.accountPrefRepo,
+                    channelPrefRepo: deps.channelPrefRepo,
+                    antigravityAccounts: deps.antigravityAccounts,
+                    botApi: deps.botApi,
                 },
                 message,
                 cmd,
@@ -122,10 +144,10 @@ export function createTelegramMessageHandler(deps: TelegramMessageHandlerDeps) {
         }
 
         // Resolve workspace binding for this Telegram chat
-        const binding = deps.telegramBindingRepo.findByChatId(chatId);
+        const binding = deps.telegramBindingRepo.findByChatIdWithParentFallback(chatId);
         if (!binding) {
             await message.reply({
-                text: 'No project is linked to this chat. Use /project to bind a workspace.',
+                text: 'No project is linked to this chat. Use /project to bind a workspace, or /project_reopen if this is a previously used session.',
             }).catch(logger.error);
             return;
         }
@@ -138,11 +160,14 @@ export function createTelegramMessageHandler(deps: TelegramMessageHandlerDeps) {
             : binding.workspacePath;
 
         await enqueueForWorkspace(workspacePath, async () => {
+            const selectedAccount = resolveAccount(chatId, message.author.id);
+            deps.bridge.selectedAccountByChannel?.set(chatId, selectedAccount);
+
             const cdpStartTime = Date.now();
             logger.debug(`[TelegramHandler] getOrConnect start (elapsed=${cdpStartTime - handlerEntryTime}ms)`);
             let cdp: CdpService;
             try {
-                cdp = await deps.bridge.pool.getOrConnect(workspacePath);
+                cdp = await deps.bridge.pool.getOrConnect(workspacePath, { name: selectedAccount });
             } catch (e: any) {
                 await message.reply({
                     text: `Failed to connect to workspace: ${e.message}`,
@@ -180,10 +205,10 @@ export function createTelegramMessageHandler(deps: TelegramMessageHandlerDeps) {
             }
 
             // Start detectors (platform-agnostic now)
-            ensureApprovalDetector(deps.bridge, cdp, projectName);
-            ensureErrorPopupDetector(deps.bridge, cdp, projectName);
-            ensurePlanningDetector(deps.bridge, cdp, projectName);
-            ensureRunCommandDetector(deps.bridge, cdp, projectName);
+            ensureApprovalDetector(deps.bridge, cdp, projectName, selectedAccount);
+            ensureErrorPopupDetector(deps.bridge, cdp, projectName, selectedAccount);
+            ensurePlanningDetector(deps.bridge, cdp, projectName, selectedAccount);
+            ensureRunCommandDetector(deps.bridge, cdp, projectName, selectedAccount);
 
             // Acknowledge receipt
             await message.react('\u{1F440}').catch(() => {});
@@ -211,6 +236,7 @@ export function createTelegramMessageHandler(deps: TelegramMessageHandlerDeps) {
 
             // Determine the prompt text — use default for image-only messages
             const effectivePrompt = promptText || 'Please review the attached images and respond accordingly.';
+            const baseline = await captureResponseMonitorBaseline(cdp);
 
             // Inject prompt (with or without images) into Antigravity
             logger.prompt(effectivePrompt);
@@ -272,6 +298,8 @@ export function createTelegramMessageHandler(deps: TelegramMessageHandlerDeps) {
                     maxDurationMs: TIMEOUT_MS,
                     stopGoneConfirmCount: 3,
                     extractionMode: deps.extractionMode,
+                    initialBaselineText: baseline.text,
+                    initialSeenProcessLogKeys: baseline.processLogKeys,
 
                     onProcessLog: (logText) => {
                         if (logText && logText.trim().length > 0) {

--- a/src/bot/telegramProjectCommand.ts
+++ b/src/bot/telegramProjectCommand.ts
@@ -1,3 +1,4 @@
+import { logger } from '../utils/logger';
 /**
  * Telegram /project command handler.
  *
@@ -13,7 +14,7 @@
 import type { PlatformMessage, PlatformSelectInteraction, SelectMenuDef } from '../platform/types';
 import type { TelegramBindingRepository } from '../database/telegramBindingRepository';
 import type { WorkspaceService } from '../services/workspaceService';
-import { logger } from '../utils/logger';
+
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -62,7 +63,13 @@ export function parseTelegramProjectCommand(text: string): ParsedProjectCommand 
 // Dependencies
 // ---------------------------------------------------------------------------
 
+import type { CdpBridge } from '../services/cdpBridgeManager';
+import { escapeHtml } from '../platform/telegram/telegramFormatter';
+
+
 export interface TelegramProjectCommandDeps {
+    readonly botApi?: any;
+    readonly bridge?: CdpBridge;
     readonly workspaceService: WorkspaceService;
     readonly telegramBindingRepo: TelegramBindingRepository;
 }
@@ -130,6 +137,73 @@ export async function handleTelegramProjectCommand(
 /**
  * Handle a workspace selection callback from inline keyboard.
  */
+
+export async function tryCreateTopicAndBind(
+    botApi: any,
+    originalChannelId: string,
+    workspacePath: string,
+    telegramBindingRepo: any,
+    pool: any
+): Promise<string> {
+    const baseChatId = originalChannelId.split('_')[0];
+    const isExistingTopic = originalChannelId.includes('_');
+
+    if (isExistingTopic) {
+        telegramBindingRepo.upsert({
+            chatId: originalChannelId,
+            workspacePath,
+        });
+        return originalChannelId;
+    }
+
+    try {
+        const chat = await botApi.getChat(baseChatId);
+        logger.debug(`[Telegram] getChat(${baseChatId}) returned:`, chat);
+        if (chat?.is_forum) {
+            const projectName = pool.extractProjectName(workspacePath) || 'Project';
+            const topicName = `[Session] ${projectName}`.substring(0, 128);
+            const topic = await botApi.createForumTopic(baseChatId, topicName);
+            const threadId = topic.message_thread_id;
+            const newChannelId = `${baseChatId}_${threadId}`;
+
+            telegramBindingRepo.upsert({
+                chatId: newChannelId,
+                workspacePath,
+            });
+
+            await botApi.sendMessage(baseChatId, `✅ <b>${escapeHtml(projectName)}</b> session started in this topic.`, {
+                message_thread_id: threadId,
+                parse_mode: 'HTML'
+            }).catch((e: any) => logger.warn('Failed to send welcome message to new topic', e));
+
+            return newChannelId;
+        }
+    } catch (error: any) {
+        logger.debug(`[Telegram] Could not create forum topic for chat ${baseChatId}`, error);
+        
+        // If the error is specifically a permissions error for creating topics
+        const errStr = String(error);
+        if (errStr.includes('not enough rights') || errStr.includes('400')) {
+            await botApi.sendMessage(
+                baseChatId,
+                '⚠️ <b>Permission Error:</b> I do not have permission to create a Topic (Forum) in this group.\n\n' +
+                'Please follow these steps to fix:\n' +
+                '1. Go to Group Info -> Edit -> Administrators\n' +
+                '2. Select this bot (<code>@' + (botApi.me?.username || 'bot') + '</code>)\n' +
+                '3. Enable the <b>"Manage Topics"</b> (or "Change Group Info") permission\n' +
+                '4. Try binding the project or using /new again.',
+                { parse_mode: 'HTML' }
+            ).catch((e: any) => logger.warn('Failed to send permission error message', e));
+        }
+    }
+
+    telegramBindingRepo.upsert({
+        chatId: originalChannelId,
+        workspacePath,
+    });
+    return originalChannelId;
+}
+
 export async function handleTelegramProjectSelect(
     deps: TelegramProjectCommandDeps,
     interaction: PlatformSelectInteraction,
@@ -148,14 +222,31 @@ export async function handleTelegramProjectSelect(
         return;
     }
 
-    deps.telegramBindingRepo.upsert({
-        chatId,
-        workspacePath: selectedWorkspace,
-    });
+    let finalChannelId = chatId;
+    if (deps.botApi && deps.bridge) {
+        finalChannelId = await tryCreateTopicAndBind(
+            deps.botApi,
+            chatId,
+            selectedWorkspace,
+            deps.telegramBindingRepo,
+            deps.bridge.pool
+        );
+    } else {
+        deps.telegramBindingRepo.upsert({
+            chatId,
+            workspacePath: selectedWorkspace,
+        });
+    }
 
-    await interaction.update({
-        text: `Workspace bound: <b>${selectedWorkspace}</b>\nSend a message to start chatting with Antigravity.`,
-    }).catch(logger.error);
+    if (finalChannelId !== chatId) {
+        await interaction.update({
+            text: `✅ Workspace bound to new topic: <b>${escapeHtml(selectedWorkspace)}</b>`,
+        }).catch(logger.error);
+    } else {
+        await interaction.update({
+            text: `Workspace bound: <b>${escapeHtml(selectedWorkspace)}</b>\nSend a message to start chatting with Antigravity.`,
+        }).catch(logger.error);
+    }
 
     logger.info(`[TelegramProject] Chat ${chatId} bound to workspace: ${selectedWorkspace}`);
 }

--- a/src/bot/telegramStartupTarget.ts
+++ b/src/bot/telegramStartupTarget.ts
@@ -1,0 +1,73 @@
+import type { TelegramBindingRecord } from '../database/telegramBindingRepository';
+import type { TelegramBotLike } from '../platform/telegram/wrappers';
+
+interface StartupChatCandidate {
+    bindingChatId: string;
+    resolvedChatId: string;
+    type: string;
+    title: string;
+    isDirectBinding: boolean;
+}
+
+function getBaseChatId(chatId: string): string {
+    const sepIdx = chatId.indexOf('_');
+    return sepIdx > 0 ? chatId.slice(0, sepIdx) : chatId;
+}
+
+function normalizeTitle(title: string): string {
+    return title.trim().replace(/^#/, '').toLowerCase();
+}
+
+function isGeneralChat(title: string): boolean {
+    return normalizeTitle(title) === 'general';
+}
+
+export async function selectTelegramStartupChatId(
+    api: TelegramBotLike['api'],
+    bindings: TelegramBindingRecord[],
+): Promise<string | null> {
+    const candidates: StartupChatCandidate[] = [];
+    const seenResolvedIds = new Set<string>();
+
+    for (const binding of bindings) {
+        const resolvedChatId = getBaseChatId(binding.chatId);
+        if (seenResolvedIds.has(resolvedChatId)) continue;
+        seenResolvedIds.add(resolvedChatId);
+
+        try {
+            const chat = await api.getChat(resolvedChatId);
+            candidates.push({
+                bindingChatId: binding.chatId,
+                resolvedChatId,
+                type: String(chat?.type ?? ''),
+                title: String(chat?.title ?? chat?.first_name ?? ''),
+                isDirectBinding: binding.chatId === resolvedChatId,
+            });
+        } catch {
+            candidates.push({
+                bindingChatId: binding.chatId,
+                resolvedChatId,
+                type: '',
+                title: '',
+                isDirectBinding: binding.chatId === resolvedChatId,
+            });
+        }
+    }
+
+    if (candidates.length === 0) return null;
+
+    const generalGroup = candidates.find((candidate) =>
+        candidate.type !== 'private' && isGeneralChat(candidate.title),
+    );
+    if (generalGroup) return generalGroup.resolvedChatId;
+
+    const directGroup = candidates.find((candidate) =>
+        candidate.type !== 'private' && candidate.isDirectBinding,
+    );
+    if (directGroup) return directGroup.resolvedChatId;
+
+    const privateChat = candidates.find((candidate) => candidate.type === 'private');
+    if (privateChat) return privateChat.bindingChatId;
+
+    return candidates[0].resolvedChatId;
+}

--- a/src/commands/chatCommandHandler.ts
+++ b/src/commands/chatCommandHandler.ts
@@ -11,6 +11,8 @@ import { ChannelManager } from '../services/channelManager';
 import { CdpConnectionPool } from '../services/cdpConnectionPool';
 import { WorkspaceService } from '../services/workspaceService';
 
+export type ResolveAccountForChannel = (channelId: string, userId: string) => string;
+
 /**
  * Handler for chat session related commands
  *
@@ -25,6 +27,7 @@ export class ChatCommandHandler {
     private readonly channelManager: ChannelManager;
     private readonly pool: CdpConnectionPool | null;
     private readonly workspaceService: WorkspaceService;
+    private readonly resolveAccountForChannel: ResolveAccountForChannel | null;
 
     constructor(
         chatSessionService: ChatSessionService,
@@ -33,6 +36,7 @@ export class ChatCommandHandler {
         channelManager: ChannelManager,
         workspaceService: WorkspaceService,
         pool?: CdpConnectionPool,
+        resolveAccountForChannel?: ResolveAccountForChannel,
     ) {
         this.chatSessionService = chatSessionService;
         this.chatSessionRepo = chatSessionRepo;
@@ -40,6 +44,7 @@ export class ChatCommandHandler {
         this.channelManager = channelManager;
         this.workspaceService = workspaceService;
         this.pool = pool ?? null;
+        this.resolveAccountForChannel = resolveAccountForChannel ?? null;
     }
 
     /**
@@ -58,21 +63,12 @@ export class ChatCommandHandler {
             return;
         }
 
-        // Check if the current channel is under a project category
-        const parentId = 'parentId' in channel ? channel.parentId : null;
-        if (!parentId) {
-            await interaction.editReply({
-                content: t('⚠️ Please run in a project category channel.\nUse `/project` to create a project first.'),
-            });
-            return;
-        }
-
-        // Determine the project path
         const currentSession = this.chatSessionRepo.findByChannelId(interaction.channelId);
         const binding = this.bindingRepo.findByChannelId(interaction.channelId);
+        const parentId = currentSession?.categoryId ?? ('parentId' in channel ? channel.parentId : null);
 
         const workspaceName = currentSession?.workspacePath ?? binding?.workspacePath;
-        if (!workspaceName) {
+        if (!parentId || !workspaceName) {
             await interaction.editReply({
                 content: t('⚠️ Please run in a project category channel.\nUse `/project` to create a project first.'),
             });
@@ -84,9 +80,10 @@ export class ChatCommandHandler {
 
         // Switch project (connect to the correct workbench page)
         let workspaceCdp;
+        const selectedAccount = this.resolveAccountForChannel?.(interaction.channelId, interaction.user.id) ?? 'default';
         if (this.pool) {
             try {
-                workspaceCdp = await this.pool.getOrConnect(workspacePath);
+                workspaceCdp = await this.pool.getOrConnect(workspacePath, { name: selectedAccount });
             } catch (e: any) {
                 await interaction.editReply({
                     content: t(`⚠️ Failed to switch project: ${e.message}`),
@@ -120,6 +117,7 @@ export class ChatCommandHandler {
             categoryId: parentId,
             workspacePath: workspaceName,
             sessionNumber,
+            activeAccountName: selectedAccount,
             guildId: guild.id,
         });
 

--- a/src/commands/joinCommandHandler.ts
+++ b/src/commands/joinCommandHandler.ts
@@ -24,6 +24,7 @@ import type { ExtractionMode } from '../utils/config';
 
 /** Maximum embed description length (Discord limit is 4096) */
 const MAX_EMBED_DESC = 4000;
+type ResolveAccountForChannel = (channelId: string, userId: string) => string;
 
 /**
  * Handler for /join and /mirror commands
@@ -41,6 +42,7 @@ export class JoinCommandHandler {
     private readonly client: Client;
     private readonly extractionMode?: ExtractionMode;
     private readonly responseTimeoutMs?: number;
+    private readonly resolveAccountForChannel: ResolveAccountForChannel | null;
 
     /** Active ResponseMonitors per workspace (for AI response mirroring) */
     private readonly activeResponseMonitors = new Map<string, ResponseMonitor>();
@@ -55,6 +57,7 @@ export class JoinCommandHandler {
         client: Client,
         extractionMode?: ExtractionMode,
         responseTimeoutMs?: number,
+        resolveAccountForChannel?: ResolveAccountForChannel,
     ) {
         this.chatSessionService = chatSessionService;
         this.chatSessionRepo = chatSessionRepo;
@@ -65,6 +68,7 @@ export class JoinCommandHandler {
         this.client = client;
         this.extractionMode = extractionMode;
         this.responseTimeoutMs = responseTimeoutMs;
+        this.resolveAccountForChannel = resolveAccountForChannel ?? null;
     }
 
     /**
@@ -94,10 +98,11 @@ export class JoinCommandHandler {
         }
 
         const projectPath = this.resolveProjectPath(projectName);
+        const accountName = this.resolveAccountForChannel?.(interaction.channelId, interaction.user.id) ?? 'default';
 
         let cdp;
         try {
-            cdp = await this.pool.getOrConnect(projectPath);
+            cdp = await this.pool.getOrConnect(projectPath, { name: accountName });
         } catch (e: any) {
             await interaction.editReply({
                 content: t(`⚠️ Failed to connect to project: ${e.message}`),
@@ -141,6 +146,7 @@ export class JoinCommandHandler {
         }
 
         const projectPath = this.resolveProjectPath(projectName);
+        const accountName = this.resolveAccountForChannel?.(interaction.channelId, interaction.user.id) ?? 'default';
 
         // Step 1: Check if a channel already exists for this session
         const existingSession = this.chatSessionRepo.findByDisplayName(projectName, selectedTitle);
@@ -166,7 +172,7 @@ export class JoinCommandHandler {
         // Step 2: Connect to CDP
         let cdp;
         try {
-            cdp = await this.pool.getOrConnect(projectPath);
+            cdp = await this.pool.getOrConnect(projectPath, { name: accountName });
         } catch (e: any) {
             await interaction.editReply({ content: t(`⚠️ Failed to connect to project: ${e.message}`) });
             return;
@@ -199,13 +205,14 @@ export class JoinCommandHandler {
             categoryId,
             workspacePath: projectName,
             sessionNumber,
+            activeAccountName: accountName,
             guildId: guild.id,
         });
 
         this.chatSessionRepo.updateDisplayName(newChannelId, selectedTitle);
 
         // Step 6: Start mirroring (routes dynamically to all bound session channels)
-        this.startMirroring(bridge, cdp, projectName);
+        this.startMirroring(bridge, cdp, projectName, accountName);
 
         const embed = new EmbedBuilder()
             .setTitle(t('🔗 Joined Session'))
@@ -239,7 +246,8 @@ export class JoinCommandHandler {
         }
 
         const projectPath = this.resolveProjectPath(projectName);
-        const detector = this.pool.getUserMessageDetector(projectName);
+        const accountName = this.resolveAccountForChannel?.(interaction.channelId, interaction.user.id) ?? 'default';
+        const detector = this.pool.getUserMessageDetector(projectName, accountName);
 
         if (detector?.isActive()) {
             // Turn OFF — stop user message detector and any active response monitor
@@ -260,7 +268,7 @@ export class JoinCommandHandler {
             // Turn ON
             let cdp;
             try {
-                cdp = await this.pool.getOrConnect(projectPath);
+                cdp = await this.pool.getOrConnect(projectPath, { name: accountName });
             } catch (e: any) {
                 await interaction.editReply({
                     content: t(`⚠️ Failed to connect to project: ${e.message}`),
@@ -268,7 +276,7 @@ export class JoinCommandHandler {
                 return;
             }
 
-            this.startMirroring(bridge, cdp, projectName);
+            this.startMirroring(bridge, cdp, projectName, accountName);
 
             const embed = new EmbedBuilder()
                 .setTitle(t('📡 Mirroring ON'))
@@ -293,11 +301,12 @@ export class JoinCommandHandler {
         bridge: CdpBridge,
         cdp: CdpService,
         projectName: string,
+        accountName: string,
     ): void {
         // Force re-prime: stop existing detector so that ensureUserMessageDetector
         // creates a fresh one. This prevents the detector from treating the
         // new session's last message as a "new" user message after /join.
-        const existing = this.pool.getUserMessageDetector(projectName);
+        const existing = this.pool.getUserMessageDetector(projectName, accountName);
         if (existing?.isActive()) {
             existing.stop();
         }
@@ -307,7 +316,7 @@ export class JoinCommandHandler {
                 .catch((err) => {
                     logger.error('[Mirror] Error routing mirrored message:', err);
                 });
-        });
+        }, accountName);
     }
 
     /**

--- a/src/commands/registerSlashCommands.ts
+++ b/src/commands/registerSlashCommands.ts
@@ -110,6 +110,29 @@ const projectCommand = new SlashCommandBuilder()
                     .setDescription(t('Name of the project to create'))
                     .setRequired(true)
             )
+    )
+    .addSubcommand((sub) =>
+        sub
+            .setName('reopen')
+            .setDescription(t('Reopen the bound project in the selected Antigravity account'))
+            .addStringOption((option) =>
+                option
+                    .setName('account')
+                    .setDescription(t('Account to reopen the project in'))
+                    .setRequired(false)
+                    .setAutocomplete(true)
+            )
+    )
+    .addSubcommand((sub) =>
+        sub
+            .setName('account')
+            .setDescription(t('Display or change the Antigravity account bound to this project channel'))
+            .addStringOption((option) =>
+                option
+                    .setName('name')
+                    .setDescription(t('Name of the account to bind to this project channel'))
+                    .setRequired(false)
+            )
     );
 
 /** /new command definition (formerly /chat new, made into a standalone command) */
@@ -161,6 +184,10 @@ const outputCommand = new SlashCommandBuilder()
             .setRequired(false)
     );
 
+/** /account command definition */
+const accountCommand = new SlashCommandBuilder()
+    .setName('account')
+    .setDescription(t('Select the Antigravity account for the current session'));
 
 /** /logs command definition */
 const logsCommand = new SlashCommandBuilder()
@@ -208,6 +235,7 @@ export const slashCommands = [
     cleanupCommand,
     joinCommand,
     mirrorCommand,
+    accountCommand,
     outputCommand,
     pingCommand,
     logsCommand,

--- a/src/commands/workspaceCommandHandler.ts
+++ b/src/commands/workspaceCommandHandler.ts
@@ -27,6 +27,12 @@ export class WorkspaceCommandHandler {
     private readonly chatSessionRepo: ChatSessionRepository;
     private readonly workspaceService: WorkspaceService;
     private readonly channelManager: ChannelManager;
+    private readonly onSessionChannelCreated?: (
+        workspacePath: string,
+        channelId: string,
+        sourceChannelId: string,
+        userId: string,
+    ) => Promise<void>;
 
     private processingWorkspaces: Set<string> = new Set();
 
@@ -69,11 +75,18 @@ export class WorkspaceCommandHandler {
         chatSessionRepo: ChatSessionRepository,
         workspaceService: WorkspaceService,
         channelManager: ChannelManager,
+        onSessionChannelCreated?: (
+            workspacePath: string,
+            channelId: string,
+            sourceChannelId: string,
+            userId: string,
+        ) => Promise<void>,
     ) {
         this.bindingRepo = bindingRepo;
         this.chatSessionRepo = chatSessionRepo;
         this.workspaceService = workspaceService;
         this.channelManager = channelManager;
+        this.onSessionChannelCreated = onSessionChannelCreated;
     }
 
     /**
@@ -107,10 +120,17 @@ export class WorkspaceCommandHandler {
         interaction: StringSelectMenuInteraction,
         guild: Guild,
     ): Promise<void> {
+        const respond = async (payload: Record<string, unknown>) => {
+            if (typeof interaction.editReply === 'function') {
+                await interaction.editReply(payload);
+                return;
+            }
+            await interaction.update(payload);
+        };
         const workspacePath = interaction.values[0];
 
         if (!this.workspaceService.exists(workspacePath)) {
-            await interaction.update({
+            await respond({
                 content: t(`❌ Project \`${workspacePath}\` not found.`),
                 embeds: [],
                 components: [],
@@ -136,7 +156,7 @@ export class WorkspaceCommandHandler {
                 .addFields({ name: t('Full Path'), value: `\`${fullPath}\`` })
                 .setTimestamp();
 
-            await interaction.update({
+            await respond({
                 embeds: [embed],
                 components: [],
             });
@@ -145,7 +165,7 @@ export class WorkspaceCommandHandler {
 
         // Lock project being processed (prevent rapid repeated clicks)
         if (this.processingWorkspaces.has(workspacePath)) {
-            await interaction.update({
+            await respond({
                 content: t(`⏳ **${workspacePath}** is being created. Please wait.`),
                 embeds: [],
                 components: [],
@@ -183,6 +203,13 @@ export class WorkspaceCommandHandler {
                 guildId: guild.id,
             });
 
+            await this.onSessionChannelCreated?.(
+                workspacePath,
+                channelId,
+                interaction.channelId,
+                interaction.user.id,
+            );
+
             const fullPath = this.workspaceService.getWorkspacePath(workspacePath);
 
             const embed = new EmbedBuilder()
@@ -195,7 +222,7 @@ export class WorkspaceCommandHandler {
                 .addFields({ name: t('Full Path'), value: `\`${fullPath}\`` })
                 .setTimestamp();
 
-            await interaction.update({
+            await respond({
                 embeds: [embed],
                 components: [],
             });
@@ -284,6 +311,13 @@ export class WorkspaceCommandHandler {
                 guildId: guild.id,
             });
 
+            await this.onSessionChannelCreated?.(
+                name,
+                channelId,
+                interaction.channelId,
+                interaction.user.id,
+            );
+
             const embed = new EmbedBuilder()
                 .setTitle('📁 Project Created')
                 .setColor(0x00AA00)
@@ -305,7 +339,13 @@ export class WorkspaceCommandHandler {
      */
     public getWorkspaceForChannel(channelId: string): string | undefined {
         const binding = this.bindingRepo.findByChannelId(channelId);
-        if (!binding) return undefined;
-        return this.workspaceService.getWorkspacePath(binding.workspacePath);
+        if (binding) {
+            return this.workspaceService.getWorkspacePath(binding.workspacePath);
+        }
+
+        const session = this.chatSessionRepo.findByChannelId(channelId);
+        if (!session) return undefined;
+
+        return this.workspaceService.getWorkspacePath(session.workspacePath);
     }
 }

--- a/src/database/accountPreferenceRepository.ts
+++ b/src/database/accountPreferenceRepository.ts
@@ -1,0 +1,29 @@
+import Database from 'better-sqlite3';
+
+export class AccountPreferenceRepository {
+    constructor(private readonly db: Database.Database) {
+        this.db.exec(`
+            CREATE TABLE IF NOT EXISTS account_preferences (
+                user_id TEXT PRIMARY KEY,
+                account_name TEXT NOT NULL,
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+        `);
+    }
+
+    getAccountName(userId: string): string | null {
+        const row = this.db.prepare(
+            'SELECT account_name FROM account_preferences WHERE user_id = ?',
+        ).get(userId) as { account_name: string } | undefined;
+        return row?.account_name ?? null;
+    }
+
+    setAccountName(userId: string, accountName: string): void {
+        this.db.prepare(`
+            INSERT INTO account_preferences (user_id, account_name)
+            VALUES (?, ?)
+            ON CONFLICT(user_id)
+            DO UPDATE SET account_name = excluded.account_name, updated_at = datetime('now')
+        `).run(userId, accountName);
+    }
+}

--- a/src/database/channelPreferenceRepository.ts
+++ b/src/database/channelPreferenceRepository.ts
@@ -1,0 +1,29 @@
+import Database from 'better-sqlite3';
+
+export class ChannelPreferenceRepository {
+    constructor(private readonly db: Database.Database) {
+        this.db.exec(`
+            CREATE TABLE IF NOT EXISTS channel_preferences (
+                channel_id TEXT PRIMARY KEY,
+                account_name TEXT,
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            )
+        `);
+    }
+
+    getAccountName(channelId: string): string | null {
+        const row = this.db.prepare(
+            'SELECT account_name FROM channel_preferences WHERE channel_id = ?',
+        ).get(channelId) as { account_name: string | null } | undefined;
+        return row?.account_name ?? null;
+    }
+
+    setAccountName(channelId: string, accountName: string): void {
+        this.db.prepare(`
+            INSERT INTO channel_preferences (channel_id, account_name)
+            VALUES (?, ?)
+            ON CONFLICT(channel_id)
+            DO UPDATE SET account_name = excluded.account_name, updated_at = datetime('now')
+        `).run(channelId, accountName);
+    }
+}

--- a/src/database/chatSessionRepository.ts
+++ b/src/database/chatSessionRepository.ts
@@ -9,6 +9,9 @@ export interface ChatSessionRecord {
     categoryId: string;
     workspacePath: string;
     sessionNumber: number;
+    conversationId: string | null;
+    activeAccountName: string | null;
+    originAccountName: string | null;
     displayName: string | null;
     isRenamed: boolean;
     guildId: string;
@@ -23,6 +26,7 @@ export interface CreateChatSessionInput {
     categoryId: string;
     workspacePath: string;
     sessionNumber: number;
+    activeAccountName?: string | null;
     guildId: string;
 }
 
@@ -46,18 +50,56 @@ export class ChatSessionRepository {
                 category_id TEXT NOT NULL,
                 workspace_path TEXT NOT NULL,
                 session_number INTEGER NOT NULL,
+                conversation_id TEXT,
+                active_account_name TEXT,
+                origin_account_name TEXT,
                 display_name TEXT,
                 is_renamed INTEGER NOT NULL DEFAULT 0,
                 guild_id TEXT NOT NULL,
                 created_at TEXT NOT NULL DEFAULT (datetime('now'))
             )
         `);
+
+        const columns = this.db.prepare('PRAGMA table_info(chat_sessions)').all() as Array<{ name: string }>;
+        const hasActiveAccountName = columns.some((column) => column.name === 'active_account_name');
+        const hasConversationId = columns.some((column) => column.name === 'conversation_id');
+        if (!hasConversationId) {
+            this.db.exec('ALTER TABLE chat_sessions ADD COLUMN conversation_id TEXT');
+        }
+        if (!hasActiveAccountName) {
+            this.db.exec('ALTER TABLE chat_sessions ADD COLUMN active_account_name TEXT');
+        }
+        const hasOriginAccountName = columns.some((column) => column.name === 'origin_account_name');
+        if (!hasOriginAccountName) {
+            this.db.exec('ALTER TABLE chat_sessions ADD COLUMN origin_account_name TEXT');
+        }
+
+        const hasLegacyAccountName = columns.some((column) => column.name === 'account_name');
+        if (hasLegacyAccountName) {
+            this.db.exec(`
+                UPDATE chat_sessions
+                SET origin_account_name = account_name
+                WHERE origin_account_name IS NULL AND account_name IS NOT NULL
+            `);
+            this.db.exec(`
+                UPDATE chat_sessions
+                SET active_account_name = COALESCE(active_account_name, origin_account_name, account_name)
+                WHERE active_account_name IS NULL
+            `);
+        } else {
+            this.db.exec(`
+                UPDATE chat_sessions
+                SET active_account_name = origin_account_name
+                WHERE active_account_name IS NULL AND origin_account_name IS NOT NULL
+            `);
+        }
     }
 
     public create(input: CreateChatSessionInput): ChatSessionRecord {
+        const activeAccountName = input.activeAccountName ?? null;
         const stmt = this.db.prepare(`
-            INSERT INTO chat_sessions (channel_id, category_id, workspace_path, session_number, guild_id)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO chat_sessions (channel_id, category_id, workspace_path, session_number, active_account_name, origin_account_name, guild_id)
+            VALUES (?, ?, ?, ?, ?, NULL, ?)
         `);
 
         const result = stmt.run(
@@ -65,6 +107,7 @@ export class ChatSessionRepository {
             input.categoryId,
             input.workspacePath,
             input.sessionNumber,
+            activeAccountName,
             input.guildId,
         );
 
@@ -74,6 +117,9 @@ export class ChatSessionRepository {
             categoryId: input.categoryId,
             workspacePath: input.workspacePath,
             sessionNumber: input.sessionNumber,
+            conversationId: null,
+            activeAccountName,
+            originAccountName: null,
             displayName: null,
             isRenamed: false,
             guildId: input.guildId,
@@ -116,6 +162,41 @@ export class ChatSessionRepository {
         return result.changes > 0;
     }
 
+    public setActiveAccountName(channelId: string, accountName: string): boolean {
+        const result = this.db.prepare(
+            'UPDATE chat_sessions SET active_account_name = ? WHERE channel_id = ?'
+        ).run(accountName, channelId);
+        return result.changes > 0;
+    }
+
+    public setOriginAccountName(channelId: string, accountName: string): boolean {
+        const result = this.db.prepare(
+            'UPDATE chat_sessions SET origin_account_name = ? WHERE channel_id = ?'
+        ).run(accountName, channelId);
+        return result.changes > 0;
+    }
+
+    public setConversationId(channelId: string, conversationId: string): boolean {
+        const result = this.db.prepare(
+            'UPDATE chat_sessions SET conversation_id = ? WHERE channel_id = ?'
+        ).run(conversationId, channelId);
+        return result.changes > 0;
+    }
+
+    public initializeConversationId(channelId: string, conversationId: string): boolean {
+        const result = this.db.prepare(
+            'UPDATE chat_sessions SET conversation_id = ? WHERE channel_id = ? AND conversation_id IS NULL'
+        ).run(conversationId, channelId);
+        return result.changes > 0;
+    }
+
+    public initializeOriginAccountName(channelId: string, accountName: string): boolean {
+        const result = this.db.prepare(
+            'UPDATE chat_sessions SET origin_account_name = ? WHERE channel_id = ? AND origin_account_name IS NULL'
+        ).run(accountName, channelId);
+        return result.changes > 0;
+    }
+
     /**
      * Find a session by display name within a workspace.
      * Returns the first match (most recent).
@@ -142,6 +223,9 @@ export class ChatSessionRepository {
             categoryId: row.category_id,
             workspacePath: row.workspace_path,
             sessionNumber: row.session_number,
+            conversationId: row.conversation_id ?? null,
+            activeAccountName: row.active_account_name ?? row.account_name ?? null,
+            originAccountName: row.origin_account_name ?? null,
             displayName: row.display_name,
             isRenamed: row.is_renamed === 1,
             guildId: row.guild_id,

--- a/src/database/telegramBindingRepository.ts
+++ b/src/database/telegramBindingRepository.ts
@@ -78,6 +78,20 @@ export class TelegramBindingRepository {
     }
 
     /**
+     * Find binding by exact chat ID, or fall back to the base chat ID for topic-style IDs.
+     * Example: "12345_67" falls back to "12345" when the topic itself has no direct binding.
+     */
+    public findByChatIdWithParentFallback(chatId: string): TelegramBindingRecord | undefined {
+        const exact = this.findByChatId(chatId);
+        if (exact) return exact;
+
+        const underscoreIndex = chatId.indexOf('_');
+        if (underscoreIndex <= 0) return undefined;
+
+        return this.findByChatId(chatId.slice(0, underscoreIndex));
+    }
+
+    /**
      * Find bindings by workspace path
      */
     public findByWorkspacePath(workspacePath: string): TelegramBindingRecord[] {

--- a/src/events/interactionCreateHandler.ts
+++ b/src/events/interactionCreateHandler.ts
@@ -23,7 +23,10 @@ import {
     OUTPUT_BTN_PLAIN,
     sendOutputUI,
 } from '../ui/outputUi';
+import { AccountPreferenceRepository } from '../database/accountPreferenceRepository';
+import { ChannelPreferenceRepository } from '../database/channelPreferenceRepository';
 import { UserPreferenceRepository, OutputFormat } from '../database/userPreferenceRepository';
+import { ChatSessionRepository } from '../database/chatSessionRepository';
 import { ChatCommandHandler } from '../commands/chatCommandHandler';
 import {
     CleanupCommandHandler,
@@ -39,8 +42,12 @@ import { CdpService } from '../services/cdpService';
 import { MODE_DISPLAY_NAMES, ModeService } from '../services/modeService';
 import { ModelService } from '../services/modelService';
 import { AutoAcceptService } from '../services/autoAcceptService';
+import { ChatSessionService } from '../services/chatSessionService';
 import { JoinCommandHandler } from '../commands/joinCommandHandler';
 import { isSessionSelectId } from '../ui/sessionPickerUi';
+import type { AntigravityAccountConfig } from '../utils/configLoader';
+import { inferParentScopeChannelId, listAccountNames, resolveScopedAccountName } from '../utils/accountUtils';
+import { ACCOUNT_SELECT_ID, sendAccountUI } from '../ui/accountUi';
 
 export interface InteractionCreateHandlerDeps {
     config: { allowedUserIds: string[] };
@@ -78,14 +85,142 @@ export interface InteractionCreateHandlerDeps {
         modelService: ModelService,
         autoAcceptService: AutoAcceptService,
         client: any,
+        accountPrefRepo?: AccountPreferenceRepository,
+        channelPrefRepo?: ChannelPreferenceRepository,
+        antigravityAccounts?: AntigravityAccountConfig[],
+        chatSessionRepo?: ChatSessionRepository,
     ) => Promise<void>;
     handleTemplateUse?: (interaction: ButtonInteraction, templateId: number) => Promise<void>;
     joinHandler?: JoinCommandHandler;
     userPrefRepo?: UserPreferenceRepository;
+    accountPrefRepo?: AccountPreferenceRepository;
+    channelPrefRepo?: ChannelPreferenceRepository;
+    antigravityAccounts?: AntigravityAccountConfig[];
+    chatSessionRepo?: ChatSessionRepository;
+    chatSessionService?: ChatSessionService;
 }
 
 export function createInteractionCreateHandler(deps: InteractionCreateHandlerDeps) {
+    const getParentChannelId = (interaction: Interaction): string | null =>
+        inferParentScopeChannelId(
+            (interaction as any).channelId,
+            (interaction as any).channel?.parentId ?? null,
+        );
+    const getSessionAccountName = (channelId: string): string | null =>
+        deps.chatSessionRepo?.findByChannelId(channelId)?.activeAccountName ?? null;
+    const resolveSelectedAccount = (channelId: string, userId: string, parentChannelId?: string | null): string =>
+        resolveScopedAccountName({
+            channelId,
+            userId,
+            sessionAccountName: getSessionAccountName(channelId),
+            parentChannelId,
+            selectedAccountByChannel: deps.bridge.selectedAccountByChannel,
+            channelPrefRepo: deps.channelPrefRepo,
+            accountPrefRepo: deps.accountPrefRepo,
+            accounts: deps.antigravityAccounts,
+        });
+    const getChannelCdp = (channelId: string, userId: string): CdpService | null =>
+        (() => {
+            const workspacePath = deps.wsHandler.getWorkspaceForChannel(channelId);
+            if (workspacePath) {
+                const projectName = deps.bridge.pool.extractProjectName(workspacePath);
+                return deps.bridge.pool.getConnected(
+                    projectName,
+                    resolveSelectedAccount(channelId, userId),
+                );
+            }
+
+            return deps.bridge.lastActiveWorkspace
+                ? deps.bridge.pool.getConnected(
+                    deps.bridge.lastActiveWorkspace,
+                    resolveSelectedAccount(channelId, userId),
+                )
+                : null;
+        })();
+    const ensureBoundSessionActive = async (
+        channelId: string,
+        userId: string,
+        cdp: CdpService,
+    ): Promise<{ ok: true } | { ok: false; error: string }> => {
+        const savedTitle = deps.chatSessionRepo?.findByChannelId(channelId)?.displayName?.trim() || '';
+        if (!savedTitle || savedTitle === t('(Untitled)') || !deps.chatSessionService) {
+            return { ok: true };
+        }
+
+        const current = await deps.chatSessionService.getCurrentSessionInfo(cdp);
+        if (current.title.trim() === savedTitle) {
+            return { ok: true };
+        }
+
+        logger.info(
+            `[ModelCommand] source=button channel=${channelId} user=${userId} ` +
+            `restoringSession target="${savedTitle}" current="${current.title.trim() || '(unknown)'}"`,
+        );
+        const activation = await deps.chatSessionService.activateSessionByTitle(cdp, savedTitle, {
+            maxWaitMs: 8000,
+            retryIntervalMs: 300,
+            allowVisibilityWarmupMs: 1000,
+        });
+        if (!activation.ok) {
+            return {
+                ok: false,
+                error: `Failed to activate saved session "${savedTitle}" before model action: ${activation.error || 'unknown'}`,
+            };
+        }
+
+        const refresh = await deps.chatSessionService.refreshSessionViewIfStuck(cdp, savedTitle);
+        if (!refresh.ok) {
+            logger.warn(
+                `[ModelCommand] source=button channel=${channelId} user=${userId} ` +
+                `sessionRefreshWarning target="${savedTitle}" error="${refresh.error || 'unknown'}"`,
+            );
+        }
+        return { ok: true };
+    };
+
     return async (interaction: Interaction): Promise<void> => {
+        if (interaction.isAutocomplete()) {
+            if (!deps.config.allowedUserIds.includes(interaction.user.id)) {
+                await interaction.respond([]).catch(logger.error);
+                return;
+            }
+
+            try {
+                if (interaction.commandName === 'project') {
+                    const subcommand = interaction.options.getSubcommand(false);
+                    const focused = interaction.options.getFocused(true);
+
+                    if (
+                        (subcommand === 'reopen' || subcommand === 'account')
+                        && focused.name === 'account'
+                    ) {
+                        const names = listAccountNames(deps.antigravityAccounts);
+                        const currentAccount = resolveSelectedAccount(
+                            interaction.channelId,
+                            interaction.user.id,
+                            getParentChannelId(interaction),
+                        );
+                        const needle = String(focused.value || '').trim().toLowerCase();
+                        const choices = names
+                            .filter((name) => !needle || name.toLowerCase().includes(needle))
+                            .slice(0, 25)
+                            .map((name) => ({
+                                name: name === currentAccount ? `${name} (current)` : name,
+                                value: name,
+                            }));
+
+                        await interaction.respond(choices);
+                        return;
+                    }
+                }
+            } catch (error) {
+                logger.error('Autocomplete handling error:', error);
+            }
+
+            await interaction.respond([]).catch(logger.error);
+            return;
+        }
+
         if (interaction.isButton()) {
             if (!deps.config.allowedUserIds.includes(interaction.user.id)) {
                 await interaction.reply({ content: t('You do not have permission.'), flags: MessageFlags.Ephemeral }).catch(logger.error);
@@ -105,7 +240,14 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
 
                     const projectName = approvalAction.projectName ?? deps.bridge.lastActiveWorkspace;
                     const detector = projectName
-                        ? deps.bridge.pool.getApprovalDetector(projectName)
+                        ? deps.bridge.pool.getApprovalDetector(
+                            projectName,
+                            resolveSelectedAccount(
+                                interaction.channelId,
+                                interaction.user.id,
+                                getParentChannelId(interaction),
+                            ),
+                        )
                         : undefined;
 
                     if (!detector) {
@@ -175,7 +317,14 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
 
                     const planWorkspaceDirName = planningAction.projectName ?? deps.bridge.lastActiveWorkspace;
                     const planDetector = planWorkspaceDirName
-                        ? deps.bridge.pool.getPlanningDetector(planWorkspaceDirName)
+                        ? deps.bridge.pool.getPlanningDetector(
+                            planWorkspaceDirName,
+                            resolveSelectedAccount(
+                                interaction.channelId,
+                                interaction.user.id,
+                                getParentChannelId(interaction),
+                            ),
+                        )
                         : undefined;
 
                     if (!planDetector) {
@@ -305,7 +454,10 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
 
                     const errorWorkspaceDirName = errorPopupAction.projectName ?? deps.bridge.lastActiveWorkspace;
                     const errorDetector = errorWorkspaceDirName
-                        ? deps.bridge.pool.getErrorPopupDetector(errorWorkspaceDirName)
+                        ? deps.bridge.pool.getErrorPopupDetector(
+                            errorWorkspaceDirName,
+                            resolveSelectedAccount(interaction.channelId, interaction.user.id, getParentChannelId(interaction)),
+                        )
                         : undefined;
 
                     if (!errorDetector) {
@@ -459,7 +611,10 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
 
                     const runCmdWorkspace = runCommandAction.projectName ?? deps.bridge.lastActiveWorkspace;
                     const runCmdDetector = runCmdWorkspace
-                        ? deps.bridge.pool.getRunCommandDetector(runCmdWorkspace)
+                        ? deps.bridge.pool.getRunCommandDetector(
+                            runCmdWorkspace,
+                            resolveSelectedAccount(interaction.channelId, interaction.user.id, getParentChannelId(interaction)),
+                        )
                         : undefined;
 
                     if (!runCmdDetector) {
@@ -529,9 +684,14 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
 
                 if (interaction.customId === 'model_set_default_btn') {
                     await interaction.deferUpdate();
-                    const cdp = deps.getCurrentCdp(deps.bridge);
+                    const cdp = getChannelCdp(interaction.channelId, interaction.user.id);
                     if (!cdp) {
                         await interaction.followUp({ content: 'Not connected to CDP.', flags: MessageFlags.Ephemeral });
+                        return;
+                    }
+                    const sessionReady = await ensureBoundSessionActive(interaction.channelId, interaction.user.id, cdp);
+                    if (!sessionReady.ok) {
+                        await interaction.followUp({ content: sessionReady.error, flags: MessageFlags.Ephemeral });
                         return;
                     }
                     const currentModel = await cdp.getCurrentModel();
@@ -546,7 +706,7 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                     await deps.sendModelsUI(
                         { editReply: async (data: any) => await interaction.editReply(data) },
                         {
-                            getCurrentCdp: () => deps.getCurrentCdp(deps.bridge),
+                            getCurrentCdp: () => getChannelCdp(interaction.channelId, interaction.user.id),
                             fetchQuota: async () => deps.bridge.quota.fetchQuota(),
                         },
                     );
@@ -556,6 +716,14 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
 
                 if (interaction.customId === 'model_clear_default_btn') {
                     await interaction.deferUpdate();
+                    const cdp = getChannelCdp(interaction.channelId, interaction.user.id);
+                    if (cdp) {
+                        const sessionReady = await ensureBoundSessionActive(interaction.channelId, interaction.user.id, cdp);
+                        if (!sessionReady.ok) {
+                            await interaction.followUp({ content: sessionReady.error, flags: MessageFlags.Ephemeral });
+                            return;
+                        }
+                    }
                     deps.modelService.setDefaultModel(null);
                     if (deps.userPrefRepo) {
                         deps.userPrefRepo.setDefaultModel(interaction.user.id, null);
@@ -563,7 +731,7 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                     await deps.sendModelsUI(
                         { editReply: async (data: any) => await interaction.editReply(data) },
                         {
-                            getCurrentCdp: () => deps.getCurrentCdp(deps.bridge),
+                            getCurrentCdp: () => getChannelCdp(interaction.channelId, interaction.user.id),
                             fetchQuota: async () => deps.bridge.quota.fetchQuota(),
                         },
                     );
@@ -573,10 +741,18 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
 
                 if (interaction.customId === 'model_refresh_btn') {
                     await interaction.deferUpdate();
+                    const cdp = getChannelCdp(interaction.channelId, interaction.user.id);
+                    if (cdp) {
+                        const sessionReady = await ensureBoundSessionActive(interaction.channelId, interaction.user.id, cdp);
+                        if (!sessionReady.ok) {
+                            await interaction.followUp({ content: sessionReady.error, flags: MessageFlags.Ephemeral });
+                            return;
+                        }
+                    }
                     await deps.sendModelsUI(
                         { editReply: async (data: any) => await interaction.editReply(data) },
                         {
-                            getCurrentCdp: () => deps.getCurrentCdp(deps.bridge),
+                            getCurrentCdp: () => getChannelCdp(interaction.channelId, interaction.user.id),
                             fetchQuota: async () => deps.bridge.quota.fetchQuota(),
                         },
                     );
@@ -587,10 +763,15 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                     await interaction.deferUpdate();
 
                     const modelName = interaction.customId.replace('model_btn_', '');
-                    const cdp = deps.getCurrentCdp(deps.bridge);
+                    const cdp = getChannelCdp(interaction.channelId, interaction.user.id);
 
                     if (!cdp) {
                         await interaction.followUp({ content: 'Not connected to CDP.', flags: MessageFlags.Ephemeral });
+                        return;
+                    }
+                    const sessionReady = await ensureBoundSessionActive(interaction.channelId, interaction.user.id, cdp);
+                    if (!sessionReady.ok) {
+                        await interaction.followUp({ content: sessionReady.error, flags: MessageFlags.Ephemeral });
                         return;
                     }
 
@@ -602,7 +783,7 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                         await deps.sendModelsUI(
                             { editReply: async (data: any) => await interaction.editReply(data) },
                             {
-                                getCurrentCdp: () => deps.getCurrentCdp(deps.bridge),
+                                getCurrentCdp: () => getChannelCdp(interaction.channelId, interaction.user.id),
                                 fetchQuota: async () => deps.bridge.quota.fetchQuota(),
                             },
                         );
@@ -712,7 +893,7 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
 
                 deps.modeService.setMode(selectedMode);
 
-                const cdp = deps.getCurrentCdp(deps.bridge);
+                const cdp = getChannelCdp(interaction.channelId, interaction.user.id);
                 if (cdp) {
                     const res = await cdp.setUiMode(selectedMode);
                     if (!res.ok) {
@@ -727,6 +908,87 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                 try {
                     if (interaction.deferred || interaction.replied) {
                         await interaction.followUp({ content: 'An error occurred while changing the mode.', flags: MessageFlags.Ephemeral }).catch(logger.error);
+                    }
+                } catch (e) {
+                    logger.error('Failed to send error message:', e);
+                }
+            }
+            return;
+        }
+
+        if (interaction.isStringSelectMenu() && interaction.customId === ACCOUNT_SELECT_ID) {
+            if (!deps.config.allowedUserIds.includes(interaction.user.id)) {
+                await interaction.reply({ content: t('You do not have permission.'), flags: MessageFlags.Ephemeral }).catch(logger.error);
+                return;
+            }
+
+            try {
+                await interaction.deferUpdate();
+            } catch (deferError: any) {
+                if (deferError?.code === 10062 || deferError?.code === 40060) {
+                    logger.warn('[Account] deferUpdate expired. Skipping.');
+                    return;
+                }
+                logger.error('[Account] deferUpdate failed:', deferError);
+                return;
+            }
+
+            try {
+                if (!deps.accountPrefRepo) {
+                    await interaction.followUp({
+                        content: 'Account preference service not available.',
+                        flags: MessageFlags.Ephemeral,
+                    }).catch(logger.error);
+                    return;
+                }
+
+                const selectedAccount = interaction.values[0];
+                const names = listAccountNames(deps.antigravityAccounts);
+
+                if (!selectedAccount || !names.includes(selectedAccount)) {
+                    await interaction.followUp({
+                        content: `⚠️ Unknown account: **${selectedAccount || 'N/A'}**`,
+                        flags: MessageFlags.Ephemeral,
+                    }).catch(logger.error);
+                    return;
+                }
+
+                deps.bridge.selectedAccountByChannel?.set(interaction.channelId, selectedAccount);
+                const currentSession = deps.chatSessionRepo?.findByChannelId(interaction.channelId);
+                if (currentSession) {
+                    deps.chatSessionRepo?.setActiveAccountName(interaction.channelId, selectedAccount);
+                } else {
+                    deps.accountPrefRepo.setAccountName(interaction.user.id, selectedAccount);
+                    deps.channelPrefRepo?.setAccountName(interaction.channelId, selectedAccount);
+                }
+
+                const channelWorkspace = deps.wsHandler.getWorkspaceForChannel(interaction.channelId);
+
+                const selectedPort = deps.antigravityAccounts?.find((a) => a.name === selectedAccount)?.cdpPort;
+                logger.info(
+                    `[AccountSwitch] source=select channel=${interaction.channelId} user=${interaction.user.id} ` +
+                    `account=${selectedAccount} port=${selectedPort ?? 'unknown'} ` +
+                    `workspace=${channelWorkspace ?? 'unbound'}`,
+                );
+
+                await sendAccountUI(
+                    { editReply: async (data: any) => await interaction.editReply(data) },
+                    selectedAccount,
+                    names,
+                );
+
+                await interaction.followUp({
+                    content: `✅ Switched session account to **${selectedAccount}**.`,
+                    flags: MessageFlags.Ephemeral,
+                }).catch(logger.error);
+            } catch (error: any) {
+                logger.error('Error during account dropdown handling:', error);
+                try {
+                    if (interaction.deferred || interaction.replied) {
+                        await interaction.followUp({
+                            content: 'An error occurred while switching account.',
+                            flags: MessageFlags.Ephemeral,
+                        }).catch(logger.error);
                     }
                 } catch (e) {
                     logger.error('Failed to send error message:', e);
@@ -774,6 +1036,7 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
             }
 
             try {
+                await interaction.deferUpdate();
                 await deps.wsHandler.handleSelectMenu(interaction, interaction.guild);
             } catch (error) {
                 logger.error('Workspace selection error:', error);
@@ -819,9 +1082,17 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                 deps.modelService,
                 deps.bridge.autoAccept,
                 deps.client,
+                deps.accountPrefRepo,
+                deps.channelPrefRepo,
+                deps.antigravityAccounts,
+                deps.chatSessionRepo,
             );
         } catch (error) {
-            logger.error('Error during slash command handling:', error);
+            logger.error(
+                `[SlashCommand] command=${commandInteraction.commandName} channel=${commandInteraction.channelId} ` +
+                `user=${commandInteraction.user.id} failed:`,
+                error,
+            );
             try {
                 await commandInteraction.editReply({ content: 'An error occurred while processing the command.' });
             } catch (replyError) {

--- a/src/events/messageCreateHandler.ts
+++ b/src/events/messageCreateHandler.ts
@@ -3,6 +3,8 @@ import { EmbedBuilder, Message, TextChannel } from 'discord.js';
 import { parseMessageContent } from '../commands/messageParser';
 import { SlashCommandHandler } from '../commands/slashCommandHandler';
 import { WorkspaceCommandHandler } from '../commands/workspaceCommandHandler';
+import { AccountPreferenceRepository } from '../database/accountPreferenceRepository';
+import { ChannelPreferenceRepository } from '../database/channelPreferenceRepository';
 import { ChatSessionRepository } from '../database/chatSessionRepository';
 import { UserPreferenceRepository } from '../database/userPreferenceRepository';
 import { formatAsPlainText } from '../utils/plainTextFormatter';
@@ -30,6 +32,7 @@ import {
     InboundImageAttachment,
     isImageAttachment as isImageAttachmentFn,
 } from '../utils/imageHandler';
+import { listAccountNames, resolveScopedAccountName } from '../utils/accountUtils';
 import { logger } from '../utils/logger';
 
 export interface MessageCreateHandlerDeps {
@@ -73,6 +76,9 @@ export interface MessageCreateHandlerDeps {
     cleanupInboundImageAttachments?: (attachments: InboundImageAttachment[]) => Promise<void>;
     isImageAttachment?: (contentType: string | null | undefined, fileName: string | null | undefined) => boolean;
     userPrefRepo?: UserPreferenceRepository;
+    accountPrefRepo?: AccountPreferenceRepository;
+    channelPrefRepo?: ChannelPreferenceRepository;
+    antigravityAccounts?: { name: string; cdpPort: number }[];
 }
 
 export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
@@ -86,6 +92,17 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
     const downloadInboundImageAttachments = deps.downloadInboundImageAttachments ?? downloadInboundImageAttachmentsFn;
     const cleanupInboundImageAttachments = deps.cleanupInboundImageAttachments ?? cleanupInboundImageAttachmentsFn;
     const isImageAttachment = deps.isImageAttachment ?? isImageAttachmentFn;
+    const getParentChannelId = (message: Message): string | null => {
+        const parentId = (message.channel as any)?.parentId;
+        return typeof parentId === 'string' && parentId.length > 0 ? parentId : null;
+    };
+
+    const getAccountPort = (accountName: string): number | null => {
+        const match = (deps.antigravityAccounts ?? []).find((account) => account.name === accountName);
+        return match ? match.cdpPort : null;
+    };
+    const getSessionAccountName = (channelId: string): string | null =>
+        deps.chatSessionRepo.findByChannelId(channelId)?.activeAccountName ?? null;
 
     // Per-workspace prompt queue: serializes send→response cycles
     const workspaceQueues = new Map<string, Promise<void>>();
@@ -133,11 +150,26 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
             if (parsed.commandName === 'status') {
                 const activeNames = deps.bridge.pool.getActiveWorkspaceNames();
                 const currentMode = deps.modeService.getCurrentMode();
+                const session = deps.chatSessionRepo.findByChannelId(message.channelId);
+                const currentAccount = resolveScopedAccountName({
+                    channelId: message.channelId,
+                    userId: message.author.id,
+                    sessionAccountName: getSessionAccountName(message.channelId),
+                    parentChannelId: getParentChannelId(message),
+                    selectedAccountByChannel: deps.bridge.selectedAccountByChannel,
+                    channelPrefRepo: deps.channelPrefRepo,
+                    accountPrefRepo: deps.accountPrefRepo,
+                    accounts: deps.antigravityAccounts,
+                });
+                const conversationTitle = session?.displayName ?? '(New chat / no saved title)';
 
                 const statusFields = [
                     { name: 'CDP Connection', value: activeNames.length > 0 ? `🟢 ${activeNames.length} project(s) connected` : '⚪ Disconnected', inline: true },
                     { name: 'Mode', value: MODE_DISPLAY_NAMES[currentMode] || currentMode, inline: true },
                     { name: 'Auto Approve', value: deps.bridge.autoAccept.isEnabled() ? '🟢 ON' : '⚪ OFF', inline: true },
+                    { name: 'Active Account', value: currentAccount, inline: true },
+                    { name: 'Original Account', value: session?.originAccountName ?? '(unset)', inline: true },
+                    { name: 'Conversation Title', value: conversationTitle, inline: false },
                 ];
 
                 let statusDescription = '';
@@ -174,6 +206,51 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
                     .setTimestamp();
 
                 await message.reply({ embeds: [embed] });
+                return;
+            }
+
+            if (parsed.commandName === 'account') {
+                const accountNames = listAccountNames(deps.antigravityAccounts);
+                const requested = parsed.args?.[0];
+
+                if (!requested) {
+                    const current = resolveScopedAccountName({
+                        channelId: message.channelId,
+                        userId: message.author.id,
+                        sessionAccountName: getSessionAccountName(message.channelId),
+                        parentChannelId: getParentChannelId(message),
+                        selectedAccountByChannel: deps.bridge.selectedAccountByChannel,
+                        channelPrefRepo: deps.channelPrefRepo,
+                        accountPrefRepo: deps.accountPrefRepo,
+                        accounts: deps.antigravityAccounts,
+                    });
+                    await message.reply(`Current account: **${current}**\nAvailable: ${accountNames.join(', ')}`).catch(() => {});
+                    return;
+                }
+
+                if (!accountNames.includes(requested)) {
+                    await message.reply(`⚠️ Unknown account: **${requested}**`).catch(() => {});
+                    return;
+                }
+
+                deps.bridge.selectedAccountByChannel?.set(message.channelId, requested);
+                const currentSession = deps.chatSessionRepo.findByChannelId(message.channelId);
+                if (currentSession) {
+                    deps.chatSessionRepo.setActiveAccountName(message.channelId, requested);
+                } else {
+                    deps.accountPrefRepo?.setAccountName(message.author.id, requested);
+                    deps.channelPrefRepo?.setAccountName(message.channelId, requested);
+                }
+
+                const channelWorkspace = deps.wsHandler.getWorkspaceForChannel(message.channelId);
+
+                logger.info(
+                    `[AccountSwitch] source=text channel=${message.channelId} user=${message.author.id} ` +
+                    `account=${requested} port=${getAccountPort(requested) ?? 'unknown'} ` +
+                    `workspace=${channelWorkspace ?? 'unbound'}`,
+                );
+
+                await message.reply(`✅ Switched session account to **${requested}**.`).catch(() => {});
                 return;
             }
 
@@ -259,20 +336,61 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
                         }
 
                         try {
-                            const cdp = await deps.bridge.pool.getOrConnect(workspacePath);
+                            const selectedAccount = resolveScopedAccountName({
+                                channelId: message.channelId,
+                                userId: message.author.id,
+                                sessionAccountName: getSessionAccountName(message.channelId),
+                                parentChannelId: getParentChannelId(message),
+                                selectedAccountByChannel: deps.bridge.selectedAccountByChannel,
+                                channelPrefRepo: deps.channelPrefRepo,
+                                accountPrefRepo: deps.accountPrefRepo,
+                                accounts: deps.antigravityAccounts,
+                            });
+                            const selectedPort = getAccountPort(selectedAccount);
+                            deps.bridge.selectedAccountByChannel?.set(message.channelId, selectedAccount);
+
+                            logger.info(
+                                `[Route] channel=${message.channelId} user=${message.author.id} ` +
+                                `project=${projectLabel} account=${selectedAccount} ` +
+                                `port=${selectedPort ?? 'unknown'} workspacePath=${workspacePath}`,
+                            );
+
+                            const previousPreferredAccount = deps.bridge.pool.getPreferredAccountForWorkspace?.(workspacePath) ?? null;
+                            const cdp = await deps.bridge.pool.getOrConnect(workspacePath, { name: selectedAccount });
                             const projectName = deps.bridge.pool.extractProjectName(workspacePath);
+                            deps.bridge.pool.setPreferredAccountForWorkspace?.(workspacePath, selectedAccount);
 
                             deps.bridge.lastActiveWorkspace = projectName;
                             const platformChannel = wrapDiscordChannel(message.channel as TextChannel);
                             deps.bridge.lastActiveChannel = platformChannel;
                             registerApprovalWorkspaceChannel(deps.bridge, projectName, platformChannel);
 
-                            ensureApprovalDetector(deps.bridge, cdp, projectName);
-                            ensureErrorPopupDetector(deps.bridge, cdp, projectName);
-                            ensurePlanningDetector(deps.bridge, cdp, projectName);
-                            ensureRunCommandDetector(deps.bridge, cdp, projectName);
+                            ensureApprovalDetector(deps.bridge, cdp, projectName, selectedAccount);
+                            ensureErrorPopupDetector(deps.bridge, cdp, projectName, selectedAccount);
+                            ensurePlanningDetector(deps.bridge, cdp, projectName, selectedAccount);
+                            ensureRunCommandDetector(deps.bridge, cdp, projectName, selectedAccount);
 
-                            const session = deps.chatSessionRepo.findByChannelId(message.channelId);
+                            let session = deps.chatSessionRepo.findByChannelId(message.channelId);
+                            const staleSessionAccount = session?.isRenamed
+                                && (
+                                    (session.activeAccountName && session.activeAccountName !== selectedAccount)
+                                    || (!session.activeAccountName && previousPreferredAccount && previousPreferredAccount !== selectedAccount)
+                                );
+                            if (session && staleSessionAccount) {
+                                logger.info(
+                                    `[SessionAccountReset] channel=${message.channelId} ` +
+                                    `project=${projectName} oldAccount=${session.activeAccountName ?? previousPreferredAccount ?? 'unknown'} ` +
+                                    `newAccount=${selectedAccount}`,
+                                );
+                                deps.chatSessionRepo.setActiveAccountName?.(message.channelId, selectedAccount);
+                                session = deps.chatSessionRepo.findByChannelId(message.channelId);
+                            }
+
+                            if (session) {
+                                deps.chatSessionRepo.setActiveAccountName?.(message.channelId, selectedAccount);
+                                deps.chatSessionRepo.initializeOriginAccountName?.(message.channelId, selectedAccount);
+                            }
+
                             if (session?.displayName) {
                                 registerApprovalSessionChannel(deps.bridge, projectName, session.displayName, platformChannel);
                             }
@@ -304,6 +422,8 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
                                                     `(channel: ${message.channelId})`,
                                                 );
                                                 deps.chatSessionRepo.updateDisplayName(message.channelId, recoveredTitle);
+                                                deps.chatSessionRepo.setActiveAccountName?.(message.channelId, selectedAccount);
+                                                deps.chatSessionRepo.initializeOriginAccountName?.(message.channelId, selectedAccount);
                                                 registerApprovalSessionChannel(deps.bridge, projectName, recoveredTitle, platformChannel);
                                             }
                                             activationResult = retryResult;
@@ -408,7 +528,10 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
                         }
                     });
                 } else {
-                    await message.reply('No project is configured for this channel. Please create or select one with `/project`.');
+                    await message.reply(
+                        'No project is configured for this channel. Use `/project` to bind one, ' +
+                        'or `/project reopen` if this is a previously used session.',
+                    );
                 }
             } finally {
                 await cleanupInboundImageAttachments(inboundImages);

--- a/src/handlers/accountSelectAction.ts
+++ b/src/handlers/accountSelectAction.ts
@@ -1,0 +1,70 @@
+import type { PlatformSelectInteraction } from '../platform/types';
+import type { SelectAction } from './selectHandler';
+import type { CdpBridge } from '../services/cdpBridgeManager';
+import type { AntigravityAccountConfig } from '../utils/configLoader';
+import type { AccountPreferenceRepository } from '../database/accountPreferenceRepository';
+import type { ChannelPreferenceRepository } from '../database/channelPreferenceRepository';
+import type { ChatSessionRepository } from '../database/chatSessionRepository';
+import { listAccountNames } from '../utils/accountUtils';
+import { ACCOUNT_SELECT_ID, buildAccountPayload } from '../ui/accountUi';
+import { logger } from '../utils/logger';
+
+export interface AccountSelectActionDeps {
+    readonly bridge: CdpBridge;
+    readonly accountPrefRepo: AccountPreferenceRepository;
+    readonly channelPrefRepo?: ChannelPreferenceRepository;
+    readonly chatSessionRepo?: ChatSessionRepository;
+    readonly getWorkspacePathForChannel?: (channelId: string) => string | null | undefined;
+    readonly antigravityAccounts: AntigravityAccountConfig[];
+}
+
+export function createAccountSelectAction(deps: AccountSelectActionDeps): SelectAction {
+    return {
+        match(customId: string): boolean {
+            return customId === ACCOUNT_SELECT_ID;
+        },
+
+        async execute(
+            interaction: PlatformSelectInteraction,
+            values: readonly string[],
+        ): Promise<void> {
+            const selectedAccount = values[0];
+            if (!selectedAccount) return;
+
+            const names = listAccountNames(deps.antigravityAccounts);
+
+            if (!names.includes(selectedAccount)) {
+                await interaction.followUp({
+                    text: `⚠️ Unknown account: **${selectedAccount}**`,
+                }).catch(() => {});
+                return;
+            }
+
+            await interaction.deferUpdate();
+
+            deps.bridge.selectedAccountByChannel?.set(interaction.channel.id, selectedAccount);
+            const currentSession = deps.chatSessionRepo?.findByChannelId(interaction.channel.id);
+            if (currentSession) {
+                deps.chatSessionRepo?.setActiveAccountName(interaction.channel.id, selectedAccount);
+            } else {
+                deps.accountPrefRepo.setAccountName(interaction.user.id, selectedAccount);
+                deps.channelPrefRepo?.setAccountName(interaction.channel.id, selectedAccount);
+            }
+
+            const channelWorkspace = deps.getWorkspacePathForChannel?.(interaction.channel.id) ?? null;
+
+            const selectedPort = deps.antigravityAccounts.find((a) => a.name === selectedAccount)?.cdpPort;
+            logger.info(
+                `[AccountSwitch] source=select channel=${interaction.channel.id} user=${interaction.user.id} ` +
+                `account=${selectedAccount} port=${selectedPort ?? 'unknown'} ` +
+                `workspace=${channelWorkspace ?? 'unbound'}`,
+            );
+
+            const payload = buildAccountPayload(selectedAccount, names);
+            await interaction.update(payload);
+            await interaction.followUp({
+                text: `✅ Switched session account to **${selectedAccount}**.`,
+            }).catch(() => {});
+        },
+    };
+}

--- a/src/handlers/modelButtonAction.ts
+++ b/src/handlers/modelButtonAction.ts
@@ -19,6 +19,7 @@ export interface ModelButtonActionDeps {
     readonly fetchQuota: () => Promise<any[]>;
     readonly modelService?: ModelService;
     readonly userPrefRepo?: UserPreferenceRepository;
+    readonly ensureSessionActivated?: (channelId: string, userId: string, cdp: NonNullable<ReturnType<typeof getCurrentCdp>>) => Promise<{ ok: true } | { ok: false; error: string }>;
 }
 
 export function createModelButtonAction(deps: ModelButtonActionDeps): ButtonAction {
@@ -44,8 +45,16 @@ export function createModelButtonAction(deps: ModelButtonActionDeps): ButtonActi
 
             const cdp = getCurrentCdp(deps.bridge);
             if (!cdp) {
+                logger.warn(`[ModelCommand] source=button user=${interaction.user.id} action=${params.action} cdp=unavailable`);
                 await interaction.followUp({ text: 'Not connected to CDP.' }).catch(() => {});
                 return;
+            }
+            if (deps.ensureSessionActivated) {
+                const sessionReady = await deps.ensureSessionActivated(interaction.channel.id, interaction.user.id, cdp);
+                if (!sessionReady.ok) {
+                    await interaction.followUp({ text: sessionReady.error }).catch(() => {});
+                    return;
+                }
             }
 
             if (params.action === 'set_default') {
@@ -76,7 +85,14 @@ export function createModelButtonAction(deps: ModelButtonActionDeps): ButtonActi
                     text: 'Default model cleared.',
                 }).catch(() => {});
             } else if (params.action === 'select') {
+                logger.info(`[ModelCommand] source=button user=${interaction.user.id} target="${params.modelName}"`);
                 const res = await cdp.setUiModel(params.modelName);
+                logger.info(
+                    `[ModelCommand] source=button user=${interaction.user.id} target="${params.modelName}" ` +
+                    `ok=${res.ok} applied=${res.model ? `"${res.model}"` : 'null'} ` +
+                    `verified=${res.verified === true} alreadySelected=${res.alreadySelected === true} ` +
+                    `error=${res.error ? `"${res.error}"` : 'null'}`,
+                );
                 if (!res.ok) {
                     await interaction.followUp({
                         text: res.error || 'Failed to change model.',

--- a/src/services/antigravityAccountDiscovery.ts
+++ b/src/services/antigravityAccountDiscovery.ts
@@ -1,0 +1,332 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFile } from 'child_process';
+import type { AntigravityAccountConfig } from '../utils/configLoader';
+import { DEFAULT_CDP_PORTS } from '../utils/cdpPorts';
+
+export interface DiscoveredAccount extends AntigravityAccountConfig {
+    source: string;
+}
+
+export interface DiscoveryResult {
+    accounts: DiscoveredAccount[];
+    warnings: string[];
+}
+
+interface CockpitInstanceRecord {
+    name?: unknown;
+    userDataDir?: unknown;
+    extraArgs?: unknown;
+}
+
+function normalizeName(rawName: string, fallbackPort: number): string {
+    const trimmed = rawName.trim().toLowerCase();
+    const sanitized = trimmed
+        .replace(/[^a-z0-9._-]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+    return sanitized || `account-${fallbackPort}`;
+}
+
+function extractPort(raw: string | undefined): number | null {
+    if (!raw) return null;
+    const match = raw.match(/--remote-debugging-port(?:=|\s+)(\d+)/);
+    if (!match) return null;
+    const port = Number(match[1]);
+    return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : null;
+}
+
+function extractUserDataDir(raw: string | undefined): string | null {
+    if (!raw) return null;
+
+    const quotedMatch = raw.match(/--user-data-dir(?:=|\s+)("([^"]+)"|'([^']+)')/);
+    if (quotedMatch) {
+        return quotedMatch[2] || quotedMatch[3] || null;
+    }
+
+    const unquotedMatch = raw.match(/--user-data-dir(?:=|\s+)(.+?)(?=\s+--[\w-]+|$)/);
+    if (!unquotedMatch) return null;
+
+    const value = unquotedMatch[1].trim();
+    return value.length > 0 ? value : null;
+}
+
+function getDefaultAntigravityUserDataDir(): string {
+    const home = os.homedir();
+    if (process.platform === 'darwin') {
+        return path.join(home, 'Library', 'Application Support', 'Antigravity');
+    }
+    if (process.platform === 'win32') {
+        const appData = process.env.APPDATA ?? path.join(home, 'AppData', 'Roaming');
+        return path.join(appData, 'Antigravity');
+    }
+    return path.join(home, '.config', 'Antigravity');
+}
+
+function parseCommandLineAccount(line: string): AntigravityAccountConfig | null {
+    if (!/antigravity/i.test(line)) return null;
+
+    const cdpPort = extractPort(line);
+    const userDataDir = extractUserDataDir(line);
+
+    if (cdpPort === null || !userDataDir) return null;
+
+    return {
+        name: normalizeName(path.basename(userDataDir), cdpPort),
+        cdpPort,
+        userDataDir,
+    };
+}
+
+function listCockpitCandidateDirs(): string[] {
+    const home = os.homedir();
+
+    if (process.platform === 'darwin') {
+        return [
+            path.join(home, '.antigravity_cockpit'),
+            path.join(home, 'Library', 'Application Support', 'com.antigravity.cockpit-tools'),
+            path.join(home, 'Library', 'Application Support', 'cockpit-tools'),
+            path.join(home, 'Library', 'Application Support', 'antigravity-cockpit-tools'),
+            path.join(home, 'Library', 'Application Support', 'com.lbjlaq.antigravity-tools'),
+        ];
+    }
+
+    if (process.platform === 'win32') {
+        const appData = process.env.APPDATA ?? path.join(home, 'AppData', 'Roaming');
+        return [
+            path.join(home, '.antigravity_cockpit'),
+            path.join(appData, 'com.antigravity.cockpit-tools'),
+            path.join(appData, 'cockpit-tools'),
+            path.join(appData, 'antigravity-cockpit-tools'),
+            path.join(appData, 'com.lbjlaq.antigravity-tools'),
+        ];
+    }
+
+    return [
+        path.join(home, '.antigravity_cockpit'),
+        path.join(home, '.config', 'com.antigravity.cockpit-tools'),
+        path.join(home, '.config', 'cockpit-tools'),
+        path.join(home, '.config', 'antigravity-cockpit-tools'),
+        path.join(home, '.config', 'com.lbjlaq.antigravity-tools'),
+    ];
+}
+
+export function hasCockpitSettings(): boolean {
+    const instancesPath = path.join(os.homedir(), '.antigravity_cockpit', 'instances.json');
+    if (fs.existsSync(instancesPath)) {
+        return true;
+    }
+
+    return listCockpitCandidateDirs().some((dir) => fs.existsSync(dir));
+}
+
+function collectJsonFiles(rootDir: string, depth: number = 3): string[] {
+    if (!fs.existsSync(rootDir)) return [];
+
+    const results: string[] = [];
+    const queue: Array<{ dir: string; depth: number }> = [{ dir: rootDir, depth: 0 }];
+
+    while (queue.length > 0) {
+        const current = queue.shift();
+        if (!current) continue;
+
+        let entries: fs.Dirent[];
+        try {
+            entries = fs.readdirSync(current.dir, { withFileTypes: true });
+        } catch {
+            continue;
+        }
+
+        for (const entry of entries) {
+            const fullPath = path.join(current.dir, entry.name);
+            if (entry.isSymbolicLink()) {
+                continue;
+            }
+            if (entry.isDirectory()) {
+                if (current.depth < depth) {
+                    queue.push({ dir: fullPath, depth: current.depth + 1 });
+                }
+                continue;
+            }
+
+            if (entry.isFile() && entry.name.toLowerCase().endsWith('.json')) {
+                results.push(fullPath);
+            }
+        }
+    }
+
+    return results;
+}
+
+function parseJsonTextForAccounts(raw: string): AntigravityAccountConfig[] {
+    const matches: AntigravityAccountConfig[] = [];
+    const pairPattern = /"name"\s*:\s*"([^"]+)"[\s\S]{0,400}?"(?:cdpPort|port|remoteDebuggingPort|remote_debugging_port)"\s*:\s*(\d+)[\s\S]{0,400}?"(?:userDataDir|user_data_dir|user-data-dir)"\s*:\s*"([^"]+)"/g;
+
+    let pairMatch: RegExpExecArray | null;
+    while ((pairMatch = pairPattern.exec(raw)) !== null) {
+        matches.push({
+            name: normalizeName(pairMatch[1], Number(pairMatch[2])),
+            cdpPort: Number(pairMatch[2]),
+            userDataDir: pairMatch[3],
+        });
+    }
+
+    const flagPattern = /--remote-debugging-port(?:=|\s+)(\d+)[\s\S]{0,200}--user-data-dir(?:=|\s+)("([^"]+)"|'([^']+)'|([^\s",]+))/g;
+    let flagMatch: RegExpExecArray | null;
+    while ((flagMatch = flagPattern.exec(raw)) !== null) {
+        const cdpPort = Number(flagMatch[1]);
+        const userDataDir = flagMatch[3] || flagMatch[4] || flagMatch[5];
+        if (!Number.isInteger(cdpPort) || !userDataDir) continue;
+        matches.push({
+            name: normalizeName(path.basename(userDataDir), cdpPort),
+            cdpPort,
+            userDataDir,
+        });
+    }
+
+    return matches;
+}
+
+function readCockpitInstancesFile(filePath: string): CockpitInstanceRecord[] {
+    if (!fs.existsSync(filePath)) return [];
+
+    try {
+        const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as { instances?: CockpitInstanceRecord[] };
+        return Array.isArray(parsed.instances) ? parsed.instances : [];
+    } catch {
+        return [];
+    }
+}
+
+function nextAvailablePort(usedPorts: Set<number>): number {
+    for (const port of DEFAULT_CDP_PORTS) {
+        if (!usedPorts.has(port)) return port;
+    }
+
+    let candidate = Math.max(...DEFAULT_CDP_PORTS, 9222) + 1;
+    while (usedPorts.has(candidate)) {
+        candidate += 1;
+    }
+    return candidate;
+}
+
+function parseCockpitInstances(
+    records: CockpitInstanceRecord[],
+    usedPorts: Set<number>,
+): DiscoveryResult {
+    const accounts: DiscoveredAccount[] = [];
+    const warnings: string[] = [];
+
+    for (const record of records) {
+        const userDataDir = typeof record.userDataDir === 'string' ? record.userDataDir.trim() : '';
+        if (!userDataDir) continue;
+
+        const recordName = typeof record.name === 'string' ? record.name : path.basename(userDataDir);
+        let cdpPort = extractPort(typeof record.extraArgs === 'string' ? record.extraArgs : undefined);
+        if (cdpPort === null) {
+            cdpPort = nextAvailablePort(usedPorts);
+            warnings.push(`Auto-assigned CDP port ${cdpPort} for "${recordName}" because cockpit extraArgs did not set --remote-debugging-port.`);
+        }
+
+        usedPorts.add(cdpPort);
+        accounts.push({
+            name: normalizeName(recordName, cdpPort),
+            cdpPort,
+            userDataDir,
+            source: 'file:' + path.join(os.homedir(), '.antigravity_cockpit', 'instances.json'),
+        });
+    }
+
+    const defaultUserDataDir = getDefaultAntigravityUserDataDir();
+    const hasDefaultMapping = accounts.some((account) => account.userDataDir === defaultUserDataDir);
+    if (!hasDefaultMapping) {
+        warnings.push(
+            `No cockpit instance explicitly uses the default Antigravity profile directory (${defaultUserDataDir}). ` +
+            'Create one in cockpit for the default instance, otherwise cockpit may not reopen that default instance correctly when another work instance is already open.',
+        );
+    }
+
+    return { accounts, warnings };
+}
+
+async function getProcessCommandLines(): Promise<string[]> {
+    const run = (command: string, args: string[]): Promise<string> =>
+        new Promise((resolve, reject) => {
+            execFile(command, args, { windowsHide: true, maxBuffer: 20 * 1024 * 1024 }, (error, stdout) => {
+                if (error) {
+                    reject(error);
+                    return;
+                }
+                resolve(stdout);
+            });
+        });
+
+    try {
+        if (process.platform === 'win32') {
+            const stdout = await run('powershell', [
+                '-NoProfile',
+                '-Command',
+                "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -and $_.CommandLine -match 'antigravity' } | Select-Object -ExpandProperty CommandLine",
+            ]);
+            return stdout.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+        }
+
+        const stdout = await run('/bin/sh', ['-lc', "ps -Ao args= | grep -i antigravity | grep -v grep"]);
+        return stdout.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+    } catch {
+        return [];
+    }
+}
+
+export async function discoverAntigravityAccounts(
+    existingAccounts: readonly AntigravityAccountConfig[] = [],
+): Promise<DiscoveryResult> {
+    const discovered = new Map<string, DiscoveredAccount>();
+    const warnings: string[] = [];
+    const usedPorts = new Set<number>(existingAccounts.map((account) => account.cdpPort));
+
+    const cockpitInstancesPath = path.join(os.homedir(), '.antigravity_cockpit', 'instances.json');
+    const cockpitResult = parseCockpitInstances(readCockpitInstancesFile(cockpitInstancesPath), usedPorts);
+    for (const account of cockpitResult.accounts) {
+        discovered.set(account.name, account);
+    }
+    warnings.push(...cockpitResult.warnings);
+
+    for (const line of await getProcessCommandLines()) {
+        const account = parseCommandLineAccount(line);
+        if (!account) continue;
+
+        const alreadyKnown = [...discovered.values()].some((existing) =>
+            existing.cdpPort === account.cdpPort ||
+            existing.userDataDir === account.userDataDir,
+        );
+        if (discovered.has(account.name) || alreadyKnown) continue;
+
+        usedPorts.add(account.cdpPort);
+        discovered.set(account.name, { ...account, source: 'running-process' });
+    }
+
+    for (const dir of listCockpitCandidateDirs()) {
+        for (const filePath of collectJsonFiles(dir)) {
+            if (filePath === cockpitInstancesPath) continue;
+
+            let raw = '';
+            try {
+                raw = fs.readFileSync(filePath, 'utf-8');
+            } catch {
+                continue;
+            }
+
+            for (const account of parseJsonTextForAccounts(raw)) {
+                if (discovered.has(account.name) || usedPorts.has(account.cdpPort)) continue;
+                usedPorts.add(account.cdpPort);
+                discovered.set(account.name, { ...account, source: `file:${filePath}` });
+            }
+        }
+    }
+
+    return {
+        accounts: [...discovered.values()].sort((a, b) => a.name.localeCompare(b.name)),
+        warnings,
+    };
+}

--- a/src/services/antigravityProcessService.ts
+++ b/src/services/antigravityProcessService.ts
@@ -1,0 +1,237 @@
+import { execFile } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { resolveAntigravityProfilePaths } from './conversationTransferService';
+
+interface CockpitInstancesFile {
+    instances?: Array<{
+        name?: unknown;
+        userDataDir?: unknown;
+        lastPid?: unknown;
+        extraArgs?: unknown;
+    }>;
+    defaultSettings?: {
+        extraArgs?: unknown;
+        lastPid?: unknown;
+    };
+}
+
+interface RunningProcess {
+    pid: number;
+    ppid: number;
+    args: string;
+}
+
+function readCockpitInstances(): CockpitInstancesFile {
+    const instancesPath = path.join(os.homedir(), '.antigravity_cockpit', 'instances.json');
+    if (!fs.existsSync(instancesPath)) {
+        return {};
+    }
+
+    try {
+        return JSON.parse(fs.readFileSync(instancesPath, 'utf8')) as CockpitInstancesFile;
+    } catch {
+        return {};
+    }
+}
+
+function getRecordedPid(profileName: string, userDataDir: string): number | null {
+    const parsed = readCockpitInstances();
+    const match = parsed.instances?.find((instance) => {
+        const name = typeof instance.name === 'string' ? instance.name.trim().toLowerCase() : '';
+        const dir = typeof instance.userDataDir === 'string' ? instance.userDataDir.trim() : '';
+        return name === profileName.trim().toLowerCase() || dir === userDataDir;
+    });
+
+    const rawPid = match?.lastPid;
+    return Number.isInteger(rawPid) && Number(rawPid) > 0 ? Number(rawPid) : null;
+}
+
+function extractRemoteDebuggingPort(extraArgs: unknown): number | null {
+    if (typeof extraArgs !== 'string' || extraArgs.trim().length === 0) {
+        return null;
+    }
+
+    const match = extraArgs.match(/--remote-debugging-port=(\d+)/);
+    if (!match) {
+        return null;
+    }
+
+    const port = Number(match[1]);
+    return Number.isInteger(port) && port > 0 ? port : null;
+}
+
+function getRecordedPort(profileName: string, userDataDir: string): number | null {
+    const parsed = readCockpitInstances();
+    const normalizedProfile = profileName.trim().toLowerCase();
+
+    if (normalizedProfile === 'default') {
+        const defaultPort = extractRemoteDebuggingPort(parsed.defaultSettings?.extraArgs);
+        if (defaultPort) {
+            return defaultPort;
+        }
+    }
+
+    const match = parsed.instances?.find((instance) => {
+        const name = typeof instance.name === 'string' ? instance.name.trim().toLowerCase() : '';
+        const dir = typeof instance.userDataDir === 'string' ? instance.userDataDir.trim() : '';
+        return name === normalizedProfile || dir === userDataDir;
+    });
+
+    return extractRemoteDebuggingPort(match?.extraArgs);
+}
+
+function isAntigravityProcess(args: string): boolean {
+    const lowered = args.toLowerCase();
+    return lowered.includes('/applications/antigravity.app/') || lowered.includes(' antigravity');
+}
+
+function isAntigravityMainProcess(args: string): boolean {
+    const lowered = args.toLowerCase();
+    return lowered.includes('/applications/antigravity.app/contents/macos/electron')
+        || lowered.includes('/applications/antigravity.app/contents/macos/antigravity')
+        || lowered.includes('\\antigravity.exe')
+        || lowered.includes('/antigravity.exe')
+        || (lowered.includes('antigravity') && lowered.includes('--remote-debugging-port'));
+}
+
+function findRootAntigravityPid(processes: RunningProcess[], startPid: number): number {
+    const byPid = new Map(processes.map((proc) => [proc.pid, proc]));
+    let current = byPid.get(startPid);
+    let lastAntigravityPid = startPid;
+
+    while (current) {
+        if (isAntigravityProcess(current.args)) {
+            lastAntigravityPid = current.pid;
+        }
+
+        const parent = byPid.get(current.ppid);
+        if (!parent || !isAntigravityProcess(parent.args)) {
+            break;
+        }
+        current = parent;
+    }
+
+    return lastAntigravityPid;
+}
+
+function execFileAsync(command: string, args: string[]): Promise<string> {
+    return new Promise((resolve, reject) => {
+        execFile(command, args, { maxBuffer: 10 * 1024 * 1024 }, (error, stdout) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+            resolve(stdout);
+        });
+    });
+}
+
+async function listRunningProcesses(): Promise<RunningProcess[]> {
+    const stdout = await execFileAsync('ps', ['-Ao', 'pid,ppid,args']);
+    return stdout
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line) => {
+            const match = line.match(/^(\d+)\s+(\d+)\s+(.+)$/);
+            if (!match) {
+                return null;
+            }
+            return {
+                pid: Number(match[1]),
+                ppid: Number(match[2]),
+                args: match[3],
+            };
+        })
+        .filter((item): item is RunningProcess => !!item);
+}
+
+function isPidAlive(pid: number): boolean {
+    try {
+        process.kill(pid, 0);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+export async function findRunningAntigravityPid(profileName: string): Promise<number | null> {
+    const profile = resolveAntigravityProfilePaths(profileName);
+    const processes = await listRunningProcesses().catch(() => []);
+    const recordedPort = getRecordedPort(profile.profileName, profile.userDataDir);
+    const normalizedDir = profile.userDataDir.toLowerCase();
+
+    if (recordedPort) {
+        const byPort = processes.find((proc) => {
+            const args = proc.args.toLowerCase();
+            return isAntigravityMainProcess(args) && args.includes(`--remote-debugging-port=${recordedPort}`);
+        });
+        if (byPort) {
+            return byPort.pid;
+        }
+    }
+
+    const recordedPid = getRecordedPid(profile.profileName, profile.userDataDir);
+    if (recordedPid && isPidAlive(recordedPid)) {
+        const proc = processes.find((candidate) => candidate.pid === recordedPid);
+        if (proc && isAntigravityProcess(proc.args)) {
+            return findRootAntigravityPid(processes, recordedPid);
+        }
+    }
+
+    const matched = processes.find((proc) => {
+        const args = proc.args.toLowerCase();
+        return isAntigravityProcess(args) && args.includes(normalizedDir);
+    });
+    if (matched) {
+        return findRootAntigravityPid(processes, matched.pid);
+    }
+
+    return null;
+}
+
+async function isProfileStopped(profileName: string): Promise<boolean> {
+    const profile = resolveAntigravityProfilePaths(profileName);
+    const processes = await listRunningProcesses().catch(() => []);
+    const recordedPort = getRecordedPort(profile.profileName, profile.userDataDir);
+    const normalizedDir = profile.userDataDir.toLowerCase();
+
+    const hasMain = recordedPort
+        ? processes.some((proc) => {
+            const args = proc.args.toLowerCase();
+            return isAntigravityMainProcess(args) && args.includes(`--remote-debugging-port=${recordedPort}`);
+        })
+        : false;
+
+    const hasProfileProcess = processes.some((proc) => {
+        const args = proc.args.toLowerCase();
+        return isAntigravityProcess(args) && args.includes(normalizedDir);
+    });
+
+    return !hasMain && !hasProfileProcess;
+}
+
+export async function quitAntigravityProfile(profileName: string, timeoutMs = 15000): Promise<boolean> {
+    const pid = await findRunningAntigravityPid(profileName);
+    if (!pid) {
+        return true;
+    }
+
+    try {
+        process.kill(pid, 'SIGTERM');
+    } catch {
+        return false;
+    }
+
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() <= deadline) {
+        if (!isPidAlive(pid) && await isProfileStopped(profileName)) {
+            return true;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+
+    return false;
+}

--- a/src/services/cdpBridgeManager.ts
+++ b/src/services/cdpBridgeManager.ts
@@ -32,6 +32,8 @@ export interface CdpBridge {
     approvalChannelByWorkspace: Map<string, PlatformChannel>;
     /** Session-level approval notification destination (workspace+sessionTitle -> channel) */
     approvalChannelBySession: Map<string, PlatformChannel>;
+    /** Channel-scoped preferred Antigravity account selection. */
+    selectedAccountByChannel?: Map<string, string>;
 }
 
 const APPROVE_ACTION_PREFIX = 'approve_action';
@@ -275,8 +277,14 @@ export function parseRunCommandCustomId(customId: string): { action: 'run' | 're
 }
 
 /** Initialize the CDP bridge (lazy connection: pool creation only) */
-export function initCdpBridge(autoApproveDefault: boolean): CdpBridge {
+export function initCdpBridge(
+    autoApproveDefault: boolean,
+    accountPorts: Record<string, number> = {},
+    accountUserDataDirs: Record<string, string> = {},
+): CdpBridge {
     const pool = new CdpConnectionPool({
+        accountPorts,
+        accountUserDataDirs,
         cdpCallTimeout: 15000,
         // Keep CDP reconnection lazy: do not reopen windows in background.
         // Reconnection is triggered when the next chat/template message is sent.
@@ -295,6 +303,7 @@ export function initCdpBridge(autoApproveDefault: boolean): CdpBridge {
         lastActiveChannel: null,
         approvalChannelByWorkspace: new Map(),
         approvalChannelBySession: new Map(),
+        selectedAccountByChannel: new Map(),
     };
 }
 
@@ -316,8 +325,9 @@ export function ensureApprovalDetector(
     bridge: CdpBridge,
     cdp: CdpService,
     projectName: string,
+    accountName: string = 'default',
 ): void {
-    const existing = bridge.pool.getApprovalDetector(projectName);
+    const existing = bridge.pool.getApprovalDetector(projectName, accountName);
     if (existing && existing.isActive()) return;
 
     // Track the most recent notification for auto-disable on resolve.
@@ -390,7 +400,7 @@ export function ensureApprovalDetector(
     });
 
     detector.start();
-    bridge.pool.registerApprovalDetector(projectName, detector);
+    bridge.pool.registerApprovalDetector(projectName, detector, accountName);
     logger.debug(`[ApprovalDetector:${projectName}] Started approval button detection`);
 }
 
@@ -402,8 +412,9 @@ export function ensurePlanningDetector(
     bridge: CdpBridge,
     cdp: CdpService,
     projectName: string,
+    accountName: string = 'default',
 ): void {
-    const existing = bridge.pool.getPlanningDetector(projectName);
+    const existing = bridge.pool.getPlanningDetector(projectName, accountName);
     if (existing && existing.isActive()) return;
 
     // Track the most recent planning notification for auto-disable on resolve.
@@ -464,7 +475,7 @@ export function ensurePlanningDetector(
     });
 
     detector.start();
-    bridge.pool.registerPlanningDetector(projectName, detector);
+    bridge.pool.registerPlanningDetector(projectName, detector, accountName);
     logger.debug(`[PlanningDetector:${projectName}] Started planning button detection`);
 }
 
@@ -476,8 +487,9 @@ export function ensureErrorPopupDetector(
     bridge: CdpBridge,
     cdp: CdpService,
     projectName: string,
+    accountName: string = 'default',
 ): void {
-    const existing = bridge.pool.getErrorPopupDetector(projectName);
+    const existing = bridge.pool.getErrorPopupDetector(projectName, accountName);
     if (existing && existing.isActive()) return;
 
     // Track the most recent error notification for auto-disable on resolve.
@@ -533,7 +545,7 @@ export function ensureErrorPopupDetector(
     });
 
     detector.start();
-    bridge.pool.registerErrorPopupDetector(projectName, detector);
+    bridge.pool.registerErrorPopupDetector(projectName, detector, accountName);
     logger.debug(`[ErrorPopupDetector:${projectName}] Started error popup detection`);
 }
 
@@ -546,8 +558,9 @@ export function ensureRunCommandDetector(
     bridge: CdpBridge,
     cdp: CdpService,
     projectName: string,
+    accountName: string = 'default',
 ): void {
-    const existing = bridge.pool.getRunCommandDetector(projectName);
+    const existing = bridge.pool.getRunCommandDetector(projectName, accountName);
     if (existing && existing.isActive()) return;
 
     let lastNotification: { sent: PlatformSentMessage; payload: MessagePayload } | null = null;
@@ -616,7 +629,7 @@ export function ensureRunCommandDetector(
     });
 
     detector.start();
-    bridge.pool.registerRunCommandDetector(projectName, detector);
+    bridge.pool.registerRunCommandDetector(projectName, detector, accountName);
     logger.debug(`[RunCommandDetector:${projectName}] Started run command detection`);
 }
 
@@ -631,17 +644,21 @@ export function ensureUserMessageDetector(
     cdp: CdpService,
     projectName: string,
     onUserMessage: (info: UserMessageInfo) => void,
+    accountName: string = 'default',
 ): void {
-    const existing = bridge.pool.getUserMessageDetector(projectName);
-    if (existing && existing.isActive()) return;
+    const existing = bridge.pool.getUserMessageDetector(projectName, accountName);
+    if (existing && existing.isActive()) {
+        existing.on('message', onUserMessage);
+        return;
+    }
 
     const detector = new UserMessageDetector({
         cdpService: cdp,
         pollIntervalMs: 2000,
-        onUserMessage,
     });
-
+    
+    detector.on('message', onUserMessage);
     detector.start();
-    bridge.pool.registerUserMessageDetector(projectName, detector);
+    bridge.pool.registerUserMessageDetector(projectName, detector, accountName);
     logger.debug(`[UserMessageDetector:${projectName}] Started user message detection`);
 }

--- a/src/services/cdpConnectionPool.ts
+++ b/src/services/cdpConnectionPool.ts
@@ -7,15 +7,20 @@ import { PlanningDetector } from './planningDetector';
 import { RunCommandDetector } from './runCommandDetector';
 import { UserMessageDetector } from './userMessageDetector';
 
+export interface AccountSelection {
+    name?: string;
+}
+
+function buildConnectionKey(projectName: string, accountName: string): string {
+    return `${accountName}::${projectName}`;
+}
+
 /**
- * Pool that manages independent CdpService instances per workspace.
- *
- * Each workspace owns its own WebSocket / contexts / pendingCalls, so
- * switching to workspace B while workspace A's ResponseMonitor is polling
- * does not destroy A's WebSocket.
+ * Pool that manages independent CdpService instances per workspace/account pair.
  */
 export class CdpConnectionPool {
     private readonly connections = new Map<string, CdpService>();
+    private readonly workspaceToAccount = new Map<string, string>();
     private readonly approvalDetectors = new Map<string, ApprovalDetector>();
     private readonly errorPopupDetectors = new Map<string, ErrorPopupDetector>();
     private readonly planningDetectors = new Map<string, PlanningDetector>();
@@ -28,274 +33,205 @@ export class CdpConnectionPool {
         this.cdpOptions = cdpOptions;
     }
 
-    /**
-     * Get a CdpService for the given workspace path.
-     * Creates a new connection and caches it if not already connected.
-     * Prevents concurrent connections via Promise locking.
-     *
-     * @param workspacePath Full path of the workspace
-     * @returns Connected CdpService
-     */
-    async getOrConnect(workspacePath: string): Promise<CdpService> {
-        const projectName = this.extractProjectName(workspacePath);
+    private resolveAccountName(projectName: string, accountName: string, explicitSelection: boolean = false): string {
+        if (explicitSelection) {
+            return accountName;
+        }
+        if (accountName !== 'default') return accountName;
+        return this.workspaceToAccount.get(projectName) || accountName;
+    }
 
-        // Return existing connection if available
-        const existing = this.connections.get(projectName);
+    async getOrConnect(workspacePath: string, selection?: AccountSelection): Promise<CdpService> {
+        const projectName = this.extractProjectName(workspacePath);
+        const explicitSelection = typeof selection?.name === 'string';
+        const accountName = selection?.name || this.workspaceToAccount.get(projectName) || 'default';
+        const effectiveAccount = this.resolveAccountName(projectName, accountName, explicitSelection);
+        const key = buildConnectionKey(projectName, effectiveAccount);
+
+        const existing = this.connections.get(key);
         if (existing && existing.isConnected()) {
-            // Re-validate that the still-open window is actually bound to this workspace.
             await existing.discoverAndConnectForWorkspace(workspacePath);
             return existing;
         }
 
-        // Wait for the pending connection promise if one exists (prevents concurrent connections)
-        const pending = this.connectingPromises.get(projectName);
+        const pending = this.connectingPromises.get(key);
         if (pending) {
             return pending;
         }
 
-        // Start a new connection
-        const connectPromise = this.createAndConnect(workspacePath, projectName);
-        this.connectingPromises.set(projectName, connectPromise);
+        const connectPromise = this.createAndConnect(workspacePath, projectName, effectiveAccount);
+        this.connectingPromises.set(key, connectPromise);
 
         try {
-            const cdp = await connectPromise;
-            return cdp;
+            return await connectPromise;
         } finally {
-            this.connectingPromises.delete(projectName);
+            this.connectingPromises.delete(key);
+            this.workspaceToAccount.set(projectName, effectiveAccount);
         }
     }
 
-    /**
-     * Get a connected CdpService (read-only).
-     * Returns null if not connected.
-     */
-    getConnected(projectName: string): CdpService | null {
-        const cdp = this.connections.get(projectName);
+    getConnected(projectName: string, accountName: string = 'default'): CdpService | null {
+        const effectiveAccount = this.resolveAccountName(projectName, accountName);
+        const cdp = this.connections.get(buildConnectionKey(projectName, effectiveAccount));
         if (cdp && cdp.isConnected()) {
             return cdp;
         }
         return null;
     }
 
-    /**
-     * Disconnect the specified workspace.
-     */
-    disconnectWorkspace(projectName: string): void {
-        const cdp = this.connections.get(projectName);
+    disconnectWorkspace(projectName: string, accountName: string = 'default'): void {
+        const effectiveAccount = this.resolveAccountName(projectName, accountName);
+        const key = buildConnectionKey(projectName, effectiveAccount);
+
+        const cdp = this.connections.get(key);
         if (cdp) {
             cdp.disconnect().catch((err) => {
-                logger.error(`[CdpConnectionPool] Error while disconnecting ${projectName}:`, err);
+                logger.error(`[CdpConnectionPool] Error while disconnecting ${key}:`, err);
             });
-            this.connections.delete(projectName);
+            this.connections.delete(key);
         }
 
-        const detector = this.approvalDetectors.get(projectName);
-        if (detector) {
-            detector.stop();
-            this.approvalDetectors.delete(projectName);
-        }
+        this.approvalDetectors.get(key)?.stop();
+        this.approvalDetectors.delete(key);
 
-        const errorPopupDetector = this.errorPopupDetectors.get(projectName);
-        if (errorPopupDetector) {
-            errorPopupDetector.stop();
-            this.errorPopupDetectors.delete(projectName);
-        }
+        this.errorPopupDetectors.get(key)?.stop();
+        this.errorPopupDetectors.delete(key);
 
-        const planningDetector = this.planningDetectors.get(projectName);
-        if (planningDetector) {
-            planningDetector.stop();
-            this.planningDetectors.delete(projectName);
-        }
+        this.planningDetectors.get(key)?.stop();
+        this.planningDetectors.delete(key);
 
-        const runCmdDetector = this.runCommandDetectors.get(projectName);
-        if (runCmdDetector) {
-            runCmdDetector.stop();
-            this.runCommandDetectors.delete(projectName);
-        }
+        this.runCommandDetectors.get(key)?.stop();
+        this.runCommandDetectors.delete(key);
 
-        const userMsgDetector = this.userMessageDetectors.get(projectName);
-        if (userMsgDetector) {
-            userMsgDetector.stop();
-            this.userMessageDetectors.delete(projectName);
-        }
+        this.userMessageDetectors.get(key)?.stop();
+        this.userMessageDetectors.delete(key);
     }
 
-    /**
-     * Disconnect all workspace connections.
-     */
     disconnectAll(): void {
-        for (const projectName of [...this.connections.keys()]) {
-            this.disconnectWorkspace(projectName);
+        for (const key of [...this.connections.keys()]) {
+            const [accountName, projectName] = key.split('::');
+            this.disconnectWorkspace(projectName, accountName);
         }
     }
 
-    /**
-     * Register an approval detector for a workspace.
-     */
-    registerApprovalDetector(projectName: string, detector: ApprovalDetector): void {
-        // Stop existing detector
-        const existing = this.approvalDetectors.get(projectName);
-        if (existing && existing.isActive()) {
-            existing.stop();
-        }
-        this.approvalDetectors.set(projectName, detector);
+    registerApprovalDetector(projectName: string, detector: ApprovalDetector, accountName: string = 'default'): void {
+        const effectiveAccount = this.resolveAccountName(projectName, accountName);
+        const key = buildConnectionKey(projectName, effectiveAccount);
+        this.approvalDetectors.get(key)?.stop();
+        this.approvalDetectors.set(key, detector);
     }
 
-    /**
-     * Get the approval detector for a workspace.
-     */
-    getApprovalDetector(projectName: string): ApprovalDetector | undefined {
-        return this.approvalDetectors.get(projectName);
+    getApprovalDetector(projectName: string, accountName: string = 'default'): ApprovalDetector | undefined {
+        const effectiveAccount = this.resolveAccountName(projectName, accountName);
+        return this.approvalDetectors.get(buildConnectionKey(projectName, effectiveAccount));
     }
 
-    /**
-     * Register an error popup detector for a workspace.
-     */
-    registerErrorPopupDetector(projectName: string, detector: ErrorPopupDetector): void {
-        // Stop existing detector
-        const existing = this.errorPopupDetectors.get(projectName);
-        if (existing && existing.isActive()) {
-            existing.stop();
-        }
-        this.errorPopupDetectors.set(projectName, detector);
+    registerErrorPopupDetector(projectName: string, detector: ErrorPopupDetector, accountName: string = 'default'): void {
+        const effectiveAccount = this.resolveAccountName(projectName, accountName);
+        const key = buildConnectionKey(projectName, effectiveAccount);
+        this.errorPopupDetectors.get(key)?.stop();
+        this.errorPopupDetectors.set(key, detector);
     }
 
-    /**
-     * Get the error popup detector for a workspace.
-     */
-    getErrorPopupDetector(projectName: string): ErrorPopupDetector | undefined {
-        return this.errorPopupDetectors.get(projectName);
+    getErrorPopupDetector(projectName: string, accountName: string = 'default'): ErrorPopupDetector | undefined {
+        const effectiveAccount = this.resolveAccountName(projectName, accountName);
+        return this.errorPopupDetectors.get(buildConnectionKey(projectName, effectiveAccount));
     }
 
-    /**
-     * Register a planning detector for a workspace.
-     */
-    registerPlanningDetector(projectName: string, detector: PlanningDetector): void {
-        // Stop existing detector
-        const existing = this.planningDetectors.get(projectName);
-        if (existing && existing.isActive()) {
-            existing.stop();
-        }
-        this.planningDetectors.set(projectName, detector);
+    registerPlanningDetector(projectName: string, detector: PlanningDetector, accountName: string = 'default'): void {
+        const effectiveAccount = this.resolveAccountName(projectName, accountName);
+        const key = buildConnectionKey(projectName, effectiveAccount);
+        this.planningDetectors.get(key)?.stop();
+        this.planningDetectors.set(key, detector);
     }
 
-    /**
-     * Get the planning detector for a workspace.
-     */
-    getPlanningDetector(projectName: string): PlanningDetector | undefined {
-        return this.planningDetectors.get(projectName);
+    getPlanningDetector(projectName: string, accountName: string = 'default'): PlanningDetector | undefined {
+        const effectiveAccount = this.resolveAccountName(projectName, accountName);
+        return this.planningDetectors.get(buildConnectionKey(projectName, effectiveAccount));
     }
 
-    /**
-     * Register a run command detector for a workspace.
-     */
-    registerRunCommandDetector(projectName: string, detector: RunCommandDetector): void {
-        const existing = this.runCommandDetectors.get(projectName);
-        if (existing && existing.isActive()) {
-            existing.stop();
-        }
-        this.runCommandDetectors.set(projectName, detector);
+    registerRunCommandDetector(projectName: string, detector: RunCommandDetector, accountName: string = 'default'): void {
+        const effectiveAccount = this.resolveAccountName(projectName, accountName);
+        const key = buildConnectionKey(projectName, effectiveAccount);
+        this.runCommandDetectors.get(key)?.stop();
+        this.runCommandDetectors.set(key, detector);
     }
 
-    /**
-     * Get the run command detector for a workspace.
-     */
-    getRunCommandDetector(projectName: string): RunCommandDetector | undefined {
-        return this.runCommandDetectors.get(projectName);
+    getRunCommandDetector(projectName: string, accountName: string = 'default'): RunCommandDetector | undefined {
+        const effectiveAccount = this.resolveAccountName(projectName, accountName);
+        return this.runCommandDetectors.get(buildConnectionKey(projectName, effectiveAccount));
     }
 
-    /**
-     * Register a user message detector for a workspace.
-     */
-    registerUserMessageDetector(projectName: string, detector: UserMessageDetector): void {
-        const existing = this.userMessageDetectors.get(projectName);
-        if (existing && existing.isActive()) {
-            existing.stop();
-        }
-        this.userMessageDetectors.set(projectName, detector);
+    registerUserMessageDetector(projectName: string, detector: UserMessageDetector, accountName: string = 'default'): void {
+        const effectiveAccount = this.resolveAccountName(projectName, accountName);
+        const key = buildConnectionKey(projectName, effectiveAccount);
+        this.userMessageDetectors.get(key)?.stop();
+        this.userMessageDetectors.set(key, detector);
     }
 
-    /**
-     * Get the user message detector for a workspace.
-     */
-    getUserMessageDetector(projectName: string): UserMessageDetector | undefined {
-        return this.userMessageDetectors.get(projectName);
+    getUserMessageDetector(projectName: string, accountName: string = 'default'): UserMessageDetector | undefined {
+        const effectiveAccount = this.resolveAccountName(projectName, accountName);
+        return this.userMessageDetectors.get(buildConnectionKey(projectName, effectiveAccount));
     }
 
-    /**
-     * Return a list of workspace names with active connections.
-     */
+    setPreferredAccountForWorkspace(workspacePath: string, accountName: string): void {
+        const projectName = this.extractProjectName(workspacePath);
+        this.workspaceToAccount.set(projectName, accountName);
+    }
+
+    getPreferredAccountForWorkspace(workspacePath: string): string | null {
+        const projectName = this.extractProjectName(workspacePath);
+        return this.workspaceToAccount.get(projectName) ?? null;
+    }
+
     getActiveWorkspaceNames(): string[] {
-        const active: string[] = [];
-        for (const [name, cdp] of this.connections) {
-            if (cdp.isConnected()) {
-                active.push(name);
-            }
+        const active = new Set<string>();
+        for (const [key, cdp] of this.connections) {
+            if (!cdp.isConnected()) continue;
+            const [, projectName] = key.split('::');
+            active.add(projectName || key);
         }
-        return active;
+        return [...active];
     }
 
-    /**
-     * Extract the project name from a workspace path.
-     */
     extractProjectName(workspacePath: string): string {
         return extractProjectNameFromPath(workspacePath) || workspacePath;
     }
 
-    /**
-     * Create a new CdpService and connect to the workspace.
-     */
-    private async createAndConnect(workspacePath: string, projectName: string): Promise<CdpService> {
-        // Disconnect old connection if exists
-        const old = this.connections.get(projectName);
+    private async createAndConnect(
+        workspacePath: string,
+        projectName: string,
+        accountName: string,
+    ): Promise<CdpService> {
+        const key = buildConnectionKey(projectName, accountName);
+        const old = this.connections.get(key);
         if (old) {
             await old.disconnect().catch(() => {});
-            this.connections.delete(projectName);
+            this.connections.delete(key);
         }
 
-        const cdp = new CdpService(this.cdpOptions);
-
-        // Auto-cleanup on disconnect
-        cdp.on('disconnected', () => {
-            logger.error(`[CdpConnectionPool] Workspace "${projectName}" disconnected`);
-            // Only remove from Map when reconnection fails
-            // (CdpService attempts reconnection internally, so we don't remove here)
+        const cdp = new CdpService({
+            ...this.cdpOptions,
+            accountName,
         });
 
         cdp.on('reconnectFailed', () => {
-            logger.error(`[CdpConnectionPool] Reconnection failed for workspace "${projectName}". Removing from pool`);
-            this.connections.delete(projectName);
-            const detector = this.approvalDetectors.get(projectName);
-            if (detector) {
-                detector.stop();
-                this.approvalDetectors.delete(projectName);
-            }
-            const errorDetector = this.errorPopupDetectors.get(projectName);
-            if (errorDetector) {
-                errorDetector.stop();
-                this.errorPopupDetectors.delete(projectName);
-            }
-            const planDetector = this.planningDetectors.get(projectName);
-            if (planDetector) {
-                planDetector.stop();
-                this.planningDetectors.delete(projectName);
-            }
-            const runCmdDetector = this.runCommandDetectors.get(projectName);
-            if (runCmdDetector) {
-                runCmdDetector.stop();
-                this.runCommandDetectors.delete(projectName);
-            }
-            const userMsgDetector = this.userMessageDetectors.get(projectName);
-            if (userMsgDetector) {
-                userMsgDetector.stop();
-                this.userMessageDetectors.delete(projectName);
-            }
+            logger.error(`[CdpConnectionPool] Reconnection failed for workspace "${key}". Removing from pool`);
+            this.connections.delete(key);
+            this.approvalDetectors.get(key)?.stop();
+            this.approvalDetectors.delete(key);
+            this.errorPopupDetectors.get(key)?.stop();
+            this.errorPopupDetectors.delete(key);
+            this.planningDetectors.get(key)?.stop();
+            this.planningDetectors.delete(key);
+            this.runCommandDetectors.get(key)?.stop();
+            this.runCommandDetectors.delete(key);
+            this.userMessageDetectors.get(key)?.stop();
+            this.userMessageDetectors.delete(key);
         });
 
-        // Connect to the workspace
         await cdp.discoverAndConnectForWorkspace(workspacePath);
-        this.connections.set(projectName, cdp);
-
+        this.connections.set(key, cdp);
         return cdp;
     }
 }

--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -2,7 +2,7 @@ import { logger } from '../utils/logger';
 import { CDP_PORTS } from '../utils/cdpPorts';
 import { EventEmitter } from 'events';
 import * as http from 'http';
-import { spawn } from 'child_process';
+import { execFile, spawn } from 'child_process';
 import { getAntigravityCliPath, extractProjectNameFromPath } from '../utils/pathUtils';
 import WebSocket from 'ws';
 
@@ -13,6 +13,9 @@ export interface CdpServiceOptions {
     maxReconnectAttempts?: number;
     /** Delay between reconnect attempts (ms). Default: 2000 */
     reconnectDelayMs?: number;
+    accountName?: string;
+    accountPorts?: Record<string, number>;
+    accountUserDataDirs?: Record<string, string>;
 }
 
 export interface CdpContext {
@@ -35,6 +38,13 @@ export interface ExtractedResponseImage {
     url?: string;
 }
 
+export interface WorkspaceRuntimeState {
+    isGenerating: boolean;
+    sessionTitle: string;
+    hasActiveChat: boolean;
+    contextId: number | null;
+}
+
 /** UI sync operation result type (Step 9) */
 export interface UiSyncResult {
     ok: boolean;
@@ -42,6 +52,9 @@ export interface UiSyncResult {
     mode?: string;
     /** Model name set (on setUiModel success) */
     model?: string;
+    verified?: boolean;
+    alreadySelected?: boolean;
+    diagnostics?: string;
     error?: string;
 }
 
@@ -57,6 +70,70 @@ const SELECTORS = {
     CONTEXT_URL_KEYWORD: 'cascade-panel',
 };
 
+const WORKSPACE_STATE_SCRIPT = `(() => {
+    const panel = document.querySelector('.antigravity-agent-side-panel');
+    const scopes = [panel, document].filter(Boolean);
+
+    let isGenerating = false;
+    for (const scope of scopes) {
+        const stopEl = scope.querySelector('[data-tooltip-id="input-send-button-cancel-tooltip"]');
+        if (stopEl) {
+            isGenerating = true;
+            break;
+        }
+    }
+
+    if (!isGenerating) {
+        const normalize = (value) => (value || '').toLowerCase().replace(/\\s+/g, ' ').trim();
+        const stopPatterns = [
+            /^stop$/,
+            /^stop generating$/,
+            /^stop response$/,
+            /^停止$/,
+            /^生成を停止$/,
+            /^応答を停止$/,
+        ];
+        for (const scope of scopes) {
+            const buttons = scope.querySelectorAll('button, [role="button"]');
+            for (let i = 0; i < buttons.length; i++) {
+                const btn = buttons[i];
+                const labels = [
+                    btn.textContent || '',
+                    btn.getAttribute('aria-label') || '',
+                    btn.getAttribute('title') || '',
+                ];
+                if (labels.some((label) => stopPatterns.some((re) => re.test(normalize(label))))) {
+                    isGenerating = true;
+                    break;
+                }
+            }
+            if (isGenerating) break;
+        }
+    }
+
+    if (!panel) {
+        return { isGenerating, sessionTitle: '', hasActiveChat: false };
+    }
+
+    const header = panel.querySelector('div[class*="border-b"]');
+    const titleEl = header?.querySelector('div[class*="text-ellipsis"]');
+    const rawTitle = titleEl ? (titleEl.textContent || '').trim() : '';
+    const hasActiveChat = rawTitle.length > 0 && rawTitle !== 'Agent';
+
+    return {
+        isGenerating,
+        sessionTitle: rawTitle || '(Untitled)',
+        hasActiveChat,
+    };
+})()`;
+
+const CHAT_READY_TIMEOUT_MS = 6000;
+const CHAT_READY_POLL_MS = 250;
+const INJECT_RETRY_READY_TIMEOUT_MS = 2500;
+const INJECT_RETRY_BACKOFF_MS = 500;
+const MODE_READY_TIMEOUT_MS = 4000;
+const MODE_RETRY_READY_TIMEOUT_MS = 2000;
+
 export class CdpService extends EventEmitter {
     private ports: number[];
     private isConnectedFlag: boolean = false;
@@ -66,6 +143,7 @@ export class CdpService extends EventEmitter {
     private idCounter = 1;
     private cdpCallTimeout = 30000;
     private targetUrl: string | null = null;
+    private targetId: string | null = null;
     /** Number of auto-reconnect attempts on disconnect */
     private maxReconnectAttempts: number;
     /** Delay between reconnect attempts (ms) */
@@ -80,13 +158,35 @@ export class CdpService extends EventEmitter {
     private currentWorkspacePath: string | null = null;
     /** Workspace switching flag (suppresses disconnected event) */
     private isSwitchingWorkspace: boolean = false;
+    private accountName: string;
+    private accountPorts: Record<string, number>;
+    private accountUserDataDirs: Record<string, string>;
 
     constructor(options: CdpServiceOptions = {}) {
         super();
-        this.ports = options.portsToScan || [...CDP_PORTS];
+        this.accountName = options.accountName || 'default';
+        this.accountPorts = options.accountPorts || {};
+        this.accountUserDataDirs = options.accountUserDataDirs || {};
+        this.ports = options.portsToScan || this.resolveAccountPorts(this.accountName);
         if (options.cdpCallTimeout) this.cdpCallTimeout = options.cdpCallTimeout;
         this.maxReconnectAttempts = options.maxReconnectAttempts ?? 3;
         this.reconnectDelayMs = options.reconnectDelayMs ?? 2000;
+    }
+
+    private resolveAccountPorts(accountName: string): number[] {
+        const explicitPort = this.accountPorts[accountName];
+        if (Number.isInteger(explicitPort) && explicitPort > 0) {
+            return [explicitPort];
+        }
+        return [...CDP_PORTS];
+    }
+
+    private resolveConfiguredUserDataDir(accountName: string): string | null {
+        const configured = this.accountUserDataDirs[accountName];
+        if (typeof configured === 'string' && configured.trim().length > 0) {
+            return configured.trim();
+        }
+        return null;
     }
 
     private async getJson(url: string): Promise<any[]> {
@@ -151,6 +251,7 @@ export class CdpService extends EventEmitter {
 
         if (target && target.webSocketDebuggerUrl) {
             this.targetUrl = target.webSocketDebuggerUrl;
+            this.targetId = typeof target.id === 'string' ? target.id : null;
             // Extract workspace name from title (e.g., "ProjectName — Antigravity")
             if (target.title && !this.currentWorkspaceName) {
                 const titleParts = target.title.split(/\\s[—–-]\\s/);
@@ -283,9 +384,54 @@ export class CdpService extends EventEmitter {
         }
         this.isConnectedFlag = false;
         this.contexts = [];
+        this.targetId = null;
         this.currentWorkspacePath = null;
         this.currentWorkspaceName = null;
         this.clearPendingCalls(new Error('disconnect() was called'));
+    }
+
+    private async evaluateAcrossContexts<T = unknown>(
+        expression: string,
+        accept: (value: T) => boolean,
+        options?: { awaitPromise?: boolean },
+    ): Promise<{ value: T | null; contextId: number | null }> {
+        const awaitPromise = options?.awaitPromise ?? true;
+        const contexts = this.getContexts();
+        let firstValue: { value: T | null; contextId: number | null } | null = null;
+
+        if (contexts.length === 0) {
+            const result = await this.call('Runtime.evaluate', {
+                expression,
+                returnByValue: true,
+                awaitPromise,
+            });
+            return {
+                value: (result?.result?.value ?? null) as T,
+                contextId: null,
+            };
+        }
+
+        for (const ctx of contexts) {
+            try {
+                const result = await this.call('Runtime.evaluate', {
+                    expression,
+                    returnByValue: true,
+                    awaitPromise,
+                    contextId: ctx.id,
+                });
+                const value = (result?.result?.value ?? null) as T;
+                if (!firstValue) {
+                    firstValue = { value, contextId: ctx.id };
+                }
+                if (accept(value)) {
+                    return { value, contextId: ctx.id };
+                }
+            } catch {
+                // Try the next context.
+            }
+        }
+
+        return firstValue ?? { value: null, contextId: null };
     }
 
     /**
@@ -322,6 +468,22 @@ export class CdpService extends EventEmitter {
             return await this._discoverAndConnectForWorkspaceImpl(workspacePath, projectName);
         } finally {
             this.isSwitchingWorkspace = false;
+        }
+    }
+
+    async openWorkspace(workspacePath: string): Promise<boolean> {
+        const projectName = extractProjectNameFromPath(workspacePath);
+        this.currentWorkspacePath = workspacePath;
+
+        try {
+            return await this.discoverAndConnectForWorkspace(workspacePath);
+        } catch (error: any) {
+            logger.info(
+                `[CdpService] Explicit open requested for workspace "${projectName}" ` +
+                `on account "${this.accountName}" — retrying with launch ` +
+                `(reason: ${error?.message || String(error)})`,
+            );
+            return this.launchAndConnectWorkspace(workspacePath, projectName, true);
         }
     }
 
@@ -426,6 +588,7 @@ export class CdpService extends EventEmitter {
 
         this.disconnectQuietly();
         this.targetUrl = page.webSocketDebuggerUrl;
+        this.targetId = typeof page.id === 'string' ? page.id : null;
         await this.connect();
         this.currentWorkspaceName = projectName;
         logger.debug(`[CdpService] Connected to workspace "${projectName}"`);
@@ -453,6 +616,7 @@ export class CdpService extends EventEmitter {
                 // Temporarily connect to retrieve document.title
                 this.disconnectQuietly();
                 this.targetUrl = page.webSocketDebuggerUrl;
+                this.targetId = typeof page.id === 'string' ? page.id : null;
                 await this.connect();
 
                 const result = await this.call('Runtime.evaluate', {
@@ -576,20 +740,66 @@ export class CdpService extends EventEmitter {
     private async launchAndConnectWorkspace(
         workspacePath: string,
         projectName: string,
+        explicitOpen: boolean = false,
     ): Promise<boolean> {
+        const targetPort = this.ports[0] ?? null;
+        const configuredUserDataDir = this.resolveConfiguredUserDataDir(this.accountName);
+        const resolvedUserDataDir = explicitOpen && targetPort !== null
+            ? (configuredUserDataDir ?? await this.resolveRunningUserDataDirForPort(targetPort))
+            : null;
+
+        if (explicitOpen && this.accountName !== 'default' && targetPort !== null && !resolvedUserDataDir) {
+            throw new Error(
+                `Could not determine user-data-dir for running account "${this.accountName}" ` +
+                `(CDP port ${targetPort}). Make sure that Antigravity instance is already running with that port.`,
+            );
+        }
+
+        if (!explicitOpen && this.accountName !== 'default' && targetPort !== null) {
+            logger.warn(
+                `[CdpService] Workspace "${projectName}" not found on account "${this.accountName}" ` +
+                `(port=${targetPort}). Skipping auto-launch to avoid opening the wrong Antigravity instance.`,
+            );
+            throw new Error(
+                `Workspace "${projectName}" is not open in account "${this.accountName}" ` +
+                `(CDP port ${targetPort}). Open it with Antigravity Cockpit or use "/project reopen" ` +
+                `command (Telegram: /project_reopen).`,
+            );
+        }
+
         // Open as folder using Antigravity CLI (not as workspace mode).
         // `open -a Antigravity` may open as workspace, resulting in title "Untitled (Workspace)".
         // CLI --new-window opens as folder, immediately reflecting directory name in title.
         const antigravityCli = getAntigravityCliPath();
 
-        logger.debug(`[CdpService] Launching Antigravity: ${antigravityCli} --new-window ${workspacePath}`);
+        const launchArgs = [
+            ...(resolvedUserDataDir ? ['--user-data-dir', resolvedUserDataDir] : []),
+            ...(targetPort !== null ? [`--remote-debugging-port=${targetPort}`] : []),
+            '--new-window',
+            workspacePath,
+        ];
+
+        logger.debug(
+            `[CdpService] Launching Antigravity for account "${this.accountName}" ` +
+            `(port=${targetPort ?? 'unknown'}, userDataDir=${resolvedUserDataDir ?? 'default'}) ` +
+            `${antigravityCli} ${launchArgs.join(' ')}`,
+        );
         try {
-            await this.runCommand(antigravityCli, ['--new-window', workspacePath]);
+            await this.runCommand(antigravityCli, launchArgs);
         } catch (error: any) {
             // Fall back to open -a if CLI not found (macOS only)
             logger.warn(`[CdpService] CLI launch failed, falling back to open -a (if macOS): ${error?.message || String(error)}`);
             if (process.platform === 'darwin') {
-                await this.runCommand('open', ['-a', 'Antigravity', workspacePath]);
+                const openArgs = [
+                    '-n',
+                    '-a',
+                    'Antigravity',
+                    '--args',
+                    ...(resolvedUserDataDir ? ['--user-data-dir', resolvedUserDataDir] : []),
+                    ...(targetPort !== null ? [`--remote-debugging-port=${targetPort}`] : []),
+                    workspacePath,
+                ];
+                await this.runCommand('open', openArgs);
             } else {
                 throw error;
             }
@@ -784,6 +994,72 @@ export class CdpService extends EventEmitter {
         });
     }
 
+    private async resolveRunningUserDataDirForPort(port: number): Promise<string | null> {
+        const commandLines = await this.getProcessCommandLines();
+        if (commandLines.length === 0) return null;
+
+        const portPattern = new RegExp(`--remote-debugging-port(?:=|\\s+)${port}(?:\\s|$)`);
+
+        for (const line of commandLines) {
+            const lowerLine = line.toLowerCase();
+            if (!lowerLine.includes('antigravity') || !portPattern.test(line) || !line.includes('--user-data-dir')) {
+                continue;
+            }
+
+            const match = line.match(/--user-data-dir(?:=|\s+)("([^"]+)"|'([^']+)'|([^\s]+))/);
+            const userDataDir = match?.[2] || match?.[3] || match?.[4];
+            if (userDataDir) {
+                logger.info(`[CdpService] Resolved user-data-dir for CDP port ${port}: ${userDataDir}`);
+                return userDataDir;
+            }
+        }
+
+        return null;
+    }
+
+    private async getProcessCommandLines(): Promise<string[]> {
+        const run = (command: string, args: string[]): Promise<string> =>
+            new Promise((resolve, reject) => {
+                execFile(command, args, { windowsHide: true, maxBuffer: 20 * 1024 * 1024 }, (error, stdout) => {
+                    if (error) {
+                        reject(error);
+                        return;
+                    }
+                    resolve(stdout);
+                });
+            });
+
+        const parseLines = (output: string): string[] =>
+            output
+                .split('\n')
+                .map((line) => line.trim())
+                .filter((line) => line.length > 0);
+
+        try {
+            if (process.platform === 'win32') {
+                try {
+                    const psOutput = await run('powershell.exe', [
+                        '-NoProfile',
+                        '-Command',
+                        "Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -and $_.CommandLine -match 'antigravity' } | Select-Object -ExpandProperty CommandLine",
+                    ]);
+                    return parseLines(psOutput);
+                } catch {
+                    const wmicOutput = await run('wmic', ['process', 'get', 'CommandLine']);
+                    return parseLines(wmicOutput)
+                        .filter((line) => line !== 'CommandLine')
+                        .filter((line) => /antigravity/i.test(line));
+                }
+            }
+
+            const psOutput = await run('/bin/sh', ['-lc', "ps -axo command= | grep -i antigravity | grep -v grep"]);
+            return parseLines(psOutput);
+        } catch (error) {
+            logger.warn(`[CdpService] Failed to inspect Antigravity processes: ${error instanceof Error ? error.message : String(error)}`);
+            return [];
+        }
+    }
+
     /**
      * Quietly disconnect the existing connection (no reconnect attempts).
      * Used during workspace switching.
@@ -802,6 +1078,93 @@ export class CdpService extends EventEmitter {
             this.contexts = [];
             this.clearPendingCalls(new Error('Disconnected for workspace switch'));
             this.targetUrl = null;
+            this.targetId = null;
+        }
+    }
+
+    async closeCurrentTarget(): Promise<boolean> {
+        if (!this.targetId) {
+            return false;
+        }
+
+        try {
+            await this.call('Target.closeTarget', { targetId: this.targetId });
+            return true;
+        } finally {
+            await this.disconnect();
+        }
+    }
+
+    async inspectWorkspaceRuntimeState(): Promise<WorkspaceRuntimeState> {
+        const result = await this.evaluateAcrossContexts<WorkspaceRuntimeState>(
+            WORKSPACE_STATE_SCRIPT,
+            (value) => !!(value && typeof value === 'object' && (value as any).hasActiveChat),
+        );
+        const value = result.value;
+
+        return {
+            isGenerating: !!(value && typeof value === 'object' && (value as any).isGenerating),
+            sessionTitle: value && typeof value === 'object' && typeof (value as any).sessionTitle === 'string'
+                ? (value as any).sessionTitle
+                : '(Untitled)',
+            hasActiveChat: !!(value && typeof value === 'object' && (value as any).hasActiveChat),
+            contextId: result.contextId,
+        };
+    }
+
+    async closeCurrentTargetGracefully(timeoutMs = 5000): Promise<boolean> {
+        if (!this.targetId) {
+            return false;
+        }
+
+        const closingTargetId = this.targetId;
+
+        try {
+            await this.call('Page.bringToFront', {}).catch(() => {});
+
+            const modifiers = process.platform === 'darwin' ? 4 : 2;
+            await this.call('Input.dispatchKeyEvent', {
+                type: 'keyDown',
+                key: 'w',
+                code: 'KeyW',
+                modifiers,
+                windowsVirtualKeyCode: 87,
+                nativeVirtualKeyCode: 87,
+            });
+            await this.call('Input.dispatchKeyEvent', {
+                type: 'keyUp',
+                key: 'w',
+                code: 'KeyW',
+                modifiers,
+                windowsVirtualKeyCode: 87,
+                nativeVirtualKeyCode: 87,
+            });
+
+            const deadline = Date.now() + timeoutMs;
+            while (Date.now() <= deadline) {
+                let stillOpen = false;
+                for (const port of this.ports) {
+                    try {
+                        const list = await this.getJson(`http://127.0.0.1:${port}/json/list`);
+                        if (list.some((page: any) => page?.id === closingTargetId)) {
+                            stillOpen = true;
+                            break;
+                        }
+                    } catch {
+                        // Ignore port failures while polling close state.
+                    }
+                }
+
+                if (!stillOpen) {
+                    return true;
+                }
+
+                await new Promise((resolve) => setTimeout(resolve, 250));
+            }
+
+            return false;
+        } finally {
+            await this.disconnect();
         }
     }
 
@@ -1010,6 +1373,130 @@ export class CdpService extends EventEmitter {
         return { ok: false, error: 'Chat input field not found' };
     }
 
+    private async waitForChatInputReady(timeoutMs = CHAT_READY_TIMEOUT_MS): Promise<{ ok: boolean; contextId?: number; error?: string }> {
+        const deadline = Date.now() + timeoutMs;
+        let lastError = 'Chat input field not found';
+
+        while (Date.now() < deadline) {
+            const focusResult = await this.focusChatInput();
+            if (focusResult.ok) {
+                return focusResult;
+            }
+            lastError = focusResult.error || lastError;
+            await new Promise((r) => setTimeout(r, CHAT_READY_POLL_MS));
+        }
+
+        return { ok: false, error: lastError };
+    }
+
+    private isTransientInjectError(error?: string): boolean {
+        const message = String(error || '');
+        return [
+            'No editor found',
+            'Chat input field not found',
+            'WebSocket is not connected',
+            'WebSocket disconnected',
+        ].some((fragment) => message.includes(fragment));
+    }
+
+    private async isModeToggleReady(): Promise<boolean> {
+        const expression = '(() => {'
+            + ' const uiNameMap = { fast: "Fast", plan: "Planning" };'
+            + ' const knownModes = Object.values(uiNameMap).map(n => n.toLowerCase());'
+            + ' const allBtns = Array.from(document.querySelectorAll("button"));'
+            + ' const visibleBtns = allBtns.filter(b => b.offsetParent !== null);'
+            + ' const modeToggleBtn = visibleBtns.find(b => {'
+            + '   const text = (b.textContent || "").trim().toLowerCase();'
+            + '   const hasChevron = b.querySelector("svg[class*=\\"chevron\\"]");'
+            + '   return knownModes.some(m => text === m) && hasChevron;'
+            + ' });'
+            + ' return !!modeToggleBtn;'
+            + '})()';
+        try {
+            const contextId = this.getPrimaryContextId();
+            const callParams: any = {
+                expression,
+                returnByValue: true,
+                awaitPromise: false,
+            };
+            if (contextId !== null) callParams.contextId = contextId;
+            const res = await this.call('Runtime.evaluate', callParams);
+            return Boolean(res?.result?.value);
+        } catch {
+            return false;
+        }
+    }
+
+    private async waitForModeToggleReady(timeoutMs = MODE_READY_TIMEOUT_MS): Promise<boolean> {
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            if (await this.isModeToggleReady()) {
+                return true;
+            }
+            await new Promise((r) => setTimeout(r, CHAT_READY_POLL_MS));
+        }
+        return false;
+    }
+
+    private isTransientModeError(error?: string): boolean {
+        const message = String(error || '');
+        return [
+            'Mode toggle button not found',
+            'WebSocket is not connected',
+            'WebSocket disconnected',
+        ].some((fragment) => message.includes(fragment));
+    }
+
+    private async injectMessageCore(text: string, imageFilePaths?: string[]): Promise<InjectResult> {
+        const focusResult = await this.waitForChatInputReady();
+        if (!focusResult.ok) {
+            return { ok: false, error: focusResult.error || 'Chat input field not found' };
+        }
+
+        // Clear any existing text in the input field before injecting.
+        await this.clearInputField();
+
+        if (imageFilePaths && imageFilePaths.length > 0) {
+            const attachResult = await this.attachImageFiles(imageFilePaths, focusResult.contextId);
+            if (!attachResult.ok) {
+                return { ok: false, error: attachResult.error || 'Failed to attach images' };
+            }
+        }
+
+        await this.call('Input.insertText', { text });
+        await new Promise(r => setTimeout(r, 200));
+        await this.pressEnterToSend();
+
+        return {
+            ok: true,
+            method: 'enter',
+            contextId: focusResult.contextId,
+        };
+    }
+
+    private async retryInjectOnce(
+        text: string,
+        firstError: string,
+        imageFilePaths?: string[],
+    ): Promise<InjectResult> {
+        logger.warn(`[CdpService] Initial message injection failed: ${firstError}. Retrying once after readiness check...`);
+
+        try {
+            await this.reconnectOnDemand(INJECT_RETRY_READY_TIMEOUT_MS);
+        } catch {
+            // Ignore reconnect failures here; readiness check below will produce the final error.
+        }
+
+        await new Promise((r) => setTimeout(r, INJECT_RETRY_BACKOFF_MS));
+
+        const ready = await this.waitForChatInputReady(INJECT_RETRY_READY_TIMEOUT_MS);
+        if (!ready.ok) {
+            return { ok: false, error: ready.error || firstError };
+        }
+
+        return this.injectMessageCore(text, imageFilePaths);
+    }
+
     /**
      * Select all text in the focused input and delete it to ensure a clean state.
      * Uses Meta+A (select all) then Backspace (delete) via CDP key events.
@@ -1207,22 +1694,12 @@ export class CdpService extends EventEmitter {
             throw new Error('Not connected to CDP. Call connect() first.');
         }
 
-        const focusResult = await this.focusChatInput();
-        if (!focusResult.ok) {
-            return { ok: false, error: focusResult.error || 'Chat input field not found' };
+        const result = await this.injectMessageCore(text);
+        if (result.ok || !this.isTransientInjectError(result.error)) {
+            return result;
         }
 
-        // Clear any existing text in the input field before injecting
-        await this.clearInputField();
-
-        // 1. Input text via CDP Input.insertText
-        await this.call('Input.insertText', { text });
-        await new Promise(r => setTimeout(r, 200));
-
-        // 2. Send via Enter key
-        await this.pressEnterToSend();
-
-        return { ok: true, method: 'enter', contextId: focusResult.contextId };
+        return this.retryInjectOnce(text, result.error || 'Message injection failed');
     }
 
     /**
@@ -1233,24 +1710,12 @@ export class CdpService extends EventEmitter {
             throw new Error('Not connected to CDP. Call connect() first.');
         }
 
-        const focusResult = await this.focusChatInput();
-        if (!focusResult.ok) {
-            return { ok: false, error: focusResult.error || 'Chat input field not found' };
+        const result = await this.injectMessageCore(text, imageFilePaths);
+        if (result.ok || !this.isTransientInjectError(result.error)) {
+            return result;
         }
 
-        // Clear any existing text in the input field before injecting
-        await this.clearInputField();
-
-        const attachResult = await this.attachImageFiles(imageFilePaths, focusResult.contextId);
-        if (!attachResult.ok) {
-            return { ok: false, error: attachResult.error || 'Failed to attach images' };
-        }
-
-        await this.call('Input.insertText', { text });
-        await new Promise(r => setTimeout(r, 200));
-        await this.pressEnterToSend();
-
-        return { ok: true, method: 'enter', contextId: focusResult.contextId };
+        return this.retryInjectOnce(text, result.error || 'Image message injection failed', imageFilePaths);
     }
 
     /**
@@ -1493,6 +1958,8 @@ export class CdpService extends EventEmitter {
             await this.reconnectOnDemand();
         }
 
+        await this.waitForModeToggleReady();
+
         const safeMode = JSON.stringify(modeName);
 
         // Internal mode name -> Antigravity UI display name mapping
@@ -1588,7 +2055,25 @@ export class CdpService extends EventEmitter {
             if (value?.ok) {
                 return { ok: true, mode: value.mode };
             }
-            return { ok: false, error: value?.error || 'UI operation failed (setUiMode)' };
+            const errorMessage = value?.error || 'UI operation failed (setUiMode)';
+            if (!this.isTransientModeError(errorMessage)) {
+                return { ok: false, error: errorMessage };
+            }
+
+            logger.warn(`[CdpService] setUiMode initial attempt failed: ${errorMessage}. Retrying once after readiness check...`);
+            try {
+                await this.reconnectOnDemand(MODE_RETRY_READY_TIMEOUT_MS);
+            } catch {
+                // Fall through to the readiness wait and retry below.
+            }
+            await this.waitForModeToggleReady(MODE_RETRY_READY_TIMEOUT_MS);
+
+            const retryRes = await this.call('Runtime.evaluate', callParams);
+            const retryValue = retryRes?.result?.value;
+            if (retryValue?.ok) {
+                return { ok: true, mode: retryValue.mode };
+            }
+            return { ok: false, error: retryValue?.error || errorMessage };
         } catch (error: any) {
             return { ok: false, error: error?.message || String(error) };
         }
@@ -1603,27 +2088,154 @@ export class CdpService extends EventEmitter {
         }
 
         const expression = `(async () => {
-            return Array.from(document.querySelectorAll('div.cursor-pointer'))
-                .map(e => ({text: (e.textContent || '').trim().replace(/New$/, ''), class: e.className}))
-                .filter(e => e.class.includes('px-2 py-1 flex items-center justify-between') || e.text.includes('Gemini') || e.text.includes('GPT') || e.text.includes('Claude'))
-                .map(e => e.text);
+            const normalize = (text) => (text || '').trim().replace(/New$/, '').trim();
+            const isBlockedModelLabel = (text) => /assist|open in terminal|terminal|code change|claude code|\\bchange\\b/i.test(text || '');
+            const looksLikeModel = (text) => {
+                const normalized = normalize(text).toLowerCase();
+                if (!normalized || isBlockedModelLabel(normalized)) return false;
+                return /gemini\\s*\\d|gpt(?:[-\\s]?\\d|[-\\s]?oss)|claude\\s+(?:opus|sonnet|haiku)|(?:opus|sonnet|haiku)\\s*\\d/i.test(normalized);
+            };
+            const isVisible = (el) => {
+                if (!(el instanceof HTMLElement)) return false;
+                const style = window.getComputedStyle(el);
+                const rect = el.getBoundingClientRect();
+                return style.visibility !== 'hidden'
+                    && style.display !== 'none'
+                    && rect.width > 0
+                    && rect.height > 0;
+            };
+            const getLabel = (el) => {
+                if (!(el instanceof HTMLElement)) return '';
+                const parts = [
+                    el.textContent || '',
+                    el.getAttribute('aria-label') || '',
+                    el.getAttribute('title') || '',
+                    el.getAttribute('data-value') || '',
+                ];
+                return normalize(parts.find((part) => normalize(part).length > 0) || '');
+            };
+            const scopeSelectors = [
+                '[role="dialog"]',
+                '[role="listbox"]',
+                '[role="menu"]',
+                '[data-radix-popper-content-wrapper]',
+                '[data-slot*="popover"]',
+                '[data-state="open"]',
+                '[class*="popover"]',
+                '[class*="dropdown"]',
+                '[class*="menu"]',
+            ];
+            const itemSelectors = [
+                '[role="option"]',
+                '[role="menuitem"]',
+                '[aria-selected]',
+                '[aria-checked]',
+                'button',
+                '[role="button"]',
+                'div.cursor-pointer',
+                'div[class*="cursor-pointer"]',
+            ];
+            const getScopes = () => {
+                const scopes = [document];
+                for (const el of document.querySelectorAll(scopeSelectors.join(','))) {
+                    if (isVisible(el)) scopes.push(el);
+                }
+                return Array.from(new Set(scopes));
+            };
+            const hasOpenPicker = () => getScopes().some((scope) => scope !== document);
+            const closePicker = async () => {
+                const active = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+                if (active) active.blur();
+                document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+                document.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape', bubbles: true, cancelable: true }));
+                document.body?.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+                document.body?.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true }));
+                document.body?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+                await new Promise((resolve) => setTimeout(resolve, 80));
+            };
+            const collectModels = () => {
+                const seen = new Set();
+                const labels = [];
+                for (const scope of getScopes()) {
+                    for (const el of scope.querySelectorAll(itemSelectors.join(','))) {
+                        if (!isVisible(el)) continue;
+                        const label = getLabel(el);
+                        if (!looksLikeModel(label)) continue;
+                        const key = label.toLowerCase();
+                        if (seen.has(key)) continue;
+                        seen.add(key);
+                        labels.push(label);
+                    }
+                }
+                return labels;
+            };
+            const triggerSelectors = [
+                '[role="combobox"]',
+                '[aria-haspopup="listbox"]',
+                '[aria-haspopup="menu"]',
+                '[aria-expanded]',
+                'button',
+                '[role="button"]',
+                'div.cursor-pointer',
+                'div[class*="cursor-pointer"]',
+            ];
+
+            let models = collectModels();
+            if (models.length > 1) {
+                if (hasOpenPicker()) await closePicker();
+                return models;
+            }
+
+            const triggers = Array.from(document.querySelectorAll(triggerSelectors.join(',')))
+                .filter(isVisible)
+                .filter((el) => {
+                    const label = getLabel(el);
+                    const attrs = normalize([
+                        el.getAttribute('aria-label') || '',
+                        el.getAttribute('title') || '',
+                        el.getAttribute('aria-haspopup') || '',
+                        el.className || '',
+                    ].join(' '));
+                    return looksLikeModel(label) || /model|listbox|combobox|popover|dropdown/.test(attrs);
+                });
+
+            for (const trigger of triggers) {
+                trigger.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+                await new Promise((resolve) => setTimeout(resolve, 300));
+                models = collectModels();
+                if (models.length > 1) {
+                    if (hasOpenPicker()) await closePicker();
+                    return models;
+                }
+            }
+
+            if (hasOpenPicker()) await closePicker();
+            return models;
         })()`;
 
         try {
-            const contextId = this.getPrimaryContextId();
-            const callParams: any = {
-                expression,
-                returnByValue: true,
-                awaitPromise: true,
-            };
-            if (contextId !== null) callParams.contextId = contextId;
+            const contexts = this.getContexts();
+            const contextIds = [
+                this.getPrimaryContextId(),
+                ...contexts.map((ctx) => ctx.id),
+            ].filter((value, index, arr): value is number => typeof value === 'number' && arr.indexOf(value) === index);
+            const targets: Array<number | null> = contextIds.length > 0 ? contextIds : [null];
 
-            const res = await this.call('Runtime.evaluate', callParams);
-            const value = res?.result?.value;
-            if (Array.isArray(value) && value.length > 0) {
-                // remove duplicates
-                return Array.from(new Set(value));
+            for (const contextId of targets) {
+                const params: any = {
+                    expression,
+                    returnByValue: true,
+                    awaitPromise: true,
+                };
+                if (typeof contextId === 'number') params.contextId = contextId;
+                const res = await this.call('Runtime.evaluate', params);
+                const value = res?.result?.value;
+                if (Array.isArray(value) && value.length > 0) {
+                    return Array.from(new Set(value));
+                }
             }
+
+            logger.warn('[CdpService] getUiModels returned no models from any execution context.');
             return [];
         } catch (error: any) {
             logger.error('Failed to get UI models:', error);
@@ -1639,17 +2251,81 @@ export class CdpService extends EventEmitter {
             return null;
         }
         const expression = `(() => {
-            return Array.from(document.querySelectorAll('div.cursor-pointer'))
-                .find(e => e.className.includes('px-2 py-1 flex items-center justify-between') && e.className.includes('bg-gray-500/20'))
-                ?.textContent?.trim().replace(/New$/, '') || null;
+            const normalize = (text) => (text || '').trim().replace(/New$/, '').trim();
+            const isBlockedModelLabel = (text) => /assist|open in terminal|terminal|code change|claude code|\\bchange\\b/i.test(text || '');
+            const looksLikeModel = (text) => {
+                const normalized = normalize(text).toLowerCase();
+                if (!normalized || isBlockedModelLabel(normalized)) return false;
+                return /gemini\\s*\\d|gpt(?:[-\\s]?\\d|[-\\s]?oss)|claude\\s+(?:opus|sonnet|haiku)|(?:opus|sonnet|haiku)\\s*\\d/i.test(normalized);
+            };
+            const isVisible = (el) => {
+                if (!(el instanceof HTMLElement)) return false;
+                const style = window.getComputedStyle(el);
+                const rect = el.getBoundingClientRect();
+                return style.visibility !== 'hidden'
+                    && style.display !== 'none'
+                    && rect.width > 0
+                    && rect.height > 0;
+            };
+            const getLabel = (el) => {
+                if (!(el instanceof HTMLElement)) return '';
+                const parts = [
+                    el.textContent || '',
+                    el.getAttribute('aria-label') || '',
+                    el.getAttribute('title') || '',
+                    el.getAttribute('data-value') || '',
+                ];
+                return normalize(parts.find((part) => normalize(part).length > 0) || '');
+            };
+            const getScore = (el) => {
+                if (!(el instanceof HTMLElement)) return 0;
+                let score = 0;
+                if (el.getAttribute('aria-selected') === 'true') score += 5;
+                if (el.getAttribute('aria-checked') === 'true') score += 5;
+                if (el.getAttribute('aria-current') === 'true') score += 4;
+                const dataState = normalize(el.getAttribute('data-state') || '');
+                if (/(checked|active|selected|on|open)/.test(dataState)) score += 4;
+                const classes = normalize(el.className || '');
+                if (classes.includes('bg-gray-500/20')) score += 3;
+                if (classes.includes('selected')) score += 3;
+                if (classes.includes('active')) score += 2;
+                if (el.getAttribute('aria-expanded') === 'true') score += 1;
+                return score;
+            };
+            const candidates = Array.from(document.querySelectorAll(
+                '[role="option"], [role="menuitem"], [role="combobox"], [aria-selected], [aria-checked], ' +
+                '[aria-current], button, [role="button"], div.cursor-pointer, div[class*="cursor-pointer"]'
+            ))
+                .filter(isVisible)
+                .map((el) => ({ el, label: getLabel(el), score: getScore(el) }))
+                .filter((entry) => looksLikeModel(entry.label))
+                .sort((a, b) => b.score - a.score || a.label.length - b.label.length);
+            if (candidates.length === 0) return null;
+            if (candidates[0].score > 0) return candidates[0].label;
+            return candidates[0].label;
         })()`;
         try {
-            const contextId = this.getPrimaryContextId();
-            const res = await this.call('Runtime.evaluate', {
-                expression, returnByValue: true, awaitPromise: true,
-                contextId: contextId || undefined
-            });
-            return res?.result?.value || null;
+            const contexts = this.getContexts();
+            const contextIds = [
+                this.getPrimaryContextId(),
+                ...contexts.map((ctx) => ctx.id),
+            ].filter((value, index, arr): value is number => typeof value === 'number' && arr.indexOf(value) === index);
+            const targets: Array<number | null> = contextIds.length > 0 ? contextIds : [null];
+
+            for (const contextId of targets) {
+                const params: any = {
+                    expression,
+                    returnByValue: true,
+                    awaitPromise: true,
+                };
+                if (typeof contextId === 'number') params.contextId = contextId;
+                const res = await this.call('Runtime.evaluate', params);
+                const value = res?.result?.value;
+                if (typeof value === 'string' && value.trim().length > 0) {
+                    return value;
+                }
+            }
+            return null;
         } catch (e: any) {
             return null;
         }
@@ -1662,6 +2338,7 @@ export class CdpService extends EventEmitter {
      * @param modelName Model name to set (e.g., 'gpt-4o', 'claude-3-opus')
      */
     async setUiModel(modelName: string): Promise<UiSyncResult> {
+        logger.info(`[CdpService] setUiModel requested account=${this.accountName} target="${modelName}" connected=${this.isConnectedFlag}`);
         if (!this.isConnectedFlag || !this.ws) {
             await this.reconnectOnDemand();
         }
@@ -1673,68 +2350,333 @@ export class CdpService extends EventEmitter {
         const safeModel = JSON.stringify(modelName);
         const expression = `(async () => {
             const targetModel = ${safeModel};
-            
-            // Get all items in the model list
-            const modelItems = Array.from(document.querySelectorAll('div.cursor-pointer'))
-                .filter(e => e.className.includes('px-2 py-1 flex items-center justify-between'));
-            
-            if (modelItems.length === 0) {
-                return { ok: false, error: 'Model list not found. The dropdown may not be open.' };
+            const normalize = (text) => (text || '').trim().replace(/New$/, '').trim();
+            const isBlockedModelLabel = (text) => /assist|open in terminal|terminal|code change|claude code|\\bchange\\b/i.test(text || '');
+            const looksLikeModel = (text) => {
+                const normalized = normalize(text).toLowerCase();
+                if (!normalized || isBlockedModelLabel(normalized)) return false;
+                return /gemini\\s*\\d|gpt(?:[-\\s]?\\d|[-\\s]?oss)|claude\\s+(?:opus|sonnet|haiku)|(?:opus|sonnet|haiku)\\s*\\d/i.test(normalized);
+            };
+            const isVisible = (el) => {
+                if (!(el instanceof HTMLElement)) return false;
+                const style = window.getComputedStyle(el);
+                const rect = el.getBoundingClientRect();
+                return style.visibility !== 'hidden'
+                    && style.display !== 'none'
+                    && rect.width > 0
+                    && rect.height > 0;
+            };
+            const getLabel = (el) => {
+                if (!(el instanceof HTMLElement)) return '';
+                const parts = [
+                    el.textContent || '',
+                    el.getAttribute('aria-label') || '',
+                    el.getAttribute('title') || '',
+                    el.getAttribute('data-value') || '',
+                ];
+                return normalize(parts.find((part) => normalize(part).length > 0) || '');
+            };
+            const itemSelectors = [
+                '[role="option"]',
+                '[role="menuitem"]',
+                '[aria-selected]',
+                '[aria-checked]',
+                'button',
+                '[role="button"]',
+                'div.cursor-pointer',
+                'div[class*="cursor-pointer"]',
+            ];
+            const triggerSelectors = [
+                '[role="combobox"]',
+                '[aria-haspopup="listbox"]',
+                '[aria-haspopup="menu"]',
+                '[aria-expanded]',
+                'button',
+                '[role="button"]',
+                'div.cursor-pointer',
+                'div[class*="cursor-pointer"]',
+            ];
+            const scopeSelectors = [
+                '[role="dialog"]',
+                '[role="listbox"]',
+                '[role="menu"]',
+                '[data-radix-popper-content-wrapper]',
+                '[data-slot*="popover"]',
+                '[data-state="open"]',
+                '[class*="popover"]',
+                '[class*="dropdown"]',
+                '[class*="menu"]',
+            ];
+            const getScopes = () => {
+                const scopes = [document];
+                for (const el of document.querySelectorAll(scopeSelectors.join(','))) {
+                    if (isVisible(el)) scopes.push(el);
+                }
+                return Array.from(new Set(scopes));
+            };
+            const getOpenPickerScopes = () => getScopes().filter((scope) => scope !== document);
+            const hasOpenPicker = () => getOpenPickerScopes().length > 0;
+            const isSelected = (el) => {
+                if (!(el instanceof HTMLElement)) return false;
+                const classes = normalize(el.className || '');
+                const state = normalize(el.getAttribute('data-state') || '');
+                return el.getAttribute('aria-selected') === 'true'
+                    || el.getAttribute('aria-checked') === 'true'
+                    || el.getAttribute('aria-current') === 'true'
+                    || /(checked|active|selected|on)/.test(state)
+                    || classes.includes('bg-gray-500/20')
+                    || classes.includes('selected')
+                    || classes.includes('active');
+            };
+            const isModelTrigger = (el) => {
+                if (!(el instanceof HTMLElement) || !isVisible(el)) return false;
+                const label = getLabel(el);
+                const attrs = normalize([
+                    el.getAttribute('aria-label') || '',
+                    el.getAttribute('title') || '',
+                    el.getAttribute('aria-haspopup') || '',
+                    el.getAttribute('role') || '',
+                    el.getAttribute('data-state') || '',
+                    el.className || '',
+                ].join(' '));
+                return looksLikeModel(label)
+                    || /select model|current:|model|listbox|combobox|dropdown|popover|dialog/.test(attrs);
+            };
+            const collectModelItems = ({ includeClosedTrigger = false } = {}) => {
+                const items = [];
+                const seen = new Set();
+                const openScopes = getOpenPickerScopes();
+                const scopes = openScopes.length > 0
+                    ? openScopes
+                    : includeClosedTrigger
+                        ? [document]
+                        : [];
+                for (const scope of scopes) {
+                    for (const el of scope.querySelectorAll(itemSelectors.join(','))) {
+                        if (!isVisible(el)) continue;
+                        if (scope === document && isModelTrigger(el)) continue;
+                        const label = getLabel(el);
+                        if (!looksLikeModel(label)) continue;
+                        const key = label.toLowerCase() + '::' + normalize((el.getAttribute('role') || '') + ' ' + (el.className || ''));
+                        if (seen.has(key)) continue;
+                        seen.add(key);
+                        items.push({ el, label });
+                    }
+                }
+                return items;
+            };
+            const summarizeElement = (el) => {
+                if (!(el instanceof HTMLElement)) return null;
+                return {
+                    label: getLabel(el),
+                    role: el.getAttribute('role') || '',
+                    ariaLabel: el.getAttribute('aria-label') || '',
+                    title: el.getAttribute('title') || '',
+                    ariaExpanded: el.getAttribute('aria-expanded') || '',
+                    ariaHaspopup: el.getAttribute('aria-haspopup') || '',
+                    ariaSelected: el.getAttribute('aria-selected') || '',
+                    dataState: el.getAttribute('data-state') || '',
+                    className: String(el.className || '').slice(0, 120),
+                };
+            };
+            const diagnostics = () => {
+                const triggers = Array.from(document.querySelectorAll(triggerSelectors.join(',')))
+                    .filter(isVisible)
+                    .map((el) => summarizeElement(el))
+                    .filter((entry) => entry && (looksLikeModel(entry.label) || /select model|current:|model|listbox|combobox|dropdown|popover|dialog/.test(normalize(entry.className + ' ' + entry.ariaLabel + ' ' + entry.title + ' ' + entry.ariaHaspopup))))
+                    .slice(0, 8);
+                const items = collectModelItems({ includeClosedTrigger: true })
+                    .map(({ el }) => summarizeElement(el))
+                    .filter(Boolean)
+                    .slice(0, 12);
+                return JSON.stringify({ triggers, items, openPicker: hasOpenPicker() });
+            };
+            const getCurrentModelLabel = () => {
+                const selectedItem = collectModelItems({ includeClosedTrigger: true }).find(({ el }) => isSelected(el));
+                if (selectedItem) return selectedItem.label;
+                const trigger = Array.from(document.querySelectorAll(triggerSelectors.join(',')))
+                    .filter(isVisible)
+                    .map((el) => ({ el, label: getLabel(el) }))
+                    .find((entry) => isModelTrigger(entry.el) && looksLikeModel(entry.label));
+                return trigger ? trigger.label : null;
+            };
+            const triggerScore = (el) => {
+                if (!(el instanceof HTMLElement)) return -1;
+                const label = getLabel(el);
+                const ariaLabel = normalize(el.getAttribute('aria-label') || '');
+                const title = normalize(el.getAttribute('title') || '');
+                const role = normalize(el.getAttribute('role') || '');
+                const ariaHaspopup = normalize(el.getAttribute('aria-haspopup') || '');
+                const ariaExpanded = normalize(el.getAttribute('aria-expanded') || '');
+                const classes = normalize(el.className || '');
+                let score = 0;
+                if (/select model|current:/.test(ariaLabel)) score += 10;
+                if (ariaHaspopup === 'dialog') score += 8;
+                if (ariaHaspopup === 'listbox' || ariaHaspopup === 'menu') score += 7;
+                if (role === 'combobox') score += 6;
+                if (ariaExpanded === 'false' || ariaExpanded === 'true') score += 4;
+                if (looksLikeModel(label)) score += 3;
+                if (/model|popover|dropdown/.test(title + ' ' + classes)) score += 2;
+                return score;
+            };
+            const activateTrigger = async (trigger) => {
+                if (!(trigger instanceof HTMLElement)) return false;
+                const tryClick = () => {
+                    trigger.focus?.();
+                    trigger.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, cancelable: true, pointerType: 'mouse' }));
+                    trigger.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+                    trigger.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, cancelable: true, pointerType: 'mouse' }));
+                    trigger.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true }));
+                    trigger.click?.();
+                    trigger.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+                };
+                tryClick();
+                for (const delay of [250, 450, 700]) {
+                    await new Promise((r) => setTimeout(r, delay));
+                    if (hasOpenPicker()) return true;
+                }
+                if (trigger.parentElement instanceof HTMLElement) {
+                    try {
+                        const rect = trigger.getBoundingClientRect();
+                        const parentRect = trigger.parentElement.getBoundingClientRect();
+                        if (parentRect.width > rect.width && parentRect.height >= rect.height) {
+                            trigger.parentElement.click?.();
+                            trigger.parentElement.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+                        }
+                    } catch {}
+                    for (const delay of [250, 450]) {
+                        await new Promise((r) => setTimeout(r, delay));
+                        if (hasOpenPicker()) return true;
+                    }
+                }
+                return hasOpenPicker();
+            };
+            const clickPossibleTrigger = async () => {
+                const triggers = Array.from(document.querySelectorAll(triggerSelectors.join(',')))
+                    .filter(isVisible)
+                    .filter((el) => isModelTrigger(el))
+                    .sort((a, b) => triggerScore(b) - triggerScore(a));
+                for (const trigger of triggers) {
+                    const opened = await activateTrigger(trigger);
+                    const candidateItems = collectModelItems();
+                    if (opened || candidateItems.length > 0) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+
+            let modelItems = collectModelItems();
+            if (modelItems.length === 0 || (modelItems.length <= 1 && !hasOpenPicker())) {
+                await clickPossibleTrigger();
+                modelItems = collectModelItems();
             }
-            
-            // Match target model by name (compare after removing New suffix)
-            const targetItem = modelItems.find(el => {
-                const text = (el.textContent || '').trim().replace(/New$/, '').trim();
-                return text === targetModel || text.toLowerCase() === targetModel.toLowerCase();
+
+            if (modelItems.length === 0 || (modelItems.length <= 1 && !hasOpenPicker())) {
+                return {
+                    ok: false,
+                    error: 'Model list not found. The dropdown may not be open.',
+                    diagnostics: diagnostics(),
+                };
+            }
+
+            const targetLabel = normalize(targetModel).toLowerCase();
+            const targetItem = modelItems.find(({ label }) => {
+                const text = normalize(label).toLowerCase();
+                return text === targetLabel;
             });
-            
+
             if (!targetItem) {
-                const available = modelItems.map(el => (el.textContent || '').trim().replace(/New$/, '').trim()).join(', ');
-                return { ok: false, error: 'Model "' + targetModel + '" not found. Available: ' + available };
+                const available = modelItems.map(({ label }) => normalize(label)).join(', ');
+                return {
+                    ok: false,
+                    error: 'Model "' + targetModel + '" not found. Available: ' + available,
+                    diagnostics: diagnostics(),
+                };
             }
-            
-            // Check if already selected
-            if (targetItem.className.includes('bg-gray-500/20') && !targetItem.className.includes('hover:bg-gray-500/20')) {
+
+            if (isSelected(targetItem.el) || getCurrentModelLabel()?.toLowerCase() === targetLabel) {
                 return { ok: true, model: targetModel, alreadySelected: true };
             }
-            
-            // Click to select model
-            targetItem.click();
+
+            targetItem.el.click();
             await new Promise(r => setTimeout(r, 500));
-            
-            // Verify selection was applied
-            const updatedItems = Array.from(document.querySelectorAll('div.cursor-pointer'))
-                .filter(e => e.className.includes('px-2 py-1 flex items-center justify-between'));
-            const selectedItem = updatedItems.find(el => {
-                const text = (el.textContent || '').trim().replace(/New$/, '').trim();
-                return text === targetModel || text.toLowerCase() === targetModel.toLowerCase();
-            });
-            
-            if (selectedItem && selectedItem.className.includes('bg-gray-500/20') && !selectedItem.className.includes('hover:bg-gray-500/20')) {
+
+            const currentModel = normalize(getCurrentModelLabel() || '').toLowerCase();
+            if (currentModel === targetLabel) {
                 return { ok: true, model: targetModel, verified: true };
             }
-            
-            // Click succeeded but verification failed
-            return { ok: true, model: targetModel, verified: false };
+
+            const updatedTarget = collectModelItems().find(({ label }) => normalize(label).toLowerCase() === targetLabel);
+            if (updatedTarget && isSelected(updatedTarget.el)) {
+                return { ok: true, model: targetModel, verified: true };
+            }
+
+            return {
+                ok: false,
+                error: 'Model click did not update selected state.',
+                diagnostics: diagnostics(),
+            };
         })()`;
 
         try {
-            const contextId = this.getPrimaryContextId();
-            const callParams: any = {
-                expression,
-                returnByValue: true,
-                awaitPromise: true,
-            };
-            if (contextId !== null) callParams.contextId = contextId;
+            const contexts = this.getContexts();
+            const contextIds = [
+                this.getPrimaryContextId(),
+                ...contexts.map((ctx) => ctx.id),
+            ].filter((value, index, arr): value is number => typeof value === 'number' && arr.indexOf(value) === index);
+            const targets: Array<number | null> = contextIds.length > 0 ? contextIds : [null];
 
-            const res = await this.call('Runtime.evaluate', callParams);
-            const value = res?.result?.value;
-            if (value?.ok) {
-                return { ok: true, model: value.model };
+            let lastError = 'UI operation failed (setUiModel)';
+            for (const contextId of targets) {
+                logger.debug(`[CdpService] setUiModel evaluating account=${this.accountName} context=${contextId ?? 'default'} target="${modelName}"`);
+                const params: any = {
+                    expression,
+                    returnByValue: true,
+                    awaitPromise: true,
+                };
+                if (typeof contextId === 'number') params.contextId = contextId;
+                const res = await this.call('Runtime.evaluate', params);
+                const value = res?.result?.value;
+                if (value?.ok) {
+                    logger.info(
+                        `[CdpService] setUiModel result account=${this.accountName} context=${contextId ?? 'default'} ` +
+                        `target="${modelName}" applied="${value.model}" verified=${value.verified === true} ` +
+                        `alreadySelected=${value.alreadySelected === true}`,
+                    );
+                    if (value.verified === false) {
+                        logger.warn(
+                            `[CdpService] setUiModel verification did not confirm selection account=${this.accountName} ` +
+                            `context=${contextId ?? 'default'} target="${modelName}"`,
+                        );
+                    }
+                    return {
+                        ok: true,
+                        model: value.model,
+                        verified: value.verified,
+                        alreadySelected: value.alreadySelected,
+                    };
+                }
+                if (value?.error) {
+                    if (value?.diagnostics) {
+                        logger.warn(
+                            `[CdpService] setUiModel diagnostics account=${this.accountName} context=${contextId ?? 'default'} ` +
+                            `target="${modelName}" details=${value.diagnostics}`,
+                        );
+                    }
+                    logger.warn(
+                        `[CdpService] setUiModel context failure account=${this.accountName} context=${contextId ?? 'default'} ` +
+                        `target="${modelName}" error="${value.error}"`,
+                    );
+                    lastError = value.error;
+                }
             }
-            return { ok: false, error: value?.error || 'UI operation failed (setUiModel)' };
+            logger.warn(`[CdpService] setUiModel failed account=${this.accountName} target="${modelName}" error="${lastError}"`);
+            return { ok: false, error: lastError };
         } catch (error: any) {
-            return { ok: false, error: error?.message || String(error) };
+            const errorMessage = error?.message || String(error);
+            logger.error(`[CdpService] setUiModel exception account=${this.accountName} target="${modelName}": ${errorMessage}`);
+            return { ok: false, error: errorMessage };
         }
     }
 }

--- a/src/services/chatSessionService.ts
+++ b/src/services/chatSessionService.ts
@@ -16,6 +16,17 @@ export interface ChatSessionInfo {
     hasActiveChat: boolean;
 }
 
+interface SessionViewState extends ChatSessionInfo {
+    panelFound?: boolean;
+    hasLoadingIndicator: boolean;
+    hasRenderableContent: boolean;
+    renderablePreview?: Array<{
+        tag: string;
+        className: string;
+        text: string;
+    }>;
+}
+
 /** Script to get the state of the new chat button */
 const GET_NEW_CHAT_BUTTON_SCRIPT = `(() => {
     const btn = document.querySelector('[data-tooltip-id="new-conversation-tooltip"]');
@@ -45,6 +56,57 @@ const GET_CHAT_TITLE_SCRIPT = `(() => {
     // "Agent" is the default empty chat title
     const hasActiveChat = title.length > 0 && title !== 'Agent';
     return { title: title || '(Untitled)', hasActiveChat };
+})()`;
+
+const GET_SESSION_VIEW_STATE_SCRIPT = `(() => {
+    const panel = document.querySelector('.antigravity-agent-side-panel');
+    if (!panel) {
+        return {
+            panelFound: false,
+            title: '',
+            hasActiveChat: false,
+            hasLoadingIndicator: false,
+            hasRenderableContent: false,
+            renderablePreview: [],
+        };
+    }
+    const header = panel.querySelector('div[class*="border-b"]');
+    const titleEl = header?.querySelector('div[class*="text-ellipsis"]');
+    const title = titleEl ? (titleEl.textContent || '').trim() : '';
+    const hasActiveChat = title.length > 0 && title !== 'Agent';
+
+    const bodyCandidates = Array.from(panel.querySelectorAll(
+        '[data-message-author-role], [data-message-role], .rendered-markdown, .prose'
+    ));
+    const renderablePreview = bodyCandidates.filter((el) => {
+        if (!(el instanceof HTMLElement)) return false;
+        const text = (el.textContent || '').trim();
+        if (el.offsetParent === null || text.length === 0) return false;
+        if (/^\\/\\*\\s*Copied from /i.test(text)) return false;
+        return true;
+    }).slice(0, 5).map((el) => ({
+        tag: el.tagName,
+        className: el.className || '',
+        text: ((el.textContent || '').trim()).slice(0, 160),
+    }));
+    const hasRenderableContent = renderablePreview.length > 0;
+
+    const hasLoadingIndicator = Boolean(
+        panel.querySelector(
+            '[role="progressbar"], ' +
+            'svg[class*="animate-spin"], div[class*="animate-spin"], ' +
+            'svg[class*="spinner"], div[class*="spinner"], div[class*="loading"]'
+        )
+    );
+
+    return {
+        panelFound: true,
+        title: title || '(Untitled)',
+        hasActiveChat,
+        hasLoadingIndicator,
+        hasRenderableContent,
+        renderablePreview,
+    };
 })()`;
 
 /**
@@ -454,6 +516,10 @@ export class ChatSessionService {
     private static readonly ACTIVATE_SESSION_MAX_WAIT_MS = 30000;
     private static readonly ACTIVATE_SESSION_RETRY_INTERVAL_MS = 800;
     private static readonly LIST_SESSIONS_TARGET = 20;
+    private static readonly HYDRATE_RETRY_DELAY_MS = 700;
+    private static readonly REOPEN_RETRY_ATTEMPTS = 4;
+    private static readonly REOPEN_NEW_CHAT_DELAY_MS = 400;
+    private static readonly REOPEN_HISTORY_DELAY_MS = 1000;
 
     /**
      * List recent sessions by opening the Past Conversations panel.
@@ -597,6 +663,26 @@ export class ChatSessionService {
         });
     }
 
+    private async dispatchNewConversationShortcut(cdpService: CdpService): Promise<void> {
+        const modifiers = process.platform === 'darwin' ? 8 : 10;
+        await cdpService.call('Input.dispatchKeyEvent', {
+            type: 'keyDown',
+            key: 'L',
+            code: 'KeyL',
+            modifiers,
+            windowsVirtualKeyCode: 76,
+            nativeVirtualKeyCode: 76,
+        });
+        await cdpService.call('Input.dispatchKeyEvent', {
+            type: 'keyUp',
+            key: 'L',
+            code: 'KeyL',
+            modifiers,
+            windowsVirtualKeyCode: 76,
+            nativeVirtualKeyCode: 76,
+        });
+    }
+
     /**
      * Start a new chat session in the Antigravity UI.
      *
@@ -643,20 +729,10 @@ export class ChatSessionService {
                 return { ok: true };
             }
 
-            // cursor: pointer -> click via CDP Input API coordinates
-            await cdpService.call('Input.dispatchMouseEvent', {
-                type: 'mouseMoved', x: btnState.x, y: btnState.y,
-            });
-            await cdpService.call('Input.dispatchMouseEvent', {
-                type: 'mousePressed', x: btnState.x, y: btnState.y,
-                button: 'left', clickCount: 1,
-            });
-            await cdpService.call('Input.dispatchMouseEvent', {
-                type: 'mouseReleased', x: btnState.x, y: btnState.y,
-                button: 'left', clickCount: 1,
-            });
+            // Prefer the keyboard shortcut because some Antigravity builds bind hover tips to the button target.
+            await this.dispatchNewConversationShortcut(cdpService);
 
-            // Wait for UI to update after click
+            // Wait for UI to update after shortcut
             await new Promise(r => setTimeout(r, 1500));
 
             // Check if button changed to not-allowed (evidence that a new chat was opened)
@@ -665,8 +741,16 @@ export class ChatSessionService {
                 return { ok: true };
             }
 
-            // Button still enabled -> click may not have worked
-            return { ok: false, error: 'Clicked new chat button but state did not change' };
+            // Fallback for older builds where the shortcut is not wired.
+            await this.cdpMouseClick(cdpService, btnState.x, btnState.y);
+            await new Promise(r => setTimeout(r, 1500));
+
+            const afterFallback = await this.getNewChatButtonState(cdpService, contexts);
+            if (afterFallback.found && !afterFallback.enabled) {
+                return { ok: true };
+            }
+
+            return { ok: false, error: 'New conversation shortcut and button click did not change state' };
         } catch (error: unknown) {
             const message = error instanceof Error ? error.message : String(error);
             return { ok: false, error: message };
@@ -703,6 +787,129 @@ export class ChatSessionService {
         }
     }
 
+    async getCurrentSessionViewState(cdpService: CdpService): Promise<SessionViewState> {
+        try {
+            const contexts = cdpService.getContexts();
+            for (const ctx of contexts) {
+                try {
+                    const result = await cdpService.call('Runtime.evaluate', {
+                        expression: GET_SESSION_VIEW_STATE_SCRIPT,
+                        returnByValue: true,
+                        contextId: ctx.id,
+                    });
+                    const value = result?.result?.value;
+                    const hasPanel = value?.panelFound === true;
+                    const looksUseful = Boolean(
+                        hasPanel ||
+                        value?.hasLoadingIndicator ||
+                        value?.hasRenderableContent ||
+                        (typeof value?.title === 'string' && value.title.trim().length > 0),
+                    );
+                    if (value && looksUseful) {
+                        return {
+                            title: value.title,
+                            hasActiveChat: value.hasActiveChat ?? false,
+                            panelFound: value.panelFound ?? false,
+                            hasLoadingIndicator: value.hasLoadingIndicator ?? false,
+                            hasRenderableContent: value.hasRenderableContent ?? false,
+                            renderablePreview: Array.isArray(value.renderablePreview) ? value.renderablePreview : [],
+                        };
+                    }
+                } catch (_) { /* try next context */ }
+            }
+        } catch (_) { /* fall through */ }
+
+        return {
+            title: '(Failed to retrieve)',
+            hasActiveChat: false,
+            panelFound: false,
+            hasLoadingIndicator: false,
+            hasRenderableContent: false,
+            renderablePreview: [],
+        };
+    }
+
+    async refreshSessionViewIfStuck(
+        cdpService: CdpService,
+        title: string,
+    ): Promise<{ ok: boolean; error?: string }> {
+        const state = await this.getCurrentSessionViewState(cdpService);
+        if (state.title.trim() !== title.trim()) {
+            return { ok: false, error: `Current title mismatch before refresh (expected="${title}", actual="${state.title}")` };
+        }
+        if (!state.hasLoadingIndicator && state.hasRenderableContent) {
+            return { ok: true };
+        }
+        const bounce = await this.recoverSessionViewWithNewConversationBounce(cdpService, title);
+        if (bounce.ok) {
+            return bounce;
+        }
+
+        return {
+            ok: false,
+            error:
+                `Session "${title}" still appears stuck after new-conversation recovery ` +
+                `(${bounce.error || 'unknown'})`,
+        };
+    }
+
+    async recoverSessionViewWithNewConversationBounce(
+        cdpService: CdpService,
+        title: string,
+        options?: {
+            maxAttempts?: number;
+            newChatDelayMs?: number;
+            reopenDelayMs?: number;
+        },
+    ): Promise<{ ok: boolean; error?: string }> {
+        const state = await this.getCurrentSessionViewState(cdpService);
+        if (state.title.trim() === title.trim() && !state.hasLoadingIndicator && state.hasRenderableContent) {
+            return { ok: true };
+        }
+
+        const maxAttempts = options?.maxAttempts ?? ChatSessionService.REOPEN_RETRY_ATTEMPTS;
+        const newChatDelayMs = options?.newChatDelayMs ?? ChatSessionService.REOPEN_NEW_CHAT_DELAY_MS;
+        const reopenDelayMs = options?.reopenDelayMs ?? ChatSessionService.REOPEN_HISTORY_DELAY_MS;
+        let lastError = `Session "${title}" still appears stuck before recovery`;
+
+        for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+            const newChat = await this.startNewChat(cdpService);
+            if (!newChat.ok) {
+                lastError =
+                    `Attempt ${attempt}/${maxAttempts}: failed to open a fresh new conversation before reopening "${title}": ` +
+                    `${newChat.error || 'unknown'}`;
+                continue;
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, newChatDelayMs));
+
+            const reopened = await this.activateSessionByTitle(cdpService, title, {
+                maxWaitMs: 8000,
+                retryIntervalMs: 300,
+                allowVisibilityWarmupMs: 1000,
+            });
+            if (!reopened.ok) {
+                lastError =
+                    `Attempt ${attempt}/${maxAttempts}: failed to reopen "${title}" after new conversation: ` +
+                    `${reopened.error || 'unknown'}`;
+                continue;
+            }
+
+            await new Promise((resolve) => setTimeout(resolve, reopenDelayMs));
+
+            const after = await this.getCurrentSessionViewState(cdpService);
+            if (after.title.trim() === title.trim() && (!after.hasLoadingIndicator || after.hasRenderableContent)) {
+                return { ok: true };
+            }
+
+            lastError =
+                `Attempt ${attempt}/${maxAttempts}: session "${title}" still appears stuck after reopening ` +
+                `(loading=${after.hasLoadingIndicator}, content=${after.hasRenderableContent}, actual="${after.title}")`;
+        }
+
+        return { ok: false, error: lastError };
+    }
+
     /**
      * Activate an existing chat by title.
      * Returns ok:false if the target chat cannot be located or verified.
@@ -713,6 +920,7 @@ export class ChatSessionService {
         options?: {
             maxWaitMs?: number;
             retryIntervalMs?: number;
+            allowVisibilityWarmupMs?: number;
         },
     ): Promise<{ ok: boolean; error?: string }> {
         if (!title || title.trim().length === 0) {
@@ -726,13 +934,15 @@ export class ChatSessionService {
 
         const maxWaitMs = options?.maxWaitMs ?? ChatSessionService.ACTIVATE_SESSION_MAX_WAIT_MS;
         const retryIntervalMs = options?.retryIntervalMs ?? ChatSessionService.ACTIVATE_SESSION_RETRY_INTERVAL_MS;
+        const allowVisibilityWarmupMs = options?.allowVisibilityWarmupMs ?? 0;
 
         let usedPastConversations = false;
         let directResult: { ok: boolean; error?: string } = { ok: false, error: 'not attempted' };
         let pastResult: { ok: boolean; error?: string } | null = null;
         let clicked = false;
-        const startedAt = Date.now();
+        let startedAt = Date.now();
         let attempts = 0;
+        let warmupConsumed = false;
 
         while (Date.now() - startedAt <= maxWaitMs) {
             attempts += 1;
@@ -769,7 +979,21 @@ export class ChatSessionService {
         await new Promise((resolve) => setTimeout(resolve, 500));
         const after = await this.getCurrentSessionInfo(cdpService);
         if (after.title.trim() === title.trim()) {
+            if (usedPastConversations) {
+                await this.closePanelWithEscape(cdpService);
+            }
             return { ok: true };
+        }
+
+        if (!warmupConsumed && allowVisibilityWarmupMs > 0 && after.title.trim() === 'Agent') {
+            warmupConsumed = true;
+            startedAt = Date.now();
+            await new Promise((resolve) => setTimeout(resolve, allowVisibilityWarmupMs));
+            return this.activateSessionByTitle(cdpService, title, {
+                maxWaitMs,
+                retryIntervalMs,
+                allowVisibilityWarmupMs: 0,
+            });
         }
 
         // If direct side-panel activation hit the wrong row, try the explicit Past Conversations flow.
@@ -779,6 +1003,7 @@ export class ChatSessionService {
                 await new Promise((resolve) => setTimeout(resolve, 500));
                 const afterPast = await this.getCurrentSessionInfo(cdpService);
                 if (afterPast.title.trim() === title.trim()) {
+                    await this.closePanelWithEscape(cdpService);
                     return { ok: true };
                 }
                 return {

--- a/src/services/conversationTransferService.ts
+++ b/src/services/conversationTransferService.ts
@@ -1,0 +1,669 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import Database from 'better-sqlite3';
+
+interface CockpitInstancesFile {
+    instances?: Array<{
+        name?: unknown;
+        userDataDir?: unknown;
+    }>;
+}
+
+export interface AntigravityProfilePaths {
+    profileName: string;
+    userDataDir: string;
+    globalStateDbPath: string;
+}
+
+export interface ConversationTransferBundle {
+    conversationId: string;
+    title: string;
+    sourceProfile: string;
+    exportedAt: string;
+    trajectoryEntryBase64: string;
+    files: {
+        conversationPb?: string;
+        annotationsPbtxt?: string;
+        brainDir?: string;
+    };
+}
+
+export interface ConversationTransferResult {
+    conversationId: string;
+    bundleDir: string;
+    dbBackupPath: string;
+}
+
+export interface WaitForConversationPersistenceOptions {
+    timeoutMs?: number;
+    pollIntervalMs?: number;
+}
+
+export interface TrajectorySummaryEntry {
+    conversationId: string;
+    title: string;
+    outerEntryBytes: Buffer;
+    rawDataBase64: string;
+}
+
+const TRAJECTORY_SUMMARIES_KEY = 'antigravityUnifiedStateSync.trajectorySummaries';
+
+function homeDir(): string {
+    return process.env.LAZY_GRAVITY_TEST_HOME || os.homedir();
+}
+
+function encodeVarint(value: number): Buffer {
+    if (!Number.isInteger(value) || value < 0) {
+        throw new Error(`Cannot encode invalid varint value: ${value}`);
+    }
+
+    const bytes: number[] = [];
+    let remaining = value >>> 0;
+
+    while (remaining >= 0x80) {
+        bytes.push((remaining & 0x7f) | 0x80);
+        remaining >>>= 7;
+    }
+
+    bytes.push(remaining);
+    return Buffer.from(bytes);
+}
+
+function encodeLengthDelimited(fieldNumber: number, payload: Buffer): Buffer {
+    const tag = encodeVarint((fieldNumber << 3) | 2);
+    const length = encodeVarint(payload.length);
+    return Buffer.concat([tag, length, payload]);
+}
+
+function readVarint(buffer: Buffer, offset: number): [number, number] {
+    let result = 0;
+    let shift = 0;
+    let cursor = offset;
+
+    while (cursor < buffer.length) {
+        const byte = buffer[cursor];
+        result |= (byte & 0x7f) << shift;
+        cursor += 1;
+
+        if ((byte & 0x80) === 0) {
+            return [result, cursor];
+        }
+
+        shift += 7;
+    }
+
+    throw new Error('Unexpected EOF while reading protobuf varint');
+}
+
+function looksLikeBase64Text(payload: Buffer): boolean {
+    if (payload.length === 0) {
+        return false;
+    }
+
+    const text = payload.toString('utf8').trim();
+    if (text.length === 0 || text.length % 4 !== 0) {
+        return false;
+    }
+
+    return /^[A-Za-z0-9+/=]+$/.test(text);
+}
+
+function decodeTrajectoryInnerTitleFromBuffer(innerBuffer: Buffer): string {
+    function skipField(offset: number, wireType: number): number {
+        if (wireType === 0) {
+            const [, afterValue] = readVarint(innerBuffer, offset);
+            return afterValue;
+        }
+
+        if (wireType === 1) {
+            return offset + 8;
+        }
+
+        if (wireType === 2) {
+            const [length, afterLength] = readVarint(innerBuffer, offset);
+            return afterLength + length;
+        }
+
+        if (wireType === 3) {
+            let cursor = offset;
+            while (cursor < innerBuffer.length) {
+                const [groupTag, afterGroupTag] = readVarint(innerBuffer, cursor);
+                cursor = afterGroupTag;
+                const groupWire = groupTag & 7;
+                if (groupWire === 4) {
+                    return cursor;
+                }
+                cursor = skipField(cursor, groupWire);
+            }
+            return cursor;
+        }
+
+        if (wireType === 5) {
+            return offset + 4;
+        }
+
+        if (wireType === 4) {
+            return offset;
+        }
+
+        throw new Error(`Unsupported wire type ${wireType} while decoding trajectory title`);
+    }
+
+    let offset = 0;
+    while (offset < innerBuffer.length) {
+        const [tag, afterTag] = readVarint(innerBuffer, offset);
+        offset = afterTag;
+        const fieldNumber = tag >> 3;
+        const wireType = tag & 7;
+
+        if (wireType === 2) {
+            const [length, afterLength] = readVarint(innerBuffer, offset);
+            offset = afterLength;
+            const payload = innerBuffer.subarray(offset, offset + length);
+            offset += length;
+
+            if (fieldNumber === 1) {
+                return payload.toString('utf8');
+            }
+            continue;
+        }
+
+        offset = skipField(offset, wireType);
+    }
+
+    return '';
+}
+
+function unwrapNestedTrajectoryTitle(title: string, depth: number = 0): string {
+    if (depth >= 3) {
+        return title;
+    }
+
+    const buffer = Buffer.from(title, 'utf8');
+    if (!looksLikeBase64Text(buffer)) {
+        return title;
+    }
+
+    try {
+        const nestedTitle = decodeTrajectoryInnerTitleFromBuffer(Buffer.from(title, 'base64'));
+        if (!nestedTitle) {
+            return title;
+        }
+        return unwrapNestedTrajectoryTitle(nestedTitle, depth + 1);
+    } catch {
+        return title;
+    }
+}
+
+function decodeTrajectoryInnerTitle(payload: Buffer): string {
+    const candidates: Buffer[] = [payload];
+    if (looksLikeBase64Text(payload)) {
+        try {
+            candidates.unshift(Buffer.from(payload.toString('utf8'), 'base64'));
+        } catch {
+            // Ignore invalid base64 decode and fall back to the raw payload.
+        }
+    }
+
+    for (const candidate of candidates) {
+        try {
+            const title = decodeTrajectoryInnerTitleFromBuffer(candidate);
+            if (title) {
+                return unwrapNestedTrajectoryTitle(title);
+            }
+        } catch {
+            // Continue through the candidate list. Mixed profile formats are tolerated.
+        }
+    }
+
+    return '';
+}
+
+export function parseTrajectorySummariesBase64(value: string): TrajectorySummaryEntry[] {
+    const decoded = Buffer.from(value, 'base64');
+    const entries: TrajectorySummaryEntry[] = [];
+    let offset = 0;
+
+    while (offset < decoded.length) {
+        const entryStart = offset;
+        const [tag, afterTag] = readVarint(decoded, offset);
+        offset = afterTag;
+
+        const fieldNumber = tag >> 3;
+        const wireType = tag & 7;
+
+        if (fieldNumber !== 1 || wireType !== 2) {
+            throw new Error(`Unexpected trajectory summaries top-level field ${fieldNumber} wire ${wireType}`);
+        }
+
+        const [entryLength, afterLength] = readVarint(decoded, offset);
+        offset = afterLength;
+        const entryPayload = decoded.subarray(offset, offset + entryLength);
+        const outerEntryBytes = decoded.subarray(entryStart, offset + entryLength);
+        offset += entryLength;
+
+        let entryOffset = 0;
+        let conversationId = '';
+        let rawDataBytes = Buffer.alloc(0);
+
+        while (entryOffset < entryPayload.length) {
+            const [entryTag, afterEntryTag] = readVarint(entryPayload, entryOffset);
+            entryOffset = afterEntryTag;
+            const entryField = entryTag >> 3;
+            const entryWire = entryTag & 7;
+
+            if (entryWire !== 2) {
+                throw new Error(`Unexpected trajectory entry field wire type ${entryWire}`);
+            }
+
+            const [entryValueLength, afterEntryLength] = readVarint(entryPayload, entryOffset);
+            entryOffset = afterEntryLength;
+            const entryValue = entryPayload.subarray(entryOffset, entryOffset + entryValueLength);
+            entryOffset += entryValueLength;
+
+            if (entryField === 1) {
+                conversationId = entryValue.toString('utf8');
+            } else if (entryField === 2) {
+                rawDataBytes = Buffer.from(entryValue);
+            }
+        }
+
+        if (!conversationId || rawDataBytes.length === 0) {
+            continue;
+        }
+
+        entries.push({
+            conversationId,
+            title: decodeTrajectoryInnerTitle(rawDataBytes),
+            outerEntryBytes: Buffer.from(outerEntryBytes),
+            rawDataBase64: rawDataBytes.toString('base64'),
+        });
+    }
+
+    return entries;
+}
+
+function normalizeProfileName(name: string): string {
+    return name.trim().toLowerCase();
+}
+
+function defaultAntigravityUserDataDir(): string {
+    const home = homeDir();
+    if (process.platform === 'darwin') {
+        return path.join(home, 'Library', 'Application Support', 'Antigravity');
+    }
+    if (process.platform === 'win32') {
+        const appData = process.env.APPDATA ?? path.join(home, 'AppData', 'Roaming');
+        return path.join(appData, 'Antigravity');
+    }
+    return path.join(home, '.config', 'Antigravity');
+}
+
+export function resolveAntigravityProfilePaths(profileName: string): AntigravityProfilePaths {
+    const normalized = normalizeProfileName(profileName);
+    const defaultDir = defaultAntigravityUserDataDir();
+
+    if (normalized === 'default') {
+        return {
+            profileName: 'default',
+            userDataDir: defaultDir,
+            globalStateDbPath: path.join(defaultDir, 'User', 'globalStorage', 'state.vscdb'),
+        };
+    }
+
+    const instancesPath = path.join(homeDir(), '.antigravity_cockpit', 'instances.json');
+    if (!fs.existsSync(instancesPath)) {
+        throw new Error(`Could not resolve profile "${profileName}" because ${instancesPath} does not exist`);
+    }
+
+    const parsed = JSON.parse(fs.readFileSync(instancesPath, 'utf8')) as CockpitInstancesFile;
+    const instances = Array.isArray(parsed.instances) ? parsed.instances : [];
+    const match = instances.find((instance) => {
+        const instanceName = typeof instance.name === 'string' ? normalizeProfileName(instance.name) : '';
+        return instanceName === normalized;
+    });
+
+    if (!match || typeof match.userDataDir !== 'string' || match.userDataDir.trim().length === 0) {
+        throw new Error(`Could not find Antigravity profile "${profileName}" in ${instancesPath}`);
+    }
+
+    const userDataDir = match.userDataDir.trim();
+    return {
+        profileName: normalized,
+        userDataDir,
+        globalStateDbPath: path.join(userDataDir, 'User', 'globalStorage', 'state.vscdb'),
+    };
+}
+
+function antigravitySharedRoot(): string {
+    return path.join(homeDir(), '.gemini', 'antigravity');
+}
+
+function ensureDir(dirPath: string): void {
+    fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function copyIfExists(sourcePath: string, targetPath: string): boolean {
+    if (!fs.existsSync(sourcePath)) {
+        return false;
+    }
+
+    if (fs.existsSync(targetPath)) {
+        return true;
+    }
+
+    ensureDir(path.dirname(targetPath));
+    fs.cpSync(sourcePath, targetPath, { recursive: true });
+    return true;
+}
+
+function writeConversationBundle(
+    bundleDir: string,
+    profileName: string,
+    entry: TrajectorySummaryEntry,
+): void {
+    ensureDir(bundleDir);
+
+    const sharedRoot = antigravitySharedRoot();
+    const relativeFiles = {
+        conversationPb: path.join('conversations', `${entry.conversationId}.pb`),
+        annotationsPbtxt: path.join('annotations', `${entry.conversationId}.pbtxt`),
+        brainDir: path.join('brain', entry.conversationId),
+    };
+
+    const manifest: ConversationTransferBundle = {
+        conversationId: entry.conversationId,
+        title: entry.title,
+        sourceProfile: profileName,
+        exportedAt: new Date().toISOString(),
+        trajectoryEntryBase64: entry.outerEntryBytes.toString('base64'),
+        files: {},
+    };
+
+    if (copyIfExists(path.join(sharedRoot, relativeFiles.conversationPb), path.join(bundleDir, relativeFiles.conversationPb))) {
+        manifest.files.conversationPb = relativeFiles.conversationPb;
+    }
+    if (copyIfExists(path.join(sharedRoot, relativeFiles.annotationsPbtxt), path.join(bundleDir, relativeFiles.annotationsPbtxt))) {
+        manifest.files.annotationsPbtxt = relativeFiles.annotationsPbtxt;
+    }
+    if (copyIfExists(path.join(sharedRoot, relativeFiles.brainDir), path.join(bundleDir, relativeFiles.brainDir))) {
+        manifest.files.brainDir = relativeFiles.brainDir;
+    }
+
+    fs.writeFileSync(path.join(bundleDir, 'manifest.json'), JSON.stringify(manifest, null, 2), 'utf8');
+}
+
+function loadTrajectorySummaries(dbPath: string): { db: Database.Database; value: string; entries: TrajectorySummaryEntry[] } {
+    if (!fs.existsSync(dbPath)) {
+        throw new Error(`Global state DB not found: ${dbPath}`);
+    }
+
+    const db = new Database(dbPath);
+    const row = db.prepare('SELECT value FROM ItemTable WHERE key = ?').get(TRAJECTORY_SUMMARIES_KEY) as { value?: Buffer | string } | undefined;
+    const value = row?.value ? String(row.value) : '';
+    const entries = value ? parseTrajectorySummariesBase64(value) : [];
+    return { db, value, entries };
+}
+
+export function findTrajectoryEntriesByTitle(profileName: string, title: string): TrajectorySummaryEntry[] {
+    const profile = resolveAntigravityProfilePaths(profileName);
+    const { db, entries } = loadTrajectorySummaries(profile.globalStateDbPath);
+    try {
+        return entries.filter((entry) => entry.title === title);
+    } finally {
+        db.close();
+    }
+}
+
+export function findLatestTrajectoryEntryByTitle(
+    profileName: string,
+    title: string,
+): TrajectorySummaryEntry | undefined {
+    const matches = findTrajectoryEntriesByTitle(profileName, title);
+    return matches.length > 0 ? matches[matches.length - 1] : undefined;
+}
+
+export function findTrajectoryEntryByConversationId(
+    profileName: string,
+    conversationId: string,
+): TrajectorySummaryEntry | undefined {
+    const profile = resolveAntigravityProfilePaths(profileName);
+    const { db, entries } = loadTrajectorySummaries(profile.globalStateDbPath);
+    try {
+        return entries.find((entry) => entry.conversationId === conversationId);
+    } finally {
+        db.close();
+    }
+}
+
+export async function waitForConversationPersistence(
+    profileName: string,
+    title: string,
+    options: WaitForConversationPersistenceOptions = {},
+): Promise<TrajectorySummaryEntry> {
+    const timeoutMs = options.timeoutMs ?? 15000;
+    const pollIntervalMs = options.pollIntervalMs ?? 500;
+    const profile = resolveAntigravityProfilePaths(profileName);
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() <= deadline) {
+        const { db, entries } = loadTrajectorySummaries(profile.globalStateDbPath);
+        try {
+            const matches = entries.filter((entry) => entry.title === title);
+            const matched = matches.length > 0 ? matches[matches.length - 1] : undefined;
+            if (matched) {
+                return matched;
+            }
+        } finally {
+            db.close();
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    }
+
+    throw new Error(
+        `Conversation titled "${title}" is not persisted in Antigravity history for profile "${profile.profileName}" yet.`,
+    );
+}
+
+export async function waitForConversationPersistenceByConversationId(
+    profileName: string,
+    conversationId: string,
+    options: WaitForConversationPersistenceOptions = {},
+): Promise<TrajectorySummaryEntry> {
+    const timeoutMs = options.timeoutMs ?? 15000;
+    const pollIntervalMs = options.pollIntervalMs ?? 500;
+    const profile = resolveAntigravityProfilePaths(profileName);
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() <= deadline) {
+        const { db, entries } = loadTrajectorySummaries(profile.globalStateDbPath);
+        try {
+            const matched = entries.find((entry) => entry.conversationId === conversationId);
+            if (matched) {
+                return matched;
+            }
+        } finally {
+            db.close();
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    }
+
+    throw new Error(
+        `Conversation ID "${conversationId}" is not persisted in Antigravity history for profile "${profile.profileName}" yet.`,
+    );
+}
+
+export function exportConversationBundleByTitle(profileName: string, title: string, outputDir: string): string {
+    const profile = resolveAntigravityProfilePaths(profileName);
+    const { db, entries } = loadTrajectorySummaries(profile.globalStateDbPath);
+
+    try {
+        const matches = entries.filter((entry) => entry.title === title);
+        const matched = matches.length > 0 ? matches[matches.length - 1] : undefined;
+        if (!matched) {
+            throw new Error(`Conversation titled "${title}" was not found in profile "${profile.profileName}" trajectory summaries`);
+        }
+
+        const bundleDir = path.join(outputDir, matched.conversationId);
+        writeConversationBundle(bundleDir, profile.profileName, matched);
+        return bundleDir;
+    } finally {
+        db.close();
+    }
+}
+
+export function exportConversationBundleByConversationId(
+    profileName: string,
+    conversationId: string,
+    outputDir: string,
+): string {
+    const profile = resolveAntigravityProfilePaths(profileName);
+    const { db, entries } = loadTrajectorySummaries(profile.globalStateDbPath);
+
+    try {
+        const matched = entries.find((entry) => entry.conversationId === conversationId);
+        if (!matched) {
+            throw new Error(
+                `Conversation ID "${conversationId}" was not found in profile "${profile.profileName}" trajectory summaries`,
+            );
+        }
+
+        const bundleDir = path.join(outputDir, matched.conversationId);
+        writeConversationBundle(bundleDir, profile.profileName, matched);
+        return bundleDir;
+    } finally {
+        db.close();
+    }
+}
+
+export function importConversationBundleToProfile(bundleDir: string, profileName: string): { conversationId: string; dbBackupPath: string } {
+    const manifestPath = path.join(bundleDir, 'manifest.json');
+    if (!fs.existsSync(manifestPath)) {
+        throw new Error(`Bundle manifest not found: ${manifestPath}`);
+    }
+
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as ConversationTransferBundle;
+    const profile = resolveAntigravityProfilePaths(profileName);
+    const sharedRoot = antigravitySharedRoot();
+    const resolveSafeBundlePath = (baseDir: string, relativePath: string, fieldName: string): string => {
+        if (path.isAbsolute(relativePath)) {
+            throw new Error(`Bundle manifest field "${fieldName}" must be a relative path.`);
+        }
+
+        const resolved = path.resolve(baseDir, relativePath);
+        const normalizedBase = path.resolve(baseDir) + path.sep;
+        if (!resolved.startsWith(normalizedBase)) {
+            throw new Error(`Bundle manifest field "${fieldName}" points outside the bundle directory.`);
+        }
+
+        return resolved;
+    };
+    const resolveSafeSharedPath = (relativePath: string, fieldName: string): string => {
+        if (path.isAbsolute(relativePath)) {
+            throw new Error(`Bundle manifest field "${fieldName}" must be a relative path.`);
+        }
+
+        const resolved = path.resolve(sharedRoot, relativePath);
+        const normalizedRoot = path.resolve(sharedRoot) + path.sep;
+        if (!resolved.startsWith(normalizedRoot)) {
+            throw new Error(`Bundle manifest field "${fieldName}" points outside the shared Antigravity directory.`);
+        }
+
+        return resolved;
+    };
+
+    if (manifest.files.conversationPb) {
+        copyIfExists(
+            resolveSafeBundlePath(bundleDir, manifest.files.conversationPb, 'conversationPb'),
+            resolveSafeSharedPath(manifest.files.conversationPb, 'conversationPb'),
+        );
+    }
+    if (manifest.files.annotationsPbtxt) {
+        copyIfExists(
+            resolveSafeBundlePath(bundleDir, manifest.files.annotationsPbtxt, 'annotationsPbtxt'),
+            resolveSafeSharedPath(manifest.files.annotationsPbtxt, 'annotationsPbtxt'),
+        );
+    }
+    if (manifest.files.brainDir) {
+        copyIfExists(
+            resolveSafeBundlePath(bundleDir, manifest.files.brainDir, 'brainDir'),
+            resolveSafeSharedPath(manifest.files.brainDir, 'brainDir'),
+        );
+    }
+
+    ensureDir(path.dirname(profile.globalStateDbPath));
+    const dbBackupPath = `${profile.globalStateDbPath}.bak.${Date.now()}`;
+    if (fs.existsSync(profile.globalStateDbPath)) {
+        fs.copyFileSync(profile.globalStateDbPath, dbBackupPath);
+    }
+
+    const { db, value, entries } = loadTrajectorySummaries(profile.globalStateDbPath);
+    try {
+        const alreadyPresent = entries.some((entry) => entry.conversationId === manifest.conversationId);
+        if (!alreadyPresent) {
+            const currentBinary = value ? Buffer.from(value, 'base64') : Buffer.alloc(0);
+            const appended = Buffer.concat([
+                currentBinary,
+                Buffer.from(manifest.trajectoryEntryBase64, 'base64'),
+            ]);
+            const updatedValue = appended.toString('base64');
+
+            const upsert = db.prepare(`
+                INSERT INTO ItemTable (key, value)
+                VALUES (?, ?)
+                ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            `);
+            upsert.run(TRAJECTORY_SUMMARIES_KEY, updatedValue);
+        }
+
+        return {
+            conversationId: manifest.conversationId,
+            dbBackupPath,
+        };
+    } finally {
+        db.close();
+    }
+}
+
+export function transferConversationByTitle(
+    sourceProfileName: string,
+    targetProfileName: string,
+    title: string,
+): ConversationTransferResult {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'lazy-gravity-conversation-transfer-'));
+
+    try {
+        const bundleDir = exportConversationBundleByTitle(sourceProfileName, title, tempRoot);
+        const imported = importConversationBundleToProfile(bundleDir, targetProfileName);
+        return {
+            conversationId: imported.conversationId,
+            bundleDir,
+            dbBackupPath: imported.dbBackupPath,
+        };
+    } finally {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+}
+
+export function transferConversationByConversationId(
+    sourceProfileName: string,
+    targetProfileName: string,
+    conversationId: string,
+): ConversationTransferResult {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'lazy-gravity-conversation-transfer-'));
+
+    try {
+        const bundleDir = exportConversationBundleByConversationId(sourceProfileName, conversationId, tempRoot);
+        const imported = importConversationBundleToProfile(bundleDir, targetProfileName);
+        return {
+            conversationId: imported.conversationId,
+            bundleDir,
+            dbBackupPath: imported.dbBackupPath,
+        };
+    } finally {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+}

--- a/src/services/responseMonitor.ts
+++ b/src/services/responseMonitor.ts
@@ -461,6 +461,160 @@ export interface ResponseMonitorOptions {
     onPhaseChange?: (phase: ResponsePhase, text: string | null) => void;
     /** Process log update callback (activity messages + tool output) */
     onProcessLog?: (text: string) => void;
+    /** Optional pre-captured baseline response text from before prompt injection */
+    initialBaselineText?: string | null;
+    /** Optional pre-captured process log keys from before prompt injection */
+    initialSeenProcessLogKeys?: string[];
+}
+
+export interface ResponseMonitorBaselineSnapshot {
+    text: string | null;
+    processLogKeys: string[];
+}
+
+interface ContextProbeTarget {
+    id: number;
+    name?: string;
+    url?: string;
+}
+
+interface ContextProbeResult<T = unknown> {
+    value: T;
+    contextId: number | null;
+    contextName: string | null;
+    contextUrl: string | null;
+}
+
+function getOrderedContextTargets(cdpService: CdpService): ContextProbeTarget[] {
+    const primaryId = cdpService.getPrimaryContextId?.() ?? null;
+    const rawContexts = cdpService.getContexts?.() ?? [];
+    const contexts = rawContexts
+        .filter((ctx: any) => ctx && typeof ctx.id === 'number')
+        .map((ctx: any) => ({
+            id: ctx.id,
+            name: typeof ctx.name === 'string' ? ctx.name : undefined,
+            url: typeof ctx.url === 'string' ? ctx.url : undefined,
+        }));
+
+    if (contexts.length === 0) {
+        return primaryId !== null ? [{ id: primaryId }] : [];
+    }
+
+    if (primaryId === null) {
+        return contexts;
+    }
+
+    const primary = contexts.find((ctx) => ctx.id === primaryId);
+    const ordered = primary ? [primary] : [{ id: primaryId }];
+    for (const ctx of contexts) {
+        if (ctx.id !== primaryId) ordered.push(ctx);
+    }
+    return ordered;
+}
+
+async function evaluateAcrossContexts<T = unknown>(
+    cdpService: CdpService,
+    expression: string,
+    accept: (value: T) => boolean,
+    options?: {
+        awaitPromise?: boolean;
+    },
+): Promise<ContextProbeResult<T>> {
+    const awaitPromise = options?.awaitPromise ?? true;
+    const targets = getOrderedContextTargets(cdpService);
+    let firstValue: ContextProbeResult<T> | null = null;
+
+    if (targets.length === 0) {
+        const result = await cdpService.call('Runtime.evaluate', {
+            expression,
+            returnByValue: true,
+            awaitPromise,
+        });
+        return {
+            value: (result?.result?.value ?? null) as T,
+            contextId: null,
+            contextName: null,
+            contextUrl: null,
+        };
+    }
+
+    for (const target of targets) {
+        try {
+            const result = await cdpService.call('Runtime.evaluate', {
+                expression,
+                returnByValue: true,
+                awaitPromise,
+                contextId: target.id,
+            });
+            const value = (result?.result?.value ?? null) as T;
+            const probed: ContextProbeResult<T> = {
+                value,
+                contextId: target.id,
+                contextName: target.name ?? null,
+                contextUrl: target.url ?? null,
+            };
+            if (!firstValue) firstValue = probed;
+            if (accept(value)) {
+                return probed;
+            }
+        } catch {
+            // Try the next context.
+        }
+    }
+
+    if (firstValue) {
+        return firstValue;
+    }
+
+    return {
+        value: null as T,
+        contextId: null,
+        contextName: null,
+        contextUrl: null,
+    };
+}
+
+/**
+ * Capture the current assistant/output DOM state before sending a new prompt.
+ * This avoids races where a fast reply is mistaken for baseline text.
+ */
+export async function captureResponseMonitorBaseline(
+    cdpService: CdpService,
+): Promise<ResponseMonitorBaselineSnapshot> {
+    let text: string | null = null;
+    try {
+        const textResult = await evaluateAcrossContexts<string | null>(
+            cdpService,
+            RESPONSE_SELECTORS.RESPONSE_TEXT,
+            (value) => typeof value === 'string' && value.trim().length > 0,
+        );
+        text = typeof textResult.value === 'string' ? textResult.value.trim() || null : null;
+    } catch {
+        text = null;
+    }
+
+    const processLogKeys = new Set<string>();
+    try {
+        const logResult = await evaluateAcrossContexts<string[] | null>(
+            cdpService,
+            RESPONSE_SELECTORS.PROCESS_LOGS,
+            (value) => Array.isArray(value) && value.length > 0,
+        );
+        const logEntries = logResult.value;
+        if (Array.isArray(logEntries)) {
+            for (const entry of logEntries) {
+                const key = String(entry || '').replace(/\r/g, '').trim().slice(0, 200);
+                if (key) processLogKeys.add(key);
+            }
+        }
+    } catch {
+        // best-effort baseline capture
+    }
+
+    return {
+        text,
+        processLogKeys: Array.from(processLogKeys),
+    };
 }
 
 /**
@@ -482,6 +636,8 @@ export class ResponseMonitor {
     private readonly onTimeout?: (lastText: string) => void;
     private readonly onPhaseChange?: (phase: ResponsePhase, text: string | null) => void;
     private readonly onProcessLog?: (text: string) => void;
+    private readonly initialBaselineText?: string | null;
+    private readonly initialSeenProcessLogKeys?: string[];
 
     private pollTimer: ReturnType<typeof setTimeout> | null = null;
     private isRunning: boolean = false;
@@ -493,6 +649,7 @@ export class ResponseMonitor {
     private quotaDetected: boolean = false;
     private seenProcessLogKeys: Set<string> = new Set();
     private structuredDiagLogged: boolean = false;
+    private lastContentContextId: number | null = null;
 
     // CDP disconnect handling (#48)
     private isPaused: boolean = false;
@@ -514,6 +671,8 @@ export class ResponseMonitor {
         this.onTimeout = options.onTimeout;
         this.onPhaseChange = options.onPhaseChange;
         this.onProcessLog = options.onProcessLog;
+        this.initialBaselineText = options.initialBaselineText;
+        this.initialSeenProcessLogKeys = options.initialSeenProcessLogKeys;
     }
 
     /** Start monitoring */
@@ -546,35 +705,45 @@ export class ResponseMonitor {
 
         this.onPhaseChange?.(this.currentPhase, null);
 
-        // Capture baseline text
-        try {
-            const baseResult = await this.cdpService.call(
-                'Runtime.evaluate',
-                this.buildEvaluateParams(RESPONSE_SELECTORS.RESPONSE_TEXT),
-            );
-            const rawValue = baseResult?.result?.value;
-            this.baselineText = typeof rawValue === 'string' ? rawValue.trim() || null : null;
-        } catch {
-            this.baselineText = null;
+        if (this.initialBaselineText !== undefined) {
+            this.baselineText = this.initialBaselineText;
+        } else {
+            try {
+                const baseResult = await this.evaluateAcrossContexts<string | null>(
+                    RESPONSE_SELECTORS.RESPONSE_TEXT,
+                    (value) => typeof value === 'string' && value.trim().length > 0,
+                );
+                this.baselineText = typeof baseResult.value === 'string' ? baseResult.value.trim() || null : null;
+            } catch {
+                this.baselineText = null;
+            }
         }
 
-        // Capture baseline process logs as already-seen keys
-        try {
-            const logResult = await this.cdpService.call(
-                'Runtime.evaluate',
-                this.buildEvaluateParams(RESPONSE_SELECTORS.PROCESS_LOGS),
+        if (this.initialSeenProcessLogKeys !== undefined) {
+            this.seenProcessLogKeys = new Set(
+                this.initialSeenProcessLogKeys
+                    .map((s) => (s || '').replace(/\r/g, '').trim())
+                    .filter((s) => s.length > 0)
+                    .map((s) => s.slice(0, 200)),
             );
-            const logEntries = logResult?.result?.value;
-            if (Array.isArray(logEntries)) {
-                this.seenProcessLogKeys = new Set(
-                    logEntries
-                        .map((s: string) => (s || '').replace(/\r/g, '').trim())
-                        .filter((s: string) => s.length > 0)
-                        .map((s: string) => s.slice(0, 200)),
+        } else {
+            try {
+                const logResult = await this.evaluateAcrossContexts<string[] | null>(
+                    RESPONSE_SELECTORS.PROCESS_LOGS,
+                    (value) => Array.isArray(value) && value.length > 0,
                 );
+                const logEntries = logResult.value;
+                if (Array.isArray(logEntries)) {
+                    this.seenProcessLogKeys = new Set(
+                        logEntries
+                            .map((s: string) => (s || '').replace(/\r/g, '').trim())
+                            .filter((s: string) => s.length > 0)
+                            .map((s: string) => s.slice(0, 200)),
+                    );
+                }
+            } catch {
+                // baseline capture only
             }
-        } catch {
-            // baseline capture only
         }
 
         // In structured mode, also capture activity lines from the structured
@@ -584,11 +753,11 @@ export class ResponseMonitor {
         // entries from previous turns leak into the process log as "new" entries.
         if (this.extractionMode === 'structured') {
             try {
-                const structuredBaseline = await this.cdpService.call(
-                    'Runtime.evaluate',
-                    this.buildEvaluateParams(RESPONSE_SELECTORS.RESPONSE_STRUCTURED),
+                const structuredBaseline = await this.evaluateAcrossContexts<unknown>(
+                    RESPONSE_SELECTORS.RESPONSE_STRUCTURED,
+                    (value) => classifyAssistantSegments(value).diagnostics.source === 'dom-structured',
                 );
-                const baselineClassified = classifyAssistantSegments(structuredBaseline?.result?.value);
+                const baselineClassified = classifyAssistantSegments(structuredBaseline.value);
                 if (baselineClassified.diagnostics.source === 'dom-structured') {
                     for (const line of baselineClassified.activityLines) {
                         const key = (line || '').replace(/\r/g, '').trim().slice(0, 200);
@@ -648,17 +817,21 @@ export class ResponseMonitor {
     /** Click the stop button to interrupt LLM generation */
     async clickStopButton(): Promise<{ ok: boolean; method?: string; error?: string }> {
         try {
-            const result = await this.cdpService.call(
-                'Runtime.evaluate',
-                this.buildEvaluateParams(RESPONSE_SELECTORS.CLICK_STOP_BUTTON),
+            const result = await this.evaluateAcrossContexts<{ ok?: boolean; method?: string; error?: string } | null>(
+                RESPONSE_SELECTORS.CLICK_STOP_BUTTON,
+                (value) => !!(value && typeof value === 'object' && (value as any).ok),
             );
-            const value = result?.result?.value;
+            const value = result.value;
 
             if (this.isRunning) {
                 await this.stop();
             }
 
-            return value ?? { ok: false, error: 'CDP evaluation returned empty' };
+            if (value && typeof value.ok === 'boolean') {
+                return value as { ok: boolean; method?: string; error?: string };
+            }
+
+            return { ok: false, error: 'CDP evaluation returned empty' };
         } catch (error: any) {
             return { ok: false, error: error.message || 'Failed to click stop button' };
         }
@@ -759,17 +932,84 @@ export class ResponseMonitor {
         }, this.pollIntervalMs);
     }
 
-    private buildEvaluateParams(expression: string): Record<string, unknown> {
-        const params: Record<string, unknown> = {
-            expression,
-            returnByValue: true,
+    private async evaluateAcrossContexts<T = unknown>(
+        expression: string,
+        accept: (value: T) => boolean,
+    ): Promise<ContextProbeResult<T>> {
+        const result = await evaluateAcrossContexts<T>(this.cdpService, expression, accept, {
             awaitPromise: true,
-        };
-        const contextId = this.cdpService.getPrimaryContextId?.();
-        if (contextId !== null && contextId !== undefined) {
-            params.contextId = contextId;
+        });
+        if (
+            result.contextId !== null
+            && accept(result.value)
+            && this.lastContentContextId !== result.contextId
+        ) {
+            this.lastContentContextId = result.contextId;
+            logger.debug(
+                `[ResponseMonitor] Using context ${result.contextId} (${result.contextName ?? 'unknown'} | ${result.contextUrl ?? 'no-url'})`,
+            );
         }
-        return params;
+        return result;
+    }
+
+    private async logStructuredExtractionDiagnostics(payload: unknown): Promise<void> {
+        try {
+            const dumpResult = await this.evaluateAcrossContexts<any[] | null>(
+                RESPONSE_SELECTORS.DUMP_ALL_TEXTS,
+                (value) => Array.isArray(value) && value.length > 0,
+            );
+            const dumpValue = Array.isArray(dumpResult.value) ? dumpResult.value : [];
+            const accepted = dumpValue.filter((entry: any) => !entry?.skip).slice(0, 5);
+            const skipped = dumpValue.filter((entry: any) => entry?.skip).slice(0, 5);
+
+            logger.warn(
+                '[ResponseMonitor:diag] Structured payload invalid. Candidates:',
+                JSON.stringify({
+                    payloadType: payload === null ? 'null' : typeof payload,
+                    contextId: dumpResult.contextId,
+                    contextUrl: dumpResult.contextUrl,
+                    totalCandidates: dumpValue.length,
+                    accepted: accepted.map((entry: any) => ({
+                        sel: entry.sel,
+                        len: entry.len,
+                        preview: entry.preview,
+                    })),
+                    skipped: skipped.map((entry: any) => ({
+                        sel: entry.sel,
+                        skip: entry.skip,
+                        len: entry.len,
+                        preview: entry.preview,
+                    })),
+                }),
+            );
+        } catch (error) {
+            logger.warn('[ResponseMonitor:diag] DUMP_ALL_TEXTS failed:', error);
+        }
+
+        try {
+            const domResult = await this.evaluateAcrossContexts<any>(
+                RESPONSE_SELECTORS.DOM_DIAGNOSTIC,
+                (value) => !!value && typeof value === 'object' && (
+                    Array.isArray((value as any).allTextNodes)
+                    || Array.isArray((value as any).activityNodes)
+                    || Array.isArray((value as any).detailsDump)
+                ),
+            );
+            const domValue = domResult.value;
+            logger.warn(
+                '[ResponseMonitor:diag] DOM_DIAGNOSTIC:',
+                JSON.stringify({
+                    contextId: domResult.contextId,
+                    contextUrl: domResult.contextUrl,
+                    detailsCount: domValue?.detailsCount ?? null,
+                    detailsDump: Array.isArray(domValue?.detailsDump) ? domValue.detailsDump.slice(0, 3) : [],
+                    activityNodes: Array.isArray(domValue?.activityNodes) ? domValue.activityNodes.slice(0, 5) : [],
+                    allTextNodes: Array.isArray(domValue?.allTextNodes) ? domValue.allTextNodes.slice(0, 5) : [],
+                }),
+            );
+        } catch (error) {
+            logger.warn('[ResponseMonitor:diag] DOM_DIAGNOSTIC failed:', error);
+        }
     }
 
     /**
@@ -803,19 +1043,19 @@ export class ResponseMonitor {
     private async poll(): Promise<void> {
         try {
             // 1. Stop button check
-            const stopResult = await this.cdpService.call(
-                'Runtime.evaluate',
-                this.buildEvaluateParams(RESPONSE_SELECTORS.STOP_BUTTON),
+            const stopResult = await this.evaluateAcrossContexts<{ isGenerating?: boolean } | null>(
+                RESPONSE_SELECTORS.STOP_BUTTON,
+                (value) => !!(value && typeof value === 'object' && (value as any).isGenerating),
             );
-            const stopValue = stopResult?.result?.value;
+            const stopValue = stopResult.value;
             const isGenerating = !!(stopValue && typeof stopValue === 'object' && (stopValue as any).isGenerating);
 
             // 2. Quota error check
-            const quotaResult = await this.cdpService.call(
-                'Runtime.evaluate',
-                this.buildEvaluateParams(RESPONSE_SELECTORS.QUOTA_ERROR),
+            const quotaResult = await this.evaluateAcrossContexts<boolean | null>(
+                RESPONSE_SELECTORS.QUOTA_ERROR,
+                (value) => value === true,
             );
-            const quotaDetected = quotaResult?.result?.value === true;
+            const quotaDetected = quotaResult.value === true;
 
             // 3. Text extraction (structured or legacy)
             let currentText: string | null = null;
@@ -824,11 +1064,11 @@ export class ResponseMonitor {
             if (this.extractionMode === 'structured') {
                 // Structured: use DOM segment extraction with HTML-to-Markdown
                 try {
-                    const structuredResult = await this.cdpService.call(
-                        'Runtime.evaluate',
-                        this.buildEvaluateParams(RESPONSE_SELECTORS.RESPONSE_STRUCTURED),
+                    const structuredResult = await this.evaluateAcrossContexts<unknown>(
+                        RESPONSE_SELECTORS.RESPONSE_STRUCTURED,
+                        (value) => classifyAssistantSegments(value).diagnostics.source === 'dom-structured',
                     );
-                    const payload = structuredResult?.result?.value;
+                    const payload = structuredResult.value;
                     const classified = classifyAssistantSegments(payload);
 
                     if (classified.diagnostics.source === 'dom-structured') {
@@ -852,6 +1092,7 @@ export class ResponseMonitor {
                             '| payload type:', typeof payload,
                             '| payload:', payload === null ? 'null' : payload === undefined ? 'undefined' : 'object',
                         );
+                        await this.logStructuredExtractionDiagnostics(payload);
                     }
                 } catch (error) {
                     logger.warn('[ResponseMonitor:poll] RESPONSE_STRUCTURED failed, falling back to legacy:', error);
@@ -860,26 +1101,21 @@ export class ResponseMonitor {
 
             // Legacy path (or fallback from structured)
             if (currentText === null) {
-                const textResult = await this.cdpService.call(
-                    'Runtime.evaluate',
-                    this.buildEvaluateParams(RESPONSE_SELECTORS.RESPONSE_TEXT),
+                const textResult = await this.evaluateAcrossContexts<string | null>(
+                    RESPONSE_SELECTORS.RESPONSE_TEXT,
+                    (value) => typeof value === 'string' && value.trim().length > 0,
                 );
-                const rawText = textResult?.result?.value;
-                const exceptionDetail = textResult?.result?.exceptionDetails ?? textResult?.exceptionDetails;
-                if (exceptionDetail) {
-                    logger.warn('[ResponseMonitor:poll] RESPONSE_TEXT threw:', exceptionDetail.text ?? JSON.stringify(exceptionDetail).slice(0, 200));
-                }
-                currentText = typeof rawText === 'string' ? rawText.trim() || null : null;
+                currentText = typeof textResult.value === 'string' ? textResult.value.trim() || null : null;
             }
 
             // 4. Process log extraction — always when structured didn't handle it
             if (!structuredHandledLogs) {
                 try {
-                    const logResult = await this.cdpService.call(
-                        'Runtime.evaluate',
-                        this.buildEvaluateParams(RESPONSE_SELECTORS.PROCESS_LOGS),
+                    const logResult = await this.evaluateAcrossContexts<string[] | null>(
+                        RESPONSE_SELECTORS.PROCESS_LOGS,
+                        (value) => Array.isArray(value) && value.length > 0,
                     );
-                    const logEntries = logResult?.result?.value;
+                    const logEntries = logResult.value;
                     if (Array.isArray(logEntries)) {
                         this.emitNewProcessLogs(logEntries);
                     }

--- a/src/services/userMessageDetector.ts
+++ b/src/services/userMessageDetector.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'events';
 import { createHash } from 'node:crypto';
 import { logger } from '../utils/logger';
 import { CdpService } from './cdpService';
@@ -13,8 +14,6 @@ export interface UserMessageDetectorOptions {
     cdpService: CdpService;
     /** Poll interval in milliseconds (default: 2000ms) */
     pollIntervalMs?: number;
-    /** Callback when a new user message is detected */
-    onUserMessage: (info: UserMessageInfo) => void;
 }
 
 /**
@@ -91,10 +90,9 @@ function computeEchoHash(text: string): string {
  * Detects user messages posted directly in the Antigravity UI (e.g., from a PC).
  * Follows the ApprovalDetector polling pattern.
  */
-export class UserMessageDetector {
+export class UserMessageDetector extends EventEmitter {
     private readonly cdpService: CdpService;
     private readonly pollIntervalMs: number;
-    private readonly onUserMessage: (info: UserMessageInfo) => void;
 
     private pollTimer: NodeJS.Timeout | null = null;
     private isRunning: boolean = false;
@@ -109,9 +107,9 @@ export class UserMessageDetector {
     private isPriming: boolean = false;
 
     constructor(options: UserMessageDetectorOptions) {
+        super();
         this.cdpService = options.cdpService;
         this.pollIntervalMs = options.pollIntervalMs ?? 2000;
-        this.onUserMessage = options.onUserMessage;
     }
 
     /**
@@ -238,7 +236,7 @@ export class UserMessageDetector {
                 this.lastDetectedHash = hash;
                 this.addToSeenHashes(hash);
                 logger.debug(`[UserMessageDetector] New message detected: "${preview}..."`);
-                this.onUserMessage(info);
+                this.emit('message', info);
             }
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);

--- a/src/ui/accountUi.ts
+++ b/src/ui/accountUi.ts
@@ -1,0 +1,92 @@
+import { ActionRowBuilder, EmbedBuilder, StringSelectMenuBuilder } from 'discord.js';
+
+import type { MessagePayload } from '../platform/types';
+import {
+    createRichContent,
+    withTitle,
+    withDescription,
+    withColor,
+    withFooter,
+    withTimestamp,
+} from '../platform/richContentBuilder';
+
+export const ACCOUNT_SELECT_ID = 'account_select';
+
+export function buildAccountPayload(currentAccount: string, accountNames: string[]): MessagePayload {
+    const names = accountNames.length > 0 ? accountNames : ['default'];
+
+    const rc = withTimestamp(
+        withFooter(
+            withDescription(
+                withColor(
+                    withTitle(createRichContent(), 'Account Management'),
+                    0x57F287,
+                ),
+                `**Current Account:** ${currentAccount}\n\n` +
+                `**Available Accounts (${names.length})**\n` +
+                names.map((name) => {
+                    const icon = name === currentAccount ? '[x]' : '[ ]';
+                    return `${icon} **${name}**`;
+                }).join('\n'),
+            ),
+            'Select an account from the dropdown below',
+        ),
+    );
+
+    return {
+        richContent: rc,
+        components: [
+            {
+                components: [
+                    {
+                        type: 'selectMenu' as const,
+                        customId: ACCOUNT_SELECT_ID,
+                        placeholder: 'Select an account...',
+                        options: names.map((name) => ({
+                            label: name,
+                            value: name,
+                            isDefault: name === currentAccount,
+                        })),
+                    },
+                ],
+            },
+        ],
+    };
+}
+
+export async function sendAccountUI(
+    target: { editReply: (opts: any) => Promise<any> },
+    currentAccount: string,
+    accountNames: string[],
+): Promise<void> {
+    const names = accountNames.length > 0 ? accountNames : ['default'];
+
+    const embed = new EmbedBuilder()
+        .setTitle('Account Management')
+        .setColor(0x57F287)
+        .setDescription(
+            `**Current Account:** ${currentAccount}\n\n` +
+            `**Available Accounts (${names.length})**\n` +
+            names.map((name) => {
+                const icon = name === currentAccount ? '[x]' : '[ ]';
+                return `${icon} **${name}**`;
+            }).join('\n'),
+        )
+        .setFooter({ text: 'Select an account from the dropdown below' })
+        .setTimestamp();
+
+    const selectMenu = new StringSelectMenuBuilder()
+        .setCustomId(ACCOUNT_SELECT_ID)
+        .setPlaceholder('Select an account...')
+        .addOptions(
+            names.map((name) => ({
+                label: name,
+                value: name,
+                default: name === currentAccount,
+            })),
+        );
+
+    const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(selectMenu);
+
+    await target.editReply({ content: '', embeds: [embed], components: [row] });
+}

--- a/src/utils/accountUtils.ts
+++ b/src/utils/accountUtils.ts
@@ -1,0 +1,65 @@
+export interface AccountConfigLike {
+    name: string;
+    cdpPort: number;
+}
+
+export interface ChannelPreferenceLookup {
+    getAccountName(channelId: string): string | null;
+}
+
+export interface AccountPreferenceLookup {
+    getAccountName(userId: string): string | null;
+}
+
+export function resolveValidAccountName(
+    requested: string | null | undefined,
+    accounts: AccountConfigLike[] | undefined,
+): string {
+    const safeAccounts = accounts && accounts.length > 0 ? accounts : [{ name: 'default', cdpPort: 9222 }];
+    if (!requested) return safeAccounts[0].name;
+    return safeAccounts.some((account) => account.name === requested) ? requested : safeAccounts[0].name;
+}
+
+export function listAccountNames(accounts: AccountConfigLike[] | undefined): string[] {
+    const safeAccounts = accounts && accounts.length > 0 ? accounts : [{ name: 'default', cdpPort: 9222 }];
+    return safeAccounts.map((account) => account.name);
+}
+
+export function inferParentScopeChannelId(channelId: string, explicitParentChannelId?: string | null): string | null {
+    if (explicitParentChannelId && explicitParentChannelId.trim().length > 0) {
+        return explicitParentChannelId.trim();
+    }
+
+    const underscoreIndex = channelId.indexOf('_');
+    if (underscoreIndex > 0) {
+        return channelId.slice(0, underscoreIndex);
+    }
+
+    return null;
+}
+
+export function resolveScopedAccountName(
+    options: {
+        channelId: string;
+        userId: string;
+        sessionAccountName?: string | null;
+        selectedAccountByChannel?: Map<string, string>;
+        channelPrefRepo?: ChannelPreferenceLookup;
+        accountPrefRepo?: AccountPreferenceLookup;
+        accounts?: AccountConfigLike[];
+        parentChannelId?: string | null;
+    },
+): string {
+    const parentChannelId = inferParentScopeChannelId(options.channelId, options.parentChannelId);
+
+    return resolveValidAccountName(
+        options.sessionAccountName
+            ?? options.selectedAccountByChannel?.get(options.channelId)
+            ?? options.channelPrefRepo?.getAccountName(options.channelId)
+            ?? (parentChannelId ? options.selectedAccountByChannel?.get(parentChannelId) : null)
+            ?? (parentChannelId ? options.channelPrefRepo?.getAccountName(parentChannelId) : null)
+            ?? options.accountPrefRepo?.getAccountName(options.userId)
+            ?? 'default',
+        options.accounts,
+    );
+}

--- a/src/utils/cdpPorts.ts
+++ b/src/utils/cdpPorts.ts
@@ -1,2 +1,117 @@
+/** Default CDP port list scanned for Antigravity connections. */
+export const DEFAULT_CDP_PORTS = [9222, 9223, 9333, 9444, 9555, 9666] as const;
+
+export interface AntigravityAccountConfigLike {
+    name: string;
+    cdpPort: number;
+    userDataDir?: string;
+}
+
+function parsePort(raw: string | undefined): number | null {
+    const port = Number(raw);
+    if (!Number.isInteger(port)) return null;
+    if (port < 1 || port > 65535) return null;
+    return port;
+}
+
+export function normalizeAntigravityAccounts(
+    accounts: readonly AntigravityAccountConfigLike[] | undefined,
+): AntigravityAccountConfigLike[] {
+    if (!accounts || accounts.length === 0) {
+        return [{ name: 'default', cdpPort: DEFAULT_CDP_PORTS[0] }];
+    }
+
+    const seenNames = new Set<string>();
+    const normalized: AntigravityAccountConfigLike[] = [];
+
+    for (const account of accounts) {
+        const name = String(account.name || '').trim();
+        const cdpPort = parsePort(String(account.cdpPort));
+        if (!name || cdpPort === null || seenNames.has(name)) continue;
+        seenNames.add(name);
+        const userDataDir = typeof account.userDataDir === 'string'
+            ? account.userDataDir.trim()
+            : '';
+        normalized.push({
+            name,
+            cdpPort,
+            ...(userDataDir ? { userDataDir } : {}),
+        });
+    }
+
+    return normalized.length > 0
+        ? normalized
+        : [{ name: 'default', cdpPort: DEFAULT_CDP_PORTS[0] }];
+}
+
+export function parseAntigravityAccounts(
+    rawValue: string | undefined,
+): AntigravityAccountConfigLike[] {
+    if (!rawValue || rawValue.trim().length === 0) {
+        return [{ name: 'default', cdpPort: DEFAULT_CDP_PORTS[0] }];
+    }
+
+    const parsed = rawValue
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0)
+        .map((entry) => {
+            const colonIndex = entry.indexOf(':');
+            if (colonIndex <= 0) return null;
+
+            const name = entry.slice(0, colonIndex).trim();
+            const rest = entry.slice(colonIndex + 1).trim();
+            const atIndex = rest.indexOf('@');
+            const portRaw = atIndex >= 0 ? rest.slice(0, atIndex).trim() : rest;
+            const userDataDirRaw = atIndex >= 0 ? rest.slice(atIndex + 1).trim() : '';
+            const cdpPort = parsePort(portRaw);
+            if (!name || cdpPort === null) return null;
+            return {
+                name,
+                cdpPort,
+                ...(userDataDirRaw ? { userDataDir: userDataDirRaw } : {}),
+            };
+        })
+        .filter((account): account is AntigravityAccountConfigLike => account !== null);
+
+    return normalizeAntigravityAccounts(parsed);
+}
+
+export function serializeAntigravityAccounts(
+    accounts: readonly AntigravityAccountConfigLike[] | undefined,
+): string {
+    return normalizeAntigravityAccounts(accounts)
+        .map((account) => {
+            const userDataDir = typeof account.userDataDir === 'string'
+                ? account.userDataDir.trim()
+                : '';
+            return userDataDir
+                ? `${account.name}:${account.cdpPort}@${userDataDir}`
+                : `${account.name}:${account.cdpPort}`;
+        })
+        .join(',');
+}
+
+export function getConfiguredCdpPorts(rawValue?: string): number[] {
+    if (!rawValue || rawValue.trim().length === 0) {
+        return [...DEFAULT_CDP_PORTS];
+    }
+
+    const accounts = parseAntigravityAccounts(rawValue);
+    const uniquePorts = new Set<number>();
+
+    for (const account of accounts) {
+        uniquePorts.add(account.cdpPort);
+    }
+
+    return uniquePorts.size > 0 ? [...uniquePorts] : [...DEFAULT_CDP_PORTS];
+}
+
+export function getAccountPortMap(rawValue?: string): Record<string, number> {
+    return Object.fromEntries(
+        parseAntigravityAccounts(rawValue).map((account) => [account.name, account.cdpPort]),
+    );
+}
+
 /** CDP port list scanned for Antigravity connections */
-export const CDP_PORTS = [9222, 9223, 9333, 9444, 9555, 9666] as const;
+export const CDP_PORTS = DEFAULT_CDP_PORTS;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,6 +1,7 @@
 import { ConfigLoader } from './configLoader';
 import type { LogLevel } from './logger';
 import type { PlatformType } from '../platform/types';
+import type { AntigravityAccountConfig } from './configLoader';
 
 export type ExtractionMode = 'legacy' | 'structured';
 
@@ -15,6 +16,8 @@ export interface AppConfig {
     autoApproveFileEdits: boolean;
     logLevel: LogLevel;
     extractionMode: ExtractionMode;
+    /** Named Antigravity instances mapped to CDP ports and optional user-data-dir. */
+    antigravityAccounts: AntigravityAccountConfig[];
     /** Telegram Bot Token (optional — required when 'telegram' is in platforms). */
     telegramToken?: string;
     /** Allowed Telegram user IDs (numeric strings). */

--- a/src/utils/configLoader.ts
+++ b/src/utils/configLoader.ts
@@ -5,6 +5,10 @@ import * as dotenv from 'dotenv';
 import type { AppConfig, ExtractionMode } from './config';
 import type { LogLevel } from './logger';
 import type { PlatformType } from '../platform/types';
+import {
+    normalizeAntigravityAccounts,
+    parseAntigravityAccounts,
+} from './cdpPorts';
 
 // Load .env at module init time (same as the original config.ts behavior).
 // dotenv will NOT override already-set env vars by default.
@@ -31,6 +35,13 @@ export interface PersistedConfig {
     telegramAllowedUserIds?: string[];
     platforms?: PlatformType[];
     responseTimeoutMs?: number;
+    antigravityAccounts?: string | AntigravityAccountConfig[];
+}
+
+export interface AntigravityAccountConfig {
+    name: string;
+    cdpPort: number;
+    userDataDir?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -122,6 +133,10 @@ function mergeConfig(persisted: PersistedConfig): AppConfig {
         persisted.responseTimeoutMs,
         900000,
     );
+    const antigravityAccounts = resolveAntigravityAccounts(
+        process.env.ANTIGRAVITY_ACCOUNTS,
+        persisted.antigravityAccounts,
+    );
 
     // Telegram credentials — only required when Telegram is an active platform
     const telegramToken = process.env.TELEGRAM_BOT_TOKEN ?? persisted.telegramToken ?? undefined;
@@ -143,6 +158,7 @@ function mergeConfig(persisted: PersistedConfig): AppConfig {
         logLevel,
         extractionMode,
         responseTimeoutMs,
+        antigravityAccounts,
         telegramToken,
         telegramAllowedUserIds,
         platforms,
@@ -197,6 +213,23 @@ function resolveTelegramAllowedUserIds(persisted: PersistedConfig): string[] | u
         return [...persisted.telegramAllowedUserIds];
     }
     return undefined;
+}
+
+function resolveAntigravityAccounts(
+    envValue: string | undefined,
+    persistedValue: string | AntigravityAccountConfig[] | undefined,
+): AntigravityAccountConfig[] {
+    if (envValue && envValue.trim().length > 0) {
+        return parseAntigravityAccounts(envValue);
+    }
+
+    if (typeof persistedValue === 'string' && persistedValue.trim().length > 0) {
+        return parseAntigravityAccounts(persistedValue);
+    }
+
+    return Array.isArray(persistedValue)
+        ? normalizeAntigravityAccounts(persistedValue)
+        : normalizeAntigravityAccounts(undefined);
 }
 
 const VALID_PLATFORMS: readonly PlatformType[] = ['discord', 'telegram'];

--- a/tests/bot.modelCommand.test.ts
+++ b/tests/bot.modelCommand.test.ts
@@ -1,0 +1,49 @@
+jest.mock('../src/services/cdpService', () => ({
+    CdpService: jest.fn(),
+}));
+
+import { handleSlashInteraction } from '../src/bot';
+
+describe('/model command', () => {
+    it('connects through the current channel workspace when no cached channel CDP exists', async () => {
+        const setUiModel = jest.fn().mockResolvedValue({ ok: true, model: 'gemini-3-flash' });
+        const cdp = { setUiModel };
+        const interaction = {
+            commandName: 'model',
+            channelId: 'channel-1',
+            channel: {},
+            user: { id: 'user-1' },
+            options: { getString: jest.fn().mockReturnValue('gemini-3-flash'), getSubcommand: jest.fn() },
+            editReply: jest.fn().mockResolvedValue(undefined),
+        } as any;
+        const bridge = {
+            selectedAccountByChannel: new Map<string, string>(),
+            pool: {
+                getConnected: jest.fn().mockReturnValue(null),
+                getOrConnect: jest.fn().mockResolvedValue(cdp),
+                extractProjectName: jest.fn().mockReturnValue('demo-project'),
+            },
+            autoAccept: { isEnabled: jest.fn().mockReturnValue(false), handle: jest.fn() },
+            quota: { fetchQuota: jest.fn().mockResolvedValue([]) },
+        } as any;
+
+        await handleSlashInteraction(
+            interaction,
+            {} as any,
+            bridge,
+            { getWorkspaceForChannel: jest.fn().mockReturnValue('/tmp/demo-project') } as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            bridge.autoAccept,
+            {} as any,
+            {} as any,
+            {} as any,
+        );
+
+        expect(bridge.pool.getOrConnect).toHaveBeenCalledWith('/tmp/demo-project', { name: 'default' });
+        expect(setUiModel).toHaveBeenCalledWith('gemini-3-flash');
+        expect(interaction.editReply).toHaveBeenCalledWith({ content: 'Model changed to **gemini-3-flash**.' });
+    });
+});

--- a/tests/bot.openCommand.test.ts
+++ b/tests/bot.openCommand.test.ts
@@ -1,0 +1,259 @@
+import fs from 'fs';
+
+jest.mock('../src/services/cdpService', () => ({
+    CdpService: jest.fn().mockImplementation(() => ({
+        openWorkspace: jest.fn().mockResolvedValue(true),
+        disconnect: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+import { CdpService } from '../src/services/cdpService';
+import { handleSlashInteraction } from '../src/bot';
+
+describe('/open command', () => {
+    const makeInteraction = () => ({
+        commandName: 'open',
+        channelId: 'channel-1',
+        user: { id: 'user-1' },
+        options: { getString: jest.fn(), getSubcommand: jest.fn() },
+        editReply: jest.fn().mockResolvedValue(undefined),
+    }) as any;
+
+    const makeBridge = () => ({
+        selectedAccountByChannel: new Map<string, string>(),
+        pool: {
+            extractProjectName: jest.fn().mockImplementation((workspacePath: string) => workspacePath.split('/').pop()),
+            setPreferredAccountForWorkspace: jest.fn(),
+        },
+        autoAccept: { isEnabled: jest.fn().mockReturnValue(false), handle: jest.fn() },
+    }) as any;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns an error when the bound folder does not exist', async () => {
+        const existsSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+        const statSpy = jest.spyOn(fs, 'statSync');
+
+        const interaction = makeInteraction();
+        const bridge = makeBridge();
+        const wsHandler = { getWorkspaceForChannel: jest.fn().mockReturnValue('/tmp/missing-project') } as any;
+
+        await handleSlashInteraction(
+            interaction,
+            {} as any,
+            bridge,
+            wsHandler,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            bridge.autoAccept,
+            {} as any,
+            {} as any,
+            {} as any,
+        );
+
+        expect(interaction.editReply).toHaveBeenCalledWith({
+            content: '❌ Project folder does not exist: `/tmp/missing-project`',
+        });
+        expect(CdpService).not.toHaveBeenCalled();
+
+        existsSpy.mockRestore();
+        statSpy.mockRestore();
+    });
+
+    it('opens the bound project in the selected account', async () => {
+        jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+        jest.spyOn(fs, 'statSync').mockReturnValue({ isDirectory: () => true } as fs.Stats);
+
+        const interaction = makeInteraction();
+        const bridge = makeBridge();
+        const wsHandler = { getWorkspaceForChannel: jest.fn().mockReturnValue('/tmp/demo-project') } as any;
+        const channelPrefRepo = { getAccountName: jest.fn().mockReturnValue('work1') } as any;
+
+        await handleSlashInteraction(
+            interaction,
+            {} as any,
+            bridge,
+            wsHandler,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            bridge.autoAccept,
+            {} as any,
+            {} as any,
+            {} as any,
+            undefined,
+            undefined,
+            undefined,
+            channelPrefRepo,
+            [
+                { name: 'default', cdpPort: 9222 },
+                { name: 'work1', cdpPort: 9333 },
+            ],
+        );
+
+        expect(CdpService).toHaveBeenCalledWith(expect.objectContaining({
+            activeAccountName: 'work1',
+            accountPorts: { default: 9222, work1: 9333 },
+        }));
+
+        const instance = (CdpService as unknown as jest.Mock).mock.results[0].value;
+        expect(instance.openWorkspace).toHaveBeenCalledWith('/tmp/demo-project');
+        expect(interaction.editReply).toHaveBeenCalledWith({
+            content: '✅ Opened **demo-project** in account **work1** (CDP 9333).',
+        });
+    });
+});
+
+describe('/account command', () => {
+    const makeInteraction = () => ({
+        commandName: 'account',
+        channelId: 'channel-1',
+        user: { id: 'user-1' },
+        options: { getString: jest.fn().mockReturnValue(null), getSubcommand: jest.fn() },
+        editReply: jest.fn().mockResolvedValue(undefined),
+    }) as any;
+
+    it('shows selectable account dropdown when no name is provided', async () => {
+        const interaction = makeInteraction();
+        const bridge = {
+            selectedAccountByChannel: new Map<string, string>([['channel-1', 'work1']]),
+            pool: {
+                setPreferredAccountForWorkspace: jest.fn(),
+            },
+            autoAccept: { isEnabled: jest.fn().mockReturnValue(false), handle: jest.fn() },
+        } as any;
+        const accountPrefRepo = { getAccountName: jest.fn().mockReturnValue('default') } as any;
+        const channelPrefRepo = { getAccountName: jest.fn().mockReturnValue('work1') } as any;
+
+        await handleSlashInteraction(
+            interaction,
+            {} as any,
+            bridge,
+            { getWorkspaceForChannel: jest.fn().mockReturnValue('/tmp/demo-project') } as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            bridge.autoAccept,
+            {} as any,
+            {} as any,
+            {} as any,
+            undefined,
+            undefined,
+            accountPrefRepo,
+            channelPrefRepo,
+            [
+                { name: 'default', cdpPort: 9222 },
+                { name: 'work1', cdpPort: 9333 },
+            ],
+        );
+
+        expect(interaction.editReply).toHaveBeenCalledTimes(1);
+        const payload = interaction.editReply.mock.calls[0][0];
+        expect(payload.embeds?.length).toBeGreaterThan(0);
+        expect(payload.components?.length).toBeGreaterThan(0);
+    });
+
+    it('stores session account without mutating channel or user defaults for session channels', async () => {
+        const interaction = {
+            commandName: 'account',
+            channelId: 'channel-1',
+            user: { id: 'user-1' },
+            options: { getString: jest.fn().mockReturnValue('work1'), getSubcommand: jest.fn() },
+            editReply: jest.fn().mockResolvedValue(undefined),
+        } as any;
+        const bridge = {
+            selectedAccountByChannel: new Map<string, string>(),
+            pool: { setPreferredAccountForWorkspace: jest.fn() },
+            autoAccept: { isEnabled: jest.fn().mockReturnValue(false), handle: jest.fn() },
+        } as any;
+        const accountPrefRepo = { setAccountName: jest.fn() } as any;
+        const channelPrefRepo = { setAccountName: jest.fn() } as any;
+        const chatSessionRepo = {
+            findByChannelId: jest.fn().mockReturnValue({ channelId: 'channel-1', activeAccountName: 'default' }),
+            setActiveAccountName: jest.fn(),
+        } as any;
+
+        await handleSlashInteraction(
+            interaction,
+            {} as any,
+            bridge,
+            { getWorkspaceForChannel: jest.fn().mockReturnValue('/tmp/demo-project') } as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            bridge.autoAccept,
+            {} as any,
+            {} as any,
+            {} as any,
+            undefined,
+            undefined,
+            accountPrefRepo,
+            channelPrefRepo,
+            [
+                { name: 'default', cdpPort: 9222 },
+                { name: 'work1', cdpPort: 9333 },
+            ],
+            chatSessionRepo,
+        );
+
+        expect(chatSessionRepo.setActiveAccountName).toHaveBeenCalledWith('channel-1', 'work1');
+        expect(accountPrefRepo.setAccountName).not.toHaveBeenCalled();
+        expect(channelPrefRepo.setAccountName).not.toHaveBeenCalled();
+        expect(interaction.editReply).toHaveBeenCalledWith({ content: '✅ Switched session account to **work1**.' });
+    });
+});
+
+describe('/project account subcommand', () => {
+    it('stores the channel-scoped project account binding', async () => {
+        const interaction = {
+            commandName: 'project',
+            channelId: 'channel-1',
+            user: { id: 'user-1' },
+            options: {
+                getString: jest.fn().mockReturnValue('work1'),
+                getSubcommand: jest.fn().mockReturnValue('account'),
+            },
+            channel: {},
+            editReply: jest.fn().mockResolvedValue(undefined),
+        } as any;
+        const bridge = {
+            selectedAccountByChannel: new Map<string, string>(),
+            pool: { setPreferredAccountForWorkspace: jest.fn(), extractProjectName: jest.fn() },
+            autoAccept: { isEnabled: jest.fn().mockReturnValue(false), handle: jest.fn() },
+        } as any;
+        const channelPrefRepo = { setAccountName: jest.fn(), getAccountName: jest.fn().mockReturnValue(null) } as any;
+
+        await handleSlashInteraction(
+            interaction,
+            {} as any,
+            bridge,
+            { getWorkspaceForChannel: jest.fn().mockReturnValue('/tmp/demo-project') } as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            bridge.autoAccept,
+            {} as any,
+            {} as any,
+            {} as any,
+            undefined,
+            undefined,
+            undefined,
+            channelPrefRepo,
+            [
+                { name: 'default', cdpPort: 9222 },
+                { name: 'work1', cdpPort: 9333 },
+            ],
+        );
+
+        expect(channelPrefRepo.setAccountName).toHaveBeenCalledWith('channel-1', 'work1');
+        expect(interaction.editReply).toHaveBeenCalledWith({ content: '✅ Bound this project channel to account **work1**.' });
+    });
+});

--- a/tests/bot.projectReopen.test.ts
+++ b/tests/bot.projectReopen.test.ts
@@ -1,0 +1,446 @@
+jest.mock('../src/services/conversationTransferService', () => ({
+    findTrajectoryEntriesByTitle: jest.fn().mockReturnValue([]),
+    findLatestTrajectoryEntryByTitle: jest.fn(),
+    transferConversationByConversationId: jest.fn(),
+    transferConversationByTitle: jest.fn(),
+    waitForConversationPersistence: jest.fn(),
+    waitForConversationPersistenceByConversationId: jest.fn(),
+}));
+
+jest.mock('../src/services/antigravityProcessService', () => ({
+    quitAntigravityProfile: jest.fn(),
+}));
+
+jest.mock('../src/services/cdpService', () => ({
+    CdpService: jest.fn(),
+}));
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { handleSlashInteraction } from '../src/bot';
+import { ChatSessionService } from '../src/services/chatSessionService';
+import {
+    findLatestTrajectoryEntryByTitle,
+    findTrajectoryEntriesByTitle,
+    transferConversationByConversationId,
+    transferConversationByTitle,
+    waitForConversationPersistence,
+    waitForConversationPersistenceByConversationId,
+} from '../src/services/conversationTransferService';
+import { quitAntigravityProfile } from '../src/services/antigravityProcessService';
+import { CdpService } from '../src/services/cdpService';
+
+describe('/project reopen', () => {
+    const mockedFindTrajectoryEntriesByTitle = findTrajectoryEntriesByTitle as jest.MockedFunction<typeof findTrajectoryEntriesByTitle>;
+    const mockedFindLatestTrajectoryEntryByTitle = findLatestTrajectoryEntryByTitle as jest.MockedFunction<typeof findLatestTrajectoryEntryByTitle>;
+    const mockedTransferConversationByConversationId = transferConversationByConversationId as jest.MockedFunction<typeof transferConversationByConversationId>;
+    const mockedTransferConversationByTitle = transferConversationByTitle as jest.MockedFunction<typeof transferConversationByTitle>;
+    const mockedWaitForConversationPersistence = waitForConversationPersistence as jest.MockedFunction<typeof waitForConversationPersistence>;
+    const mockedWaitForConversationPersistenceByConversationId = waitForConversationPersistenceByConversationId as jest.MockedFunction<typeof waitForConversationPersistenceByConversationId>;
+    const mockedQuitAntigravityProfile = quitAntigravityProfile as jest.MockedFunction<typeof quitAntigravityProfile>;
+    const mockedCdpService = CdpService as unknown as jest.Mock;
+
+    let workspacePath: string;
+    let activateSessionSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), 'lazy-gravity-project-reopen-'));
+        activateSessionSpy = jest.spyOn(ChatSessionService.prototype, 'activateSessionByTitle').mockResolvedValue({ ok: true });
+        mockedFindTrajectoryEntriesByTitle.mockReset();
+        mockedFindLatestTrajectoryEntryByTitle.mockReset();
+        mockedTransferConversationByConversationId.mockReset();
+        mockedTransferConversationByTitle.mockReset();
+        mockedWaitForConversationPersistence.mockReset();
+        mockedWaitForConversationPersistenceByConversationId.mockReset();
+        mockedQuitAntigravityProfile.mockReset();
+        mockedCdpService.mockReset();
+        mockedFindTrajectoryEntriesByTitle.mockReturnValue([]);
+        mockedFindLatestTrajectoryEntryByTitle.mockReturnValue(undefined);
+        mockedTransferConversationByConversationId.mockReturnValue({
+            conversationId: 'conv-123',
+            bundleDir: '/tmp/unused-bundle',
+            dbBackupPath: '/tmp/work3-state.vscdb.bak',
+        });
+        mockedTransferConversationByTitle.mockReturnValue({
+            conversationId: 'conv-123',
+            bundleDir: '/tmp/unused-bundle',
+            dbBackupPath: '/tmp/work3-state.vscdb.bak',
+        });
+        mockedWaitForConversationPersistence.mockResolvedValue({
+            conversationId: 'conv-123',
+            title: 'Listing DevTools Directory',
+            outerEntryBytes: Buffer.from('entry'),
+            rawDataBase64: 'raw',
+        });
+        mockedWaitForConversationPersistenceByConversationId.mockResolvedValue({
+            conversationId: 'conv-123',
+            title: 'Listing DevTools Directory',
+            outerEntryBytes: Buffer.from('entry'),
+            rawDataBase64: 'raw',
+        });
+        mockedQuitAntigravityProfile.mockResolvedValue(true);
+        mockedCdpService.mockImplementation(() => ({
+            discoverAndConnectForWorkspace: jest.fn().mockResolvedValue(true),
+            inspectWorkspaceRuntimeState: jest.fn().mockResolvedValue({
+                isGenerating: false,
+                sessionTitle: 'Listing DevTools Directory',
+                hasActiveChat: true,
+                contextId: 1,
+            }),
+            closeCurrentTargetGracefully: jest.fn().mockResolvedValue(true),
+            openWorkspace: jest.fn().mockResolvedValue(undefined),
+            disconnect: jest.fn().mockResolvedValue(undefined),
+        }));
+    });
+
+    afterEach(() => {
+        activateSessionSpy.mockRestore();
+        fs.rmSync(workspacePath, { recursive: true, force: true });
+    });
+
+    it('imports the saved conversation into the selected account before reopening the workspace', async () => {
+        const interaction = {
+            commandName: 'project',
+            channelId: 'channel-1',
+            user: { id: 'user-1' },
+            options: {
+                getSubcommand: jest.fn().mockReturnValue('reopen'),
+                getString: jest.fn().mockReturnValue(null),
+            },
+            editReply: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        const bridge = {
+            selectedAccountByChannel: new Map<string, string>([['channel-1', 'work3']]),
+            lastActiveWorkspace: null,
+            pool: {
+                extractProjectName: jest.fn().mockReturnValue('DevTools'),
+                getPreferredAccountForWorkspace: jest.fn().mockReturnValue('default'),
+                setPreferredAccountForWorkspace: jest.fn(),
+            },
+            autoAccept: { isEnabled: jest.fn().mockReturnValue(false), handle: jest.fn() },
+        } as any;
+
+        const chatSessionRepo = {
+            findByChannelId: jest.fn().mockReturnValue({
+                channelId: 'channel-1',
+                conversationId: 'conv-123',
+                activeAccountName: 'work3',
+                originAccountName: 'default',
+                displayName: 'Listing DevTools Directory',
+            }),
+            setActiveAccountName: jest.fn(),
+            setConversationId: jest.fn(),
+        } as any;
+
+        await handleSlashInteraction(
+            interaction,
+            {} as any,
+            bridge,
+            { getWorkspaceForChannel: jest.fn().mockReturnValue(workspacePath) } as any,
+            {} as any,
+            {} as any,
+            { getCurrentMode: jest.fn().mockReturnValue('normal') } as any,
+            {} as any,
+            bridge.autoAccept,
+            {} as any,
+            {} as any,
+            {} as any,
+            undefined,
+            undefined,
+            { getAccountName: jest.fn().mockReturnValue(null) } as any,
+            { getAccountName: jest.fn().mockReturnValue(null), setAccountName: jest.fn() } as any,
+            [
+                { name: 'default', cdpPort: 9222, userDataDir: '/tmp/default-profile' },
+                { name: 'work3', cdpPort: 9444, userDataDir: '/tmp/work3-profile' },
+            ],
+            chatSessionRepo,
+        );
+
+        expect(mockedTransferConversationByConversationId).toHaveBeenCalledWith(
+            'default',
+            'work3',
+            'conv-123',
+        );
+        expect(mockedWaitForConversationPersistenceByConversationId).toHaveBeenCalledWith(
+            'default',
+            'conv-123',
+            expect.objectContaining({ timeoutMs: 20000, pollIntervalMs: 500 }),
+        );
+        expect(activateSessionSpy).toHaveBeenCalled();
+        expect(mockedQuitAntigravityProfile).toHaveBeenNthCalledWith(1, 'default');
+        expect(mockedQuitAntigravityProfile).toHaveBeenNthCalledWith(2, 'work3');
+        expect(mockedCdpService).toHaveBeenCalledWith(expect.objectContaining({
+            accountName: 'default',
+            accountPorts: { default: 9222, work3: 9444 },
+        }));
+        expect(mockedCdpService).toHaveBeenCalledWith(expect.objectContaining({
+            accountName: 'work3',
+            accountPorts: { default: 9222, work3: 9444 },
+        }));
+        expect(chatSessionRepo.setActiveAccountName).toHaveBeenCalledWith('channel-1', 'work3');
+        expect(chatSessionRepo.setConversationId).toHaveBeenCalledWith('channel-1', 'conv-123');
+        expect(bridge.pool.setPreferredAccountForWorkspace).toHaveBeenCalledWith(workspacePath, 'work3');
+        expect(interaction.editReply).toHaveBeenCalledWith({
+            content: [
+                '✅ Reopened **DevTools** in account **work3** (CDP 9444).',
+                'Active Account: **work3**',
+                'Origin Account: **default**',
+                'Conversation Title: **Listing DevTools Directory**',
+            ].join('\n'),
+        });
+    });
+
+    it('falls back to the latest matching conversation when the session has no saved conversation id yet', async () => {
+        const interaction = {
+            commandName: 'project',
+            channelId: 'channel-1',
+            user: { id: 'user-1' },
+            options: {
+                getSubcommand: jest.fn().mockReturnValue('reopen'),
+                getString: jest.fn().mockReturnValue(null),
+            },
+            editReply: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        const bridge = {
+            selectedAccountByChannel: new Map<string, string>([['channel-1', 'default']]),
+            lastActiveWorkspace: null,
+            pool: {
+                extractProjectName: jest.fn().mockReturnValue('DevTools'),
+                getPreferredAccountForWorkspace: jest.fn().mockReturnValue('work4'),
+                setPreferredAccountForWorkspace: jest.fn(),
+            },
+            autoAccept: { isEnabled: jest.fn().mockReturnValue(false), handle: jest.fn() },
+        } as any;
+
+        const chatSessionRepo = {
+            findByChannelId: jest.fn().mockReturnValue({
+                channelId: 'channel-1',
+                conversationId: null,
+                activeAccountName: 'default',
+                originAccountName: 'work4',
+                displayName: 'Analyzing Project Directory',
+            }),
+            setActiveAccountName: jest.fn(),
+            setConversationId: jest.fn(),
+        } as any;
+
+        mockedWaitForConversationPersistence.mockResolvedValue({
+            conversationId: 'older-conv',
+            title: 'Analyzing Project Directory',
+            outerEntryBytes: Buffer.from('entry'),
+            rawDataBase64: 'raw',
+        });
+        mockedFindLatestTrajectoryEntryByTitle.mockReturnValue({
+            conversationId: 'latest-conv',
+            title: 'Analyzing Project Directory',
+            outerEntryBytes: Buffer.from('entry'),
+            rawDataBase64: 'raw',
+        });
+        mockedTransferConversationByConversationId.mockReturnValue({
+            conversationId: 'latest-conv',
+            bundleDir: '/tmp/unused-bundle',
+            dbBackupPath: '/tmp/default-state.vscdb.bak',
+        });
+
+        await handleSlashInteraction(
+            interaction,
+            {} as any,
+            bridge,
+            { getWorkspaceForChannel: jest.fn().mockReturnValue(workspacePath) } as any,
+            {} as any,
+            {} as any,
+            { getCurrentMode: jest.fn().mockReturnValue('normal') } as any,
+            {} as any,
+            bridge.autoAccept,
+            {} as any,
+            {} as any,
+            {} as any,
+            undefined,
+            undefined,
+            { getAccountName: jest.fn().mockReturnValue(null) } as any,
+            { getAccountName: jest.fn().mockReturnValue(null), setAccountName: jest.fn() } as any,
+            [
+                { name: 'default', cdpPort: 9222, userDataDir: '/tmp/default-profile' },
+                { name: 'work4', cdpPort: 9444, userDataDir: '/tmp/work4-profile' },
+            ],
+            chatSessionRepo,
+        );
+
+        expect(mockedWaitForConversationPersistence).toHaveBeenCalledWith(
+            'work4',
+            'Analyzing Project Directory',
+            expect.objectContaining({ timeoutMs: 20000, pollIntervalMs: 500 }),
+        );
+        expect(mockedFindLatestTrajectoryEntryByTitle).toHaveBeenCalledWith('work4', 'Analyzing Project Directory');
+        expect(chatSessionRepo.setConversationId).toHaveBeenNthCalledWith(1, 'channel-1', 'latest-conv');
+        expect(mockedTransferConversationByConversationId).toHaveBeenCalledWith('work4', 'default', 'latest-conv');
+        expect(chatSessionRepo.setConversationId).toHaveBeenNthCalledWith(2, 'channel-1', 'latest-conv');
+        expect(mockedTransferConversationByTitle).not.toHaveBeenCalled();
+    });
+
+    it('accepts an explicit reopen account override from the slash command option', async () => {
+        const interaction = {
+            commandName: 'project',
+            channelId: 'channel-1',
+            user: { id: 'user-1' },
+            options: {
+                getSubcommand: jest.fn().mockReturnValue('reopen'),
+                getString: jest.fn((name: string) => (name === 'account' ? 'work3' : null)),
+            },
+            editReply: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        const bridge = {
+            selectedAccountByChannel: new Map<string, string>([['channel-1', 'default']]),
+            lastActiveWorkspace: null,
+            pool: {
+                extractProjectName: jest.fn().mockReturnValue('DevTools'),
+                getPreferredAccountForWorkspace: jest.fn().mockReturnValue('default'),
+                setPreferredAccountForWorkspace: jest.fn(),
+            },
+            autoAccept: { isEnabled: jest.fn().mockReturnValue(false), handle: jest.fn() },
+        } as any;
+
+        const chatSessionRepo = {
+            findByChannelId: jest.fn().mockReturnValue({
+                channelId: 'channel-1',
+                conversationId: 'conv-123',
+                activeAccountName: 'default',
+                originAccountName: 'default',
+                displayName: 'Listing DevTools Directory',
+            }),
+            setActiveAccountName: jest.fn(),
+            setConversationId: jest.fn(),
+        } as any;
+
+        await handleSlashInteraction(
+            interaction,
+            {} as any,
+            bridge,
+            { getWorkspaceForChannel: jest.fn().mockReturnValue(workspacePath) } as any,
+            {} as any,
+            {} as any,
+            { getCurrentMode: jest.fn().mockReturnValue('normal') } as any,
+            {} as any,
+            bridge.autoAccept,
+            {} as any,
+            {} as any,
+            {} as any,
+            undefined,
+            undefined,
+            { getAccountName: jest.fn().mockReturnValue(null) } as any,
+            { getAccountName: jest.fn().mockReturnValue(null), setAccountName: jest.fn() } as any,
+            [
+                { name: 'default', cdpPort: 9222, userDataDir: '/tmp/default-profile' },
+                { name: 'work3', cdpPort: 9444, userDataDir: '/tmp/work3-profile' },
+            ],
+            chatSessionRepo,
+        );
+
+        expect(mockedTransferConversationByConversationId).toHaveBeenCalledWith('default', 'work3', 'conv-123');
+        expect(chatSessionRepo.setActiveAccountName).toHaveBeenCalledWith('channel-1', 'work3');
+        expect(interaction.editReply).toHaveBeenCalledWith({
+            content: [
+                '✅ Reopened **DevTools** in account **work3** (CDP 9444).',
+                'Active Account: **work3**',
+                'Origin Account: **default**',
+                'Conversation Title: **Listing DevTools Directory**',
+            ].join('\n'),
+        });
+    });
+
+    it('refuses to reopen when either source or target account still has an active task', async () => {
+        const interaction = {
+            commandName: 'project',
+            channelId: 'channel-1',
+            user: { id: 'user-1' },
+            options: {
+                getSubcommand: jest.fn().mockReturnValue('reopen'),
+                getString: jest.fn().mockReturnValue(null),
+            },
+            editReply: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        const inspectMock = jest
+            .fn()
+            .mockResolvedValueOnce({
+                isGenerating: false,
+                sessionTitle: 'Target Idle Session',
+                hasActiveChat: true,
+                contextId: 1,
+            })
+            .mockResolvedValueOnce({
+                isGenerating: true,
+                sessionTitle: 'Listing DevTools Directory',
+                hasActiveChat: true,
+                contextId: 1,
+            });
+        mockedCdpService.mockImplementation(() => {
+            return {
+                discoverAndConnectForWorkspace: jest.fn().mockResolvedValue(true),
+                inspectWorkspaceRuntimeState: inspectMock,
+                closeCurrentTargetGracefully: jest.fn().mockResolvedValue(true),
+                openWorkspace: jest.fn().mockResolvedValue(undefined),
+                disconnect: jest.fn().mockResolvedValue(undefined),
+            };
+        });
+
+        const bridge = {
+            selectedAccountByChannel: new Map<string, string>([['channel-1', 'work3']]),
+            lastActiveWorkspace: null,
+            pool: {
+                extractProjectName: jest.fn().mockReturnValue('DevTools'),
+                getPreferredAccountForWorkspace: jest.fn().mockReturnValue('default'),
+                setPreferredAccountForWorkspace: jest.fn(),
+            },
+            autoAccept: { isEnabled: jest.fn().mockReturnValue(false), handle: jest.fn() },
+        } as any;
+
+        const chatSessionRepo = {
+            findByChannelId: jest.fn().mockReturnValue({
+                channelId: 'channel-1',
+                conversationId: null,
+                activeAccountName: 'work3',
+                originAccountName: 'default',
+                displayName: 'Listing DevTools Directory',
+            }),
+            setActiveAccountName: jest.fn(),
+            setConversationId: jest.fn(),
+        } as any;
+
+        await handleSlashInteraction(
+            interaction,
+            {} as any,
+            bridge,
+            { getWorkspaceForChannel: jest.fn().mockReturnValue(workspacePath) } as any,
+            {} as any,
+            {} as any,
+            { getCurrentMode: jest.fn().mockReturnValue('normal') } as any,
+            {} as any,
+            bridge.autoAccept,
+            {} as any,
+            {} as any,
+            {} as any,
+            undefined,
+            undefined,
+            { getAccountName: jest.fn().mockReturnValue(null) } as any,
+            { getAccountName: jest.fn().mockReturnValue(null), setAccountName: jest.fn() } as any,
+            [
+                { name: 'default', cdpPort: 9222, userDataDir: '/tmp/default-profile' },
+                { name: 'work3', cdpPort: 9444, userDataDir: '/tmp/work3-profile' },
+            ],
+            chatSessionRepo,
+        );
+
+        expect(mockedTransferConversationByConversationId).not.toHaveBeenCalled();
+        expect(mockedTransferConversationByTitle).not.toHaveBeenCalled();
+        expect(mockedWaitForConversationPersistenceByConversationId).not.toHaveBeenCalled();
+        expect(mockedWaitForConversationPersistence).not.toHaveBeenCalled();
+        expect(interaction.editReply).toHaveBeenCalledWith({
+            content: '❌ Failed to reopen project in account **work3**: origin account **default** is still running session **Listing DevTools Directory**. Use `/stop` in that session, close the workspace, then rerun `/project reopen`.',
+        });
+    });
+});

--- a/tests/bot.statusCommand.test.ts
+++ b/tests/bot.statusCommand.test.ts
@@ -1,0 +1,71 @@
+import { handleSlashInteraction } from '../src/bot';
+
+describe('/status command', () => {
+    it('shows active account, original account, and conversation title', async () => {
+        const interaction = {
+            commandName: 'status',
+            channelId: 'channel-1',
+            user: { id: 'user-1' },
+            options: { getString: jest.fn().mockReturnValue(null), getSubcommand: jest.fn().mockReturnValue(null) },
+            editReply: jest.fn().mockResolvedValue(undefined),
+        } as any;
+        const bridge = {
+            selectedAccountByChannel: new Map<string, string>([['channel-1', 'work1']]),
+            lastActiveWorkspace: null,
+            pool: {
+                getActiveWorkspaceNames: jest.fn().mockReturnValue([]),
+                getConnected: jest.fn().mockReturnValue(null),
+                getUserMessageDetector: jest.fn().mockReturnValue(undefined),
+                getApprovalDetector: jest.fn().mockReturnValue(undefined),
+                extractProjectName: jest.fn(),
+            },
+            autoAccept: { isEnabled: jest.fn().mockReturnValue(false), handle: jest.fn() },
+        } as any;
+        const chatSessionRepo = {
+            findByChannelId: jest.fn().mockReturnValue({
+                channelId: 'channel-1',
+                activeAccountName: 'work1',
+                originAccountName: 'default',
+                displayName: 'Imported Session',
+            }),
+        } as any;
+
+        await handleSlashInteraction(
+            interaction,
+            {} as any,
+            bridge,
+            { getWorkspaceForChannel: jest.fn().mockReturnValue('/tmp/demo-project') } as any,
+            {} as any,
+            {} as any,
+            { getCurrentMode: jest.fn().mockReturnValue('normal') } as any,
+            {} as any,
+            bridge.autoAccept,
+            {} as any,
+            {} as any,
+            {} as any,
+            undefined,
+            undefined,
+            undefined,
+            { getAccountName: jest.fn().mockReturnValue(null) } as any,
+            [
+                { name: 'default', cdpPort: 9222 },
+                { name: 'work1', cdpPort: 9333 },
+            ],
+            chatSessionRepo,
+        );
+
+        expect(interaction.editReply).toHaveBeenCalledWith(expect.objectContaining({
+            embeds: expect.arrayContaining([
+                expect.objectContaining({
+                    data: expect.objectContaining({
+                        fields: expect.arrayContaining([
+                            expect.objectContaining({ name: 'Active Account', value: 'work1' }),
+                            expect.objectContaining({ name: 'Original Account', value: 'default' }),
+                            expect.objectContaining({ name: 'Conversation Title', value: 'Imported Session' }),
+                        ]),
+                    }),
+                }),
+            ]),
+        }));
+    });
+});

--- a/tests/bot/telegramJoinCommand.test.ts
+++ b/tests/bot/telegramJoinCommand.test.ts
@@ -24,7 +24,7 @@ describe('telegramJoinCommand.handleMirror', () => {
             },
         } as any;
         const telegramBindingRepo = {
-            findByChatId: jest.fn().mockReturnValue({
+            findByChatIdWithParentFallback: jest.fn().mockReturnValue({
                 chatId: 'chat-123',
                 workspacePath: 'project-a',
             }),

--- a/tests/bot/telegramJoinCommand.test.ts
+++ b/tests/bot/telegramJoinCommand.test.ts
@@ -1,0 +1,62 @@
+import { handleMirror } from '../../src/bot/telegramJoinCommand';
+import { ensureUserMessageDetector } from '../../src/services/cdpBridgeManager';
+
+jest.mock('../../src/services/cdpBridgeManager', () => ({
+    ...jest.requireActual('../../src/services/cdpBridgeManager'),
+    ensureUserMessageDetector: jest.fn(),
+    getCurrentChatTitle: jest.fn().mockResolvedValue(null),
+}));
+
+describe('telegramJoinCommand.handleMirror', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('looks up and registers mirror detectors by project name', async () => {
+        const getUserMessageDetector = jest.fn().mockReturnValue(undefined);
+        const getOrConnect = jest.fn().mockResolvedValue({} as any);
+        const bridge = {
+            selectedAccountByChannel: new Map<string, string>(),
+            pool: {
+                extractProjectName: jest.fn().mockReturnValue('project-a'),
+                getUserMessageDetector,
+                getOrConnect,
+            },
+        } as any;
+        const telegramBindingRepo = {
+            findByChatId: jest.fn().mockReturnValue({
+                chatId: 'chat-123',
+                workspacePath: 'project-a',
+            }),
+        } as any;
+        const workspaceService = {
+            getWorkspacePath: jest.fn().mockReturnValue('/workspace/project-a'),
+        } as any;
+        const message = {
+            channel: { id: 'chat-123', send: jest.fn() },
+            author: { id: 'user-1' },
+            reply: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        await handleMirror({
+            bridge,
+            telegramBindingRepo,
+            workspaceService,
+            channelPrefRepo: { getAccountName: jest.fn().mockReturnValue('work1') } as any,
+            accountPrefRepo: { getAccountName: jest.fn().mockReturnValue('default') } as any,
+            antigravityAccounts: [
+                { name: 'default', cdpPort: 9222 },
+                { name: 'work1', cdpPort: 9333 },
+            ],
+        }, message);
+
+        expect(getUserMessageDetector).toHaveBeenCalledWith('project-a', 'work1');
+        expect(ensureUserMessageDetector).toHaveBeenCalledWith(
+            bridge,
+            expect.anything(),
+            'project-a',
+            expect.any(Function),
+            'work1',
+        );
+    });
+});

--- a/tests/bot/telegramMessageHandler.test.ts
+++ b/tests/bot/telegramMessageHandler.test.ts
@@ -27,6 +27,10 @@ jest.mock('../../src/services/cdpBridgeManager', () => ({
 }));
 
 jest.mock('../../src/services/responseMonitor', () => ({
+    captureResponseMonitorBaseline: jest.fn().mockResolvedValue({
+        text: null,
+        processLogKeys: [],
+    }),
     ResponseMonitor: jest.fn().mockImplementation((opts) => ({
         start: jest.fn().mockImplementation(async () => {
             if (opts.onComplete) await opts.onComplete('Response text');
@@ -122,6 +126,7 @@ function createBridge(pool = createMockPool()) {
 function createTelegramBindingRepo(binding?: { chatId: string; workspacePath: string }) {
     return {
         findByChatId: jest.fn().mockReturnValue(binding),
+        findByChatIdWithParentFallback: jest.fn().mockReturnValue(binding),
     } as any;
 }
 
@@ -160,6 +165,7 @@ describe('createTelegramMessageHandler', () => {
     it('sends error reply if no workspace binding found for chat', async () => {
         const { message } = createMockMessage();
         const telegramBindingRepo = createTelegramBindingRepo(undefined);
+        telegramBindingRepo.findByChatIdWithParentFallback = jest.fn().mockReturnValue(undefined);
 
         const handler = createTelegramMessageHandler({
             bridge: createBridge(),
@@ -168,10 +174,30 @@ describe('createTelegramMessageHandler', () => {
 
         await handler(message as any);
 
-        expect(telegramBindingRepo.findByChatId).toHaveBeenCalledWith('chat-123');
+        expect(telegramBindingRepo.findByChatIdWithParentFallback).toHaveBeenCalledWith('chat-123');
         expect(message.reply).toHaveBeenCalledWith({
-            text: 'No project is linked to this chat. Use /project to bind a workspace.',
+            text: 'No project is linked to this chat. Use /project to bind a workspace, or /project_reopen if this is a previously used session.',
         });
+    });
+
+    it('falls back to the base chat binding for Telegram topics', async () => {
+        const mockCdp = createMockCdp();
+        const pool = createMockPool(mockCdp);
+        const bridge = createBridge(pool);
+        const binding = { chatId: 'chat-123', workspacePath: '/workspace/a' };
+        const telegramBindingRepo = createTelegramBindingRepo(binding);
+        telegramBindingRepo.findByChatIdWithParentFallback = jest.fn().mockReturnValue(binding);
+        const { message } = createMockMessage({
+            content: 'topic prompt',
+            channel: createMockChannel('chat-123_55'),
+        });
+
+        const handler = createTelegramMessageHandler({ bridge, telegramBindingRepo });
+        await handler(message as any);
+
+        expect(telegramBindingRepo.findByChatIdWithParentFallback).toHaveBeenCalledWith('chat-123_55');
+        expect(pool.getOrConnect).toHaveBeenCalledWith('/workspace/a', { name: 'default' });
+        expect(mockCdp.injectMessage).toHaveBeenCalledWith('topic prompt');
     });
 
     it('connects to CDP and sends prompt', async () => {
@@ -185,8 +211,70 @@ describe('createTelegramMessageHandler', () => {
         const handler = createTelegramMessageHandler({ bridge, telegramBindingRepo });
         await handler(message as any);
 
-        expect(pool.getOrConnect).toHaveBeenCalledWith('/workspace/a');
+        expect(pool.getOrConnect).toHaveBeenCalledWith('/workspace/a', { name: 'default' });
         expect(mockCdp.injectMessage).toHaveBeenCalledWith('test prompt');
+    });
+
+    it('restores the saved account preference when reconnecting Telegram after restart', async () => {
+        const mockCdp = createMockCdp();
+        const pool = createMockPool(mockCdp);
+        const bridge = createBridge(pool);
+        bridge.selectedAccountByChannel = new Map();
+        const binding = { chatId: 'chat-123', workspacePath: '/workspace/a' };
+        const telegramBindingRepo = createTelegramBindingRepo(binding);
+        const channelPrefRepo = { getAccountName: jest.fn().mockReturnValue('work1') } as any;
+        const accountPrefRepo = { getAccountName: jest.fn().mockReturnValue('default') } as any;
+        const { message } = createMockMessage({ content: 'test prompt' });
+
+        const handler = createTelegramMessageHandler({
+            bridge,
+            telegramBindingRepo,
+            channelPrefRepo,
+            accountPrefRepo,
+            antigravityAccounts: [
+                { name: 'default', cdpPort: 9222 },
+                { name: 'work1', cdpPort: 9333 },
+            ],
+        });
+        await handler(message as any);
+
+        expect(channelPrefRepo.getAccountName).toHaveBeenCalledWith('chat-123');
+        expect(pool.getOrConnect).toHaveBeenCalledWith('/workspace/a', { name: 'work1' });
+        expect(bridge.selectedAccountByChannel.get('chat-123')).toBe('work1');
+    });
+
+    it('inherits the account from the base Telegram chat when the current topic has no override', async () => {
+        const mockCdp = createMockCdp();
+        const pool = createMockPool(mockCdp);
+        const bridge = createBridge(pool);
+        bridge.selectedAccountByChannel = new Map();
+        const binding = { chatId: 'chat-123_99', workspacePath: '/workspace/a' };
+        const telegramBindingRepo = createTelegramBindingRepo(binding);
+        const channelPrefRepo = {
+            getAccountName: jest.fn((chatId: string) => (chatId === 'chat-123' ? 'work1' : null)),
+        } as any;
+        const accountPrefRepo = { getAccountName: jest.fn().mockReturnValue('default') } as any;
+        const { message } = createMockMessage({
+            content: 'test prompt',
+            channel: createMockChannel('chat-123_99'),
+        });
+
+        const handler = createTelegramMessageHandler({
+            bridge,
+            telegramBindingRepo,
+            channelPrefRepo,
+            accountPrefRepo,
+            antigravityAccounts: [
+                { name: 'default', cdpPort: 9222 },
+                { name: 'work1', cdpPort: 9333 },
+            ],
+        });
+        await handler(message as any);
+
+        expect(channelPrefRepo.getAccountName).toHaveBeenCalledWith('chat-123_99');
+        expect(channelPrefRepo.getAccountName).toHaveBeenCalledWith('chat-123');
+        expect(pool.getOrConnect).toHaveBeenCalledWith('/workspace/a', { name: 'work1' });
+        expect(bridge.selectedAccountByChannel.get('chat-123_99')).toBe('work1');
     });
 
     it('calls message.react() after successful CDP connection', async () => {
@@ -261,10 +349,10 @@ describe('createTelegramMessageHandler', () => {
             'test-project',
             message.channel,
         );
-        expect(ensureApprovalDetector).toHaveBeenCalledWith(bridge, mockCdp, 'test-project');
-        expect(ensureErrorPopupDetector).toHaveBeenCalledWith(bridge, mockCdp, 'test-project');
-        expect(ensurePlanningDetector).toHaveBeenCalledWith(bridge, mockCdp, 'test-project');
-        expect(ensureRunCommandDetector).toHaveBeenCalledWith(bridge, mockCdp, 'test-project');
+        expect(ensureApprovalDetector).toHaveBeenCalledWith(bridge, mockCdp, 'test-project', 'default');
+        expect(ensureErrorPopupDetector).toHaveBeenCalledWith(bridge, mockCdp, 'test-project', 'default');
+        expect(ensurePlanningDetector).toHaveBeenCalledWith(bridge, mockCdp, 'test-project', 'default');
+        expect(ensureRunCommandDetector).toHaveBeenCalledWith(bridge, mockCdp, 'test-project', 'default');
     });
 
     it('sets lastActiveWorkspace and lastActiveChannel on bridge', async () => {
@@ -529,9 +617,9 @@ describe('createTelegramMessageHandler', () => {
         await handler(message as any);
 
         // Falls through to normal binding check → "No project is linked"
-        expect(telegramBindingRepo.findByChatId).toHaveBeenCalled();
+        expect(telegramBindingRepo.findByChatIdWithParentFallback).toHaveBeenCalled();
         expect(message.reply).toHaveBeenCalledWith({
-            text: 'No project is linked to this chat. Use /project to bind a workspace.',
+            text: 'No project is linked to this chat. Use /project to bind a workspace, or /project_reopen if this is a previously used session.',
         });
     });
 

--- a/tests/bot/telegramProjectCommand.test.ts
+++ b/tests/bot/telegramProjectCommand.test.ts
@@ -4,6 +4,7 @@ import {
     handleTelegramProjectSelect,
     createTelegramSelectHandler,
     TG_PROJECT_SELECT_ID,
+    tryCreateTopicAndBind,
 } from '../../src/bot/telegramProjectCommand';
 import type { PlatformMessage, PlatformSelectInteraction } from '../../src/platform/types';
 
@@ -355,6 +356,38 @@ describe('handleTelegramProjectSelect', () => {
 
         expect(deps.telegramBindingRepo.upsert).not.toHaveBeenCalled();
         expect(interaction.reply).not.toHaveBeenCalled();
+    });
+});
+
+describe('tryCreateTopicAndBind', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('reuses the current forum topic when the command is already inside one', async () => {
+        const telegramBindingRepo = createMockBindingRepo();
+        const botApi = {
+            getChat: jest.fn(),
+            createForumTopic: jest.fn(),
+            sendMessage: jest.fn(),
+        };
+        const pool = {
+            extractProjectName: jest.fn().mockReturnValue('proj-a'),
+        };
+
+        const result = await tryCreateTopicAndBind(
+            botApi,
+            'chat-100_42',
+            'proj-a',
+            telegramBindingRepo,
+            pool,
+        );
+
+        expect(result).toBe('chat-100_42');
+        expect(telegramBindingRepo.upsert).toHaveBeenCalledWith({
+            chatId: 'chat-100_42',
+            workspacePath: 'proj-a',
+        });
+        expect(botApi.getChat).not.toHaveBeenCalled();
+        expect(botApi.createForumTopic).not.toHaveBeenCalled();
     });
 });
 

--- a/tests/bot/telegramStartupTarget.test.ts
+++ b/tests/bot/telegramStartupTarget.test.ts
@@ -1,0 +1,78 @@
+import { selectTelegramStartupChatId } from '../../src/bot/telegramStartupTarget';
+
+describe('selectTelegramStartupChatId', () => {
+    it('prefers a group chat named general', async () => {
+        const getChat = jest.fn(async (chatId: string) => {
+            if (chatId === '-1001') return { id: -1001, type: 'private', first_name: 'CY' };
+            if (chatId === '-2002') return { id: -2002, type: 'supergroup', title: 'general' };
+            return { id: chatId, type: 'private' };
+        });
+
+        const chatId = await selectTelegramStartupChatId(
+            { getChat } as any,
+            [
+                { id: 1, chatId: '-1001', workspacePath: 'A' },
+                { id: 2, chatId: '-2002_76', workspacePath: 'B' },
+                { id: 3, chatId: '-2002_126', workspacePath: 'C' },
+            ],
+        );
+
+        expect(chatId).toBe('-2002');
+        expect(getChat).toHaveBeenCalledTimes(2);
+    });
+
+    it('falls back to the first private chat when no general group exists', async () => {
+        const getChat = jest.fn(async (chatId: string) => {
+            if (chatId === '-1001') return { id: -1001, type: 'private', first_name: 'CY' };
+            if (chatId === '-2002') return { id: -2002, type: 'supergroup', title: 'Project Room' };
+            return { id: chatId, type: 'private' };
+        });
+
+        const chatId = await selectTelegramStartupChatId(
+            { getChat } as any,
+            [
+                { id: 1, chatId: '-1001', workspacePath: 'A' },
+                { id: 2, chatId: '-2002_76', workspacePath: 'B' },
+            ],
+        );
+
+        expect(chatId).toBe('-1001');
+    });
+
+    it('prefers a directly bound group chat before private chat', async () => {
+        const getChat = jest.fn(async (chatId: string) => {
+            if (chatId === '-1001') return { id: -1001, type: 'private', first_name: 'CY' };
+            if (chatId === '-2002') return { id: -2002, type: 'supergroup', title: 'Team Forum' };
+            return { id: chatId, type: 'private' };
+        });
+
+        const chatId = await selectTelegramStartupChatId(
+            { getChat } as any,
+            [
+                { id: 1, chatId: '-1001', workspacePath: 'A' },
+                { id: 2, chatId: '-2002', workspacePath: 'B' },
+                { id: 3, chatId: '-2002_76', workspacePath: 'C' },
+            ],
+        );
+
+        expect(chatId).toBe('-2002');
+    });
+
+    it('falls back to the first directly bound group chat when no private chat exists', async () => {
+        const getChat = jest.fn(async (chatId: string) => {
+            if (chatId === '-2002') return { id: -2002, type: 'supergroup', title: 'Project Room' };
+            if (chatId === '-3003') return { id: -3003, type: 'group', title: 'Ops' };
+            return { id: chatId, type: 'group' };
+        });
+
+        const chatId = await selectTelegramStartupChatId(
+            { getChat } as any,
+            [
+                { id: 1, chatId: '-2002_76', workspacePath: 'A' },
+                { id: 2, chatId: '-3003', workspacePath: 'B' },
+            ],
+        );
+
+        expect(chatId).toBe('-3003');
+    });
+});

--- a/tests/commands/chatCommandHandler.test.ts
+++ b/tests/commands/chatCommandHandler.test.ts
@@ -16,6 +16,7 @@ describe('ChatCommandHandler', () => {
     let bindingRepo: WorkspaceBindingRepository;
     let channelManager: ChannelManager;
     let mockWorkspaceService: jest.Mocked<WorkspaceService>;
+    let resolveAccountForChannel: jest.Mock;
 
     beforeEach(() => {
         mockService = {
@@ -44,7 +45,16 @@ describe('ChatCommandHandler', () => {
             exists: jest.fn().mockReturnValue(true),
         } as any;
 
-        handler = new ChatCommandHandler(mockService, chatSessionRepo, bindingRepo, channelManager, mockWorkspaceService, mockPool);
+        resolveAccountForChannel = jest.fn().mockReturnValue('work4');
+        handler = new ChatCommandHandler(
+            mockService,
+            chatSessionRepo,
+            bindingRepo,
+            channelManager,
+            mockWorkspaceService,
+            mockPool,
+            resolveAccountForChannel,
+        );
     });
 
     afterEach(() => {
@@ -72,6 +82,7 @@ describe('ChatCommandHandler', () => {
                 guild: { id: 'guild-1' },
                 channel: { type: 0, parentId: null },
                 channelId: 'ch-1',
+                user: { id: 'user-1' },
                 editReply: jest.fn().mockResolvedValue(undefined),
             };
 
@@ -89,6 +100,7 @@ describe('ChatCommandHandler', () => {
                 guild: { id: 'guild-1' },
                 channel: { type: 0, parentId: 'cat-1' },
                 channelId: 'unbound-ch',
+                user: { id: 'user-1' },
                 editReply: jest.fn().mockResolvedValue(undefined),
             };
 
@@ -129,15 +141,17 @@ describe('ChatCommandHandler', () => {
                 guild: mockGuild,
                 channel: { type: 0, parentId: 'cat-1' },
                 channelId: 'ch-1',
+                user: { id: 'user-1' },
                 editReply: jest.fn().mockResolvedValue(undefined),
             };
 
             await handler.handleNew(interaction as any);
 
-            expect(mockPool.getOrConnect).toHaveBeenCalledWith('/tmp/workspaces/my-proj');
+            expect(mockPool.getOrConnect).toHaveBeenCalledWith('/tmp/workspaces/my-proj', { name: 'work4' });
             expect(mockGuild.channels.create).toHaveBeenCalledWith(
                 expect.objectContaining({ name: 'session-2', parent: 'cat-1' })
             );
+            expect(chatSessionRepo.findByChannelId('new-ch-2')?.activeAccountName).toBe('work4');
             expect(interaction.editReply).toHaveBeenCalledWith(
                 expect.objectContaining({
                     embeds: expect.arrayContaining([
@@ -177,6 +191,7 @@ describe('ChatCommandHandler', () => {
                 guild: mockGuild,
                 channel: { type: 0, parentId: 'cat-1' },
                 channelId: 'ch-1',
+                user: { id: 'user-1' },
                 editReply: jest.fn().mockResolvedValue(undefined),
             };
 
@@ -187,7 +202,13 @@ describe('ChatCommandHandler', () => {
         });
 
         it('returns an error when the pool is not initialized', async () => {
-            const handlerNoPool = new ChatCommandHandler(mockService, chatSessionRepo, bindingRepo, channelManager, mockWorkspaceService);
+            const handlerNoPool = new ChatCommandHandler(
+                mockService,
+                chatSessionRepo,
+                bindingRepo,
+                channelManager,
+                mockWorkspaceService,
+            );
 
             chatSessionRepo.create({
                 channelId: 'ch-1', categoryId: 'cat-1', workspacePath: 'proj',
@@ -198,6 +219,7 @@ describe('ChatCommandHandler', () => {
                 guild: { id: 'guild-1' },
                 channel: { type: 0, parentId: 'cat-1' },
                 channelId: 'ch-1',
+                user: { id: 'user-1' },
                 editReply: jest.fn().mockResolvedValue(undefined),
             };
 
@@ -206,6 +228,51 @@ describe('ChatCommandHandler', () => {
             expect(interaction.editReply).toHaveBeenCalledWith(
                 expect.objectContaining({
                     content: expect.stringContaining('CDP pool is not initialized'),
+                })
+            );
+        });
+
+        it('creates a new session from the saved session context even when the channel parent is missing', async () => {
+            chatSessionRepo.create({
+                channelId: 'ch-1',
+                categoryId: 'cat-1',
+                workspacePath: 'my-proj',
+                sessionNumber: 1,
+                activeAccountName: 'work4',
+                guildId: 'guild-1',
+            });
+
+            const mockCdp = {
+                isConnected: jest.fn().mockReturnValue(true),
+                discoverAndConnectForWorkspace: jest.fn().mockResolvedValue(true),
+            };
+            mockPool.getOrConnect.mockResolvedValue(mockCdp as any);
+
+            const mockGuild = {
+                id: 'guild-1',
+                channels: {
+                    cache: { get: jest.fn().mockReturnValue(undefined) },
+                    create: jest.fn().mockResolvedValue({ id: 'new-ch-2', name: 'session-2' }),
+                },
+            };
+
+            const interaction = {
+                guild: mockGuild,
+                channel: { type: 0, parentId: null },
+                channelId: 'ch-1',
+                user: { id: 'user-1' },
+                editReply: jest.fn().mockResolvedValue(undefined),
+            };
+
+            await handler.handleNew(interaction as any);
+
+            expect(mockPool.getOrConnect).toHaveBeenCalledWith('/tmp/workspaces/my-proj', { name: 'work4' });
+            expect(mockGuild.channels.create).toHaveBeenCalledWith(
+                expect.objectContaining({ name: 'session-2', parent: 'cat-1' })
+            );
+            expect(interaction.editReply).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    embeds: expect.any(Array),
                 })
             );
         });

--- a/tests/commands/registerSlashCommands.test.ts
+++ b/tests/commands/registerSlashCommands.test.ts
@@ -18,6 +18,7 @@ jest.mock('discord.js', () => {
                 setName: jest.fn().mockReturnThis(),
                 setDescription: jest.fn().mockReturnThis(),
                 setRequired: jest.fn().mockReturnThis(),
+                setAutocomplete: jest.fn().mockReturnThis(),
                 addChoices: jest.fn().mockReturnThis(),
             };
             fn(option);
@@ -45,6 +46,7 @@ jest.mock('discord.js', () => {
                         setName: jest.fn().mockReturnThis(),
                         setDescription: jest.fn().mockReturnThis(),
                         setRequired: jest.fn().mockReturnThis(),
+                        setAutocomplete: jest.fn().mockReturnThis(),
                     };
                     optFn(option);
                     return sub;
@@ -90,6 +92,16 @@ describe('registerSlashCommands', () => {
     it('includes the output command in registration targets', () => {
         const names = slashCommands.map((cmd) => cmd.toJSON().name);
         expect(names).toContain('output');
+    });
+
+    it('includes the account command in registration targets', () => {
+        const names = slashCommands.map((cmd) => cmd.toJSON().name);
+        expect(names).toContain('account');
+    });
+
+    it('includes the project command in registration targets', () => {
+        const names = slashCommands.map((cmd) => cmd.toJSON().name);
+        expect(names).toContain('project');
     });
 
     beforeEach(() => {

--- a/tests/commands/workspaceCommandHandler.test.ts
+++ b/tests/commands/workspaceCommandHandler.test.ts
@@ -72,6 +72,8 @@ describe('WorkspaceCommandHandler', () => {
     describe('handleSelectMenu', () => {
         it('creates a category and session-1 for the selected workspace and binds them', async () => {
             fs.mkdirSync(path.join(tmpDir, 'selected-project'));
+            const onSessionChannelCreated = jest.fn().mockResolvedValue(undefined);
+            handler = new WorkspaceCommandHandler(bindingRepo, chatSessionRepo, service, channelManager, onSessionChannelCreated);
 
             const mockGuild = {
                 id: 'guild-1',
@@ -92,6 +94,7 @@ describe('WorkspaceCommandHandler', () => {
                 values: ['selected-project'],
                 channelId: 'ch-1',
                 guildId: 'guild-1',
+                user: { id: 'user-1' },
                 update: jest.fn().mockResolvedValue(undefined),
             };
 
@@ -108,6 +111,7 @@ describe('WorkspaceCommandHandler', () => {
             expect(session?.categoryId).toBe('cat-1');
             expect(session?.sessionNumber).toBe(1);
             expect(session?.workspacePath).toBe('selected-project');
+            expect(onSessionChannelCreated).toHaveBeenCalledWith('selected-project', 'new-ch-1', 'ch-1', 'user-1');
         });
 
         it('displays an error for a non-existent workspace', async () => {
@@ -234,6 +238,19 @@ describe('WorkspaceCommandHandler', () => {
             bindingRepo.create({ channelId: 'ch-1', workspacePath: 'my-proj', guildId: 'guild-1' });
             const result = handler.getWorkspaceForChannel('ch-1');
             expect(result).toBe(path.join(tmpDir, 'my-proj'));
+        });
+
+        it('falls back to the chat session workspace when the channel binding is missing', () => {
+            chatSessionRepo.create({
+                channelId: 'ch-session-1',
+                categoryId: 'cat-1',
+                workspacePath: 'session-proj',
+                sessionNumber: 1,
+                guildId: 'guild-1',
+            });
+
+            const result = handler.getWorkspaceForChannel('ch-session-1');
+            expect(result).toBe(path.join(tmpDir, 'session-proj'));
         });
 
         it('returns undefined when the channel is not bound', () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -114,6 +114,42 @@ describe('Config', () => {
         expect(config.autoApproveFileEdits).toBe(true);
     });
 
+    it('defaults antigravityAccounts to the default account', () => {
+        process.env.DISCORD_BOT_TOKEN = 'secret_token';
+        process.env.CLIENT_ID = 'client123';
+        process.env.ALLOWED_USER_IDS = 'user1';
+        delete process.env.ANTIGRAVITY_ACCOUNTS;
+
+        const config = loadConfig();
+        expect(config.antigravityAccounts).toEqual([{ name: 'default', cdpPort: 9222 }]);
+    });
+
+    it('parses ANTIGRAVITY_ACCOUNTS from env', () => {
+        process.env.DISCORD_BOT_TOKEN = 'secret_token';
+        process.env.CLIENT_ID = 'client123';
+        process.env.ALLOWED_USER_IDS = 'user1';
+        process.env.ANTIGRAVITY_ACCOUNTS = 'default:9222,work:9333';
+
+        const config = loadConfig();
+        expect(config.antigravityAccounts).toEqual([
+            { name: 'default', cdpPort: 9222 },
+            { name: 'work', cdpPort: 9333 },
+        ]);
+    });
+
+    it('parses ANTIGRAVITY_ACCOUNTS with optional user-data-dir from env', () => {
+        process.env.DISCORD_BOT_TOKEN = 'secret_token';
+        process.env.CLIENT_ID = 'client123';
+        process.env.ALLOWED_USER_IDS = 'user1';
+        process.env.ANTIGRAVITY_ACCOUNTS = 'default:9222,work:9333@/Users/test/work';
+
+        const config = loadConfig();
+        expect(config.antigravityAccounts).toEqual([
+            { name: 'default', cdpPort: 9222 },
+            { name: 'work', cdpPort: 9333, userDataDir: '/Users/test/work' },
+        ]);
+    });
+
     it('defaults platforms to ["discord"] when PLATFORMS is not set', () => {
         process.env.DISCORD_BOT_TOKEN = 'secret_token';
         process.env.CLIENT_ID = 'client123';

--- a/tests/configLoader.test.ts
+++ b/tests/configLoader.test.ts
@@ -1,0 +1,75 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('ConfigLoader persistence', () => {
+    const originalEnv = process.env;
+    let tmpHome: string;
+
+    beforeEach(() => {
+        jest.resetModules();
+        tmpHome = fs.mkdtempSync(path.join('/tmp', 'lazy-gravity-config-loader-'));
+        process.env = { ...originalEnv };
+        delete process.env.ANTIGRAVITY_ACCOUNTS;
+        delete process.env.DISCORD_BOT_TOKEN;
+        delete process.env.CLIENT_ID;
+        delete process.env.ALLOWED_USER_IDS;
+        jest.doMock('os', () => {
+            const actual = jest.requireActual('os');
+            return {
+                ...actual,
+                homedir: () => tmpHome,
+            };
+        });
+    });
+
+    afterEach(() => {
+        jest.dontMock('os');
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+    });
+
+    afterAll(() => {
+        process.env = originalEnv;
+    });
+
+    it('saves antigravityAccounts as structured JSON in config.json', () => {
+        const { ConfigLoader } = require('../src/utils/configLoader');
+
+        ConfigLoader.save({
+            antigravityAccounts: [
+                { name: 'default', cdpPort: 9222, userDataDir: '/tmp/default' },
+                { name: 'work4', cdpPort: 9666, userDataDir: '/tmp/work4' },
+            ],
+        });
+
+        const saved = JSON.parse(
+            fs.readFileSync(path.join(tmpHome, '.lazy-gravity', 'config.json'), 'utf-8'),
+        );
+
+        expect(saved.antigravityAccounts).toEqual([
+            { name: 'default', cdpPort: 9222, userDataDir: '/tmp/default' },
+            { name: 'work4', cdpPort: 9666, userDataDir: '/tmp/work4' },
+        ]);
+    });
+
+    it('still reads legacy string antigravityAccounts from persisted config', () => {
+        const configDir = path.join(tmpHome, '.lazy-gravity');
+        fs.mkdirSync(configDir, { recursive: true });
+        fs.writeFileSync(
+            path.join(configDir, 'config.json'),
+            JSON.stringify({
+                discordToken: 'token',
+                clientId: 'client123',
+                allowedUserIds: ['user1'],
+                antigravityAccounts: 'default:9222@/tmp/default,work4:9666@/tmp/work4',
+            }, null, 2),
+        );
+
+        const { ConfigLoader } = require('../src/utils/configLoader');
+        const config = ConfigLoader.load();
+
+        expect(config.antigravityAccounts).toEqual([
+            { name: 'default', cdpPort: 9222, userDataDir: '/tmp/default' },
+            { name: 'work4', cdpPort: 9666, userDataDir: '/tmp/work4' },
+        ]);
+    });
+});

--- a/tests/database/chatSessionRepository.test.ts
+++ b/tests/database/chatSessionRepository.test.ts
@@ -30,6 +30,7 @@ describe('ChatSessionRepository', () => {
                 categoryId: 'cat-1',
                 workspacePath: 'my-project',
                 sessionNumber: 1,
+                activeAccountName: 'work4',
                 guildId: 'guild-1',
             });
             expect(result.id).toBeDefined();
@@ -37,6 +38,9 @@ describe('ChatSessionRepository', () => {
             expect(result.categoryId).toBe('cat-1');
             expect(result.workspacePath).toBe('my-project');
             expect(result.sessionNumber).toBe(1);
+            expect(result.conversationId).toBeNull();
+            expect(result.activeAccountName).toBe('work4');
+            expect(result.originAccountName).toBeNull();
             expect(result.displayName).toBeNull();
             expect(result.isRenamed).toBe(false);
             expect(result.guildId).toBe('guild-1');
@@ -56,6 +60,9 @@ describe('ChatSessionRepository', () => {
             const found = repo.findByChannelId('ch-1');
             expect(found).toBeDefined();
             expect(found?.workspacePath).toBe('proj');
+            expect(found?.conversationId).toBeNull();
+            expect(found?.activeAccountName).toBeNull();
+            expect(found?.originAccountName).toBeNull();
             expect(found?.isRenamed).toBe(false);
         });
 
@@ -112,6 +119,55 @@ describe('ChatSessionRepository', () => {
 
         it('returns false for a non-existent channel ID', () => {
             expect(repo.updateDisplayName('nonexistent', 'title')).toBe(false);
+        });
+    });
+
+    describe('accountName helpers', () => {
+        it('updates the account name for an existing session', () => {
+            repo.create({ channelId: 'ch-1', categoryId: 'cat-1', workspacePath: 'proj', sessionNumber: 1, guildId: 'guild-1' });
+
+            const updated = repo.setActiveAccountName('ch-1', 'work4');
+            expect(updated).toBe(true);
+
+            const found = repo.findByChannelId('ch-1');
+            expect(found?.activeAccountName).toBe('work4');
+            expect(found?.originAccountName).toBeNull();
+        });
+
+        it('initializes original account provenance only once', () => {
+            repo.create({ channelId: 'ch-1', categoryId: 'cat-1', workspacePath: 'proj', sessionNumber: 1, activeAccountName: 'default', guildId: 'guild-1' });
+
+            const initialized = repo.initializeOriginAccountName('ch-1', 'default');
+            expect(initialized).toBe(true);
+
+            const secondAttempt = repo.initializeOriginAccountName('ch-1', 'work4');
+            expect(secondAttempt).toBe(false);
+
+            repo.setActiveAccountName('ch-1', 'work4');
+
+            const found = repo.findByChannelId('ch-1');
+            expect(found?.activeAccountName).toBe('work4');
+            expect(found?.originAccountName).toBe('default');
+        });
+    });
+
+    describe('conversationId helpers', () => {
+        it('updates the conversation id for an existing session', () => {
+            repo.create({ channelId: 'ch-1', categoryId: 'cat-1', workspacePath: 'proj', sessionNumber: 1, guildId: 'guild-1' });
+
+            const updated = repo.setConversationId('ch-1', 'conv-123');
+            expect(updated).toBe(true);
+
+            const found = repo.findByChannelId('ch-1');
+            expect(found?.conversationId).toBe('conv-123');
+        });
+
+        it('initializes conversation id only once', () => {
+            repo.create({ channelId: 'ch-1', categoryId: 'cat-1', workspacePath: 'proj', sessionNumber: 1, guildId: 'guild-1' });
+
+            expect(repo.initializeConversationId('ch-1', 'conv-123')).toBe(true);
+            expect(repo.initializeConversationId('ch-1', 'conv-456')).toBe(false);
+            expect(repo.findByChannelId('ch-1')?.conversationId).toBe('conv-123');
         });
     });
 

--- a/tests/database/telegramBindingRepository.test.ts
+++ b/tests/database/telegramBindingRepository.test.ts
@@ -61,6 +61,13 @@ describe('TelegramBindingRepository', () => {
             expect(found?.createdAt).toBeDefined();
             expect(typeof found?.createdAt).toBe('string');
         });
+
+        it('falls back from a topic chat id to the base chat binding', () => {
+            repo.create({ chatId: '100200300', workspacePath: 'my-project' });
+            const found = repo.findByChatIdWithParentFallback('100200300_77');
+            expect(found).toBeDefined();
+            expect(found?.workspacePath).toBe('my-project');
+        });
     });
 
     describe('findByWorkspacePath - search by workspace path', () => {

--- a/tests/events/interactionCreateHandler.test.ts
+++ b/tests/events/interactionCreateHandler.test.ts
@@ -142,4 +142,130 @@ describe('interactionCreateHandler', () => {
             expect.objectContaining({ content: 'ok', flags: 64 }),
         );
     });
+
+    it('handles account dropdown selection and persists global/channel account choice for non-session channels', async () => {
+        const deferUpdate = jest.fn().mockResolvedValue(undefined);
+        const editReply = jest.fn().mockResolvedValue(undefined);
+        const followUp = jest.fn().mockResolvedValue(undefined);
+        const accountPrefRepo = { setAccountName: jest.fn() };
+        const channelPrefRepo = { setAccountName: jest.fn() };
+        const wsHandler = { getWorkspaceForChannel: jest.fn().mockReturnValue('/tmp/demo-project') };
+
+        const interaction = {
+            isButton: () => false,
+            isStringSelectMenu: () => true,
+            isChatInputCommand: () => false,
+            customId: 'account_select',
+            values: ['work1'],
+            channelId: 'channel-a',
+            user: { id: 'allowed' },
+            deferUpdate,
+            editReply,
+            followUp,
+        } as any;
+
+        const handler = createInteractionCreateHandler({
+            config: { allowedUserIds: ['allowed'] },
+            bridge: {
+                selectedAccountByChannel: new Map<string, string>(),
+                pool: {},
+            } as any,
+            cleanupHandler: {} as any,
+            modeService: {} as any,
+            modelService: {} as any,
+            slashCommandHandler: {} as any,
+            wsHandler: wsHandler as any,
+            chatHandler: {} as any,
+            client: {} as any,
+            sendModeUI: jest.fn(),
+            sendModelsUI: jest.fn(),
+            sendAutoAcceptUI: jest.fn(),
+            handleScreenshot: jest.fn(),
+            getCurrentCdp: jest.fn(),
+            parseApprovalCustomId: jest.fn().mockReturnValue(null),
+            parseErrorPopupCustomId: jest.fn().mockReturnValue(null),
+            parsePlanningCustomId: jest.fn().mockReturnValue(null),
+            parseRunCommandCustomId: jest.fn().mockReturnValue(null),
+            handleSlashInteraction: jest.fn(),
+            accountPrefRepo: accountPrefRepo as any,
+            channelPrefRepo: channelPrefRepo as any,
+            antigravityAccounts: [
+                { name: 'default', cdpPort: 9222 },
+                { name: 'work1', cdpPort: 9333 },
+            ],
+        });
+
+        await handler(interaction);
+
+        expect(deferUpdate).toHaveBeenCalled();
+        expect(accountPrefRepo.setAccountName).toHaveBeenCalledWith('allowed', 'work1');
+        expect(channelPrefRepo.setAccountName).toHaveBeenCalledWith('channel-a', 'work1');
+        expect(editReply).toHaveBeenCalled();
+        expect(followUp).toHaveBeenCalledWith(
+            expect.objectContaining({ content: '✅ Switched session account to **work1**.', flags: 64 }),
+        );
+    });
+
+    it('handles account dropdown selection as a session-scoped change for session channels', async () => {
+        const deferUpdate = jest.fn().mockResolvedValue(undefined);
+        const editReply = jest.fn().mockResolvedValue(undefined);
+        const followUp = jest.fn().mockResolvedValue(undefined);
+        const accountPrefRepo = { setAccountName: jest.fn() };
+        const channelPrefRepo = { setAccountName: jest.fn() };
+        const chatSessionRepo = {
+            findByChannelId: jest.fn().mockReturnValue({ channelId: 'channel-a', activeAccountName: 'default' }),
+            setActiveAccountName: jest.fn(),
+        };
+
+        const interaction = {
+            isButton: () => false,
+            isStringSelectMenu: () => true,
+            isChatInputCommand: () => false,
+            customId: 'account_select',
+            values: ['work1'],
+            channelId: 'channel-a',
+            user: { id: 'allowed' },
+            deferUpdate,
+            editReply,
+            followUp,
+        } as any;
+
+        const handler = createInteractionCreateHandler({
+            config: { allowedUserIds: ['allowed'] },
+            bridge: {
+                selectedAccountByChannel: new Map<string, string>(),
+                pool: {},
+            } as any,
+            cleanupHandler: {} as any,
+            modeService: {} as any,
+            modelService: {} as any,
+            slashCommandHandler: {} as any,
+            wsHandler: { getWorkspaceForChannel: jest.fn().mockReturnValue('/tmp/demo-project') } as any,
+            chatHandler: {} as any,
+            client: {} as any,
+            sendModeUI: jest.fn(),
+            sendModelsUI: jest.fn(),
+            sendAutoAcceptUI: jest.fn(),
+            handleScreenshot: jest.fn(),
+            getCurrentCdp: jest.fn(),
+            parseApprovalCustomId: jest.fn().mockReturnValue(null),
+            parseErrorPopupCustomId: jest.fn().mockReturnValue(null),
+            parsePlanningCustomId: jest.fn().mockReturnValue(null),
+            parseRunCommandCustomId: jest.fn().mockReturnValue(null),
+            handleSlashInteraction: jest.fn(),
+            accountPrefRepo: accountPrefRepo as any,
+            channelPrefRepo: channelPrefRepo as any,
+            chatSessionRepo: chatSessionRepo as any,
+            antigravityAccounts: [
+                { name: 'default', cdpPort: 9222 },
+                { name: 'work1', cdpPort: 9333 },
+            ],
+        });
+
+        await handler(interaction);
+
+        expect(chatSessionRepo.setActiveAccountName).toHaveBeenCalledWith('channel-a', 'work1');
+        expect(accountPrefRepo.setAccountName).not.toHaveBeenCalled();
+        expect(channelPrefRepo.setAccountName).not.toHaveBeenCalled();
+    });
 });

--- a/tests/events/messageCreateHandler.test.ts
+++ b/tests/events/messageCreateHandler.test.ts
@@ -19,6 +19,8 @@ function buildDeps(overrides: Record<string, any> = {}) {
             pool: {
                 getOrConnect: jest.fn().mockResolvedValue({}),
                 extractProjectName: jest.fn().mockReturnValue('proj-a'),
+                getPreferredAccountForWorkspace: jest.fn().mockReturnValue(null),
+                setPreferredAccountForWorkspace: jest.fn(),
             },
         } as any,
         modeService: {} as any,
@@ -74,23 +76,66 @@ describe('messageCreateHandler', () => {
         expect(sendPromptToAntigravity).not.toHaveBeenCalled();
     });
 
+    it('shows active account, original account, and conversation title in text status', async () => {
+        const reply = jest.fn().mockResolvedValue(undefined);
+        const handler = createMessageCreateHandler(buildDeps({
+            modeService: { getCurrentMode: jest.fn().mockReturnValue('normal') },
+            antigravityAccounts: [
+                { name: 'default', cdpPort: 9222 },
+                { name: 'work4', cdpPort: 9444 },
+            ],
+            bridge: {
+                autoAccept: { handle: jest.fn(), isEnabled: jest.fn().mockReturnValue(false) },
+                selectedAccountByChannel: new Map<string, string>([['ch-1', 'work4']]),
+                pool: {
+                    getActiveWorkspaceNames: jest.fn().mockReturnValue([]),
+                    getConnected: jest.fn().mockReturnValue(null),
+                    getApprovalDetector: jest.fn().mockReturnValue(undefined),
+                    extractProjectName: jest.fn().mockReturnValue('proj-a'),
+                },
+            } as any,
+            chatSessionRepo: {
+                findByChannelId: jest.fn().mockReturnValue({
+                    channelId: 'ch-1',
+                    activeAccountName: 'work4',
+                    originAccountName: 'default',
+                    displayName: 'Imported Session',
+                }),
+            } as any,
+        }));
+
+        await handler(buildMessage({ content: '/status', reply }));
+
+        const payload = reply.mock.calls[0][0];
+        const embed = payload.embeds[0].data;
+        expect(embed.fields).toEqual(expect.arrayContaining([
+            expect.objectContaining({ name: 'Active Account', value: 'work4' }),
+            expect.objectContaining({ name: 'Original Account', value: 'default' }),
+            expect.objectContaining({ name: 'Conversation Title', value: 'Imported Session' }),
+        ]));
+    });
+
     it('re-registers session channel after autoRenameChannel sets displayName', async () => {
         const sendPromptToAntigravity = mockSendPromptImmediate();
         const registerApprovalSessionChannel = jest.fn();
         const findByChannelId = jest.fn()
-            .mockReturnValueOnce({ isRenamed: false, displayName: null })
+            .mockReturnValueOnce({ isRenamed: false, displayName: null, activeAccountName: null })
+            .mockReturnValueOnce({ isRenamed: false, displayName: null, activeAccountName: null })
             .mockReturnValueOnce({ isRenamed: true, displayName: 'New Session Title' });
 
         const handler = createMessageCreateHandler(buildDeps({
             sendPromptToAntigravity,
             registerApprovalSessionChannel,
             chatSessionRepo: { findByChannelId },
-            chatSessionService: { startNewChat: jest.fn().mockResolvedValue({ ok: true }) },
+            chatSessionService: {
+                startNewChat: jest.fn().mockResolvedValue({ ok: true }),
+                activateSessionByTitle: jest.fn().mockResolvedValue({ ok: true }),
+            },
         }));
 
         await handler(buildMessage());
 
-        expect(findByChannelId).toHaveBeenCalledTimes(2);
+        expect(findByChannelId).toHaveBeenCalledTimes(3);
         const sessionCalls = registerApprovalSessionChannel.mock.calls;
         const lastCall = sessionCalls[sessionCalls.length - 1];
         expect(lastCall[2]).toBe('New Session Title');
@@ -155,6 +200,75 @@ describe('messageCreateHandler', () => {
 
         expect(updateDisplayName).toHaveBeenCalledWith('ch-1', 'New Title');
         expect(activateSessionByTitle).toHaveBeenCalledTimes(2);
+        expect(sendPromptToAntigravity).toHaveBeenCalled();
+    });
+
+    it('resets stale renamed session state when the channel is reopened under a different account', async () => {
+        const sendPromptToAntigravity = mockSendPromptImmediate();
+        const activateSessionByTitle = jest.fn();
+        const startNewChat = jest.fn().mockResolvedValue({ ok: true });
+        const setActiveAccountName = jest.fn().mockReturnValue(true);
+        const initializeOriginAccountName = jest.fn().mockReturnValue(true);
+        const findByChannelId = jest.fn()
+            .mockReturnValueOnce({
+                isRenamed: true,
+                displayName: 'Legacy Session',
+                activeAccountName: 'default',
+                categoryId: 'cat-1',
+                channelId: 'ch-1',
+            })
+            .mockReturnValueOnce({
+                isRenamed: true,
+                displayName: 'Legacy Session',
+                activeAccountName: 'default',
+                categoryId: 'cat-1',
+                channelId: 'ch-1',
+            })
+            .mockReturnValueOnce({
+                isRenamed: false,
+                displayName: null,
+                activeAccountName: 'work4',
+                categoryId: 'cat-1',
+                channelId: 'ch-1',
+            })
+            .mockReturnValueOnce({
+                isRenamed: false,
+                displayName: null,
+                activeAccountName: 'work4',
+                categoryId: 'cat-1',
+                channelId: 'ch-1',
+            });
+
+        const handler = createMessageCreateHandler(buildDeps({
+            antigravityAccounts: [{ name: 'work4', cdpPort: 9321 }],
+            bridge: {
+                autoAccept: { handle: jest.fn(), isEnabled: jest.fn() },
+                selectedAccountByChannel: new Map<string, string>([['ch-1', 'work4']]),
+                pool: {
+                    getOrConnect: jest.fn().mockResolvedValue({}),
+                    extractProjectName: jest.fn().mockReturnValue('proj-a'),
+                    getPreferredAccountForWorkspace: jest.fn().mockReturnValue('default'),
+                    setPreferredAccountForWorkspace: jest.fn(),
+                },
+            } as any,
+            sendPromptToAntigravity,
+            chatSessionService: {
+                activateSessionByTitle,
+                startNewChat,
+            },
+            chatSessionRepo: {
+                findByChannelId,
+                setActiveAccountName,
+                initializeOriginAccountName,
+            },
+        }));
+
+        await handler(buildMessage());
+
+        expect(setActiveAccountName).toHaveBeenCalledWith('ch-1', 'work4');
+        expect(activateSessionByTitle).not.toHaveBeenCalled();
+        expect(startNewChat).toHaveBeenCalled();
+        expect(initializeOriginAccountName).toHaveBeenCalledWith('ch-1', 'work4');
         expect(sendPromptToAntigravity).toHaveBeenCalled();
     });
 

--- a/tests/services/antigravityAccountDiscovery.test.ts
+++ b/tests/services/antigravityAccountDiscovery.test.ts
@@ -1,0 +1,186 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { DiscoveryResult } from '../../src/services/antigravityAccountDiscovery';
+
+describe('antigravityAccountDiscovery', () => {
+    let tempHome: string;
+
+    beforeEach(() => {
+        jest.resetModules();
+        tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ag-discovery-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tempHome, { recursive: true, force: true });
+        jest.dontMock('os');
+        jest.dontMock('child_process');
+    });
+
+    async function loadDiscovery(): Promise<(
+        existingAccounts?: readonly { name: string; cdpPort: number; userDataDir?: string }[]
+    ) => Promise<DiscoveryResult>> {
+        jest.doMock('os', () => {
+            const actual = jest.requireActual('os');
+            return {
+                ...actual,
+                homedir: () => tempHome,
+            };
+        });
+
+        jest.doMock('child_process', () => ({
+            execFile: jest.fn((
+                _command: string,
+                _args: string[],
+                _options: unknown,
+                callback: (error: Error | null, stdout: string) => void,
+            ) => {
+                callback(null, '');
+            }),
+        }));
+
+        const mod = await import('../../src/services/antigravityAccountDiscovery');
+        return mod.discoverAntigravityAccounts;
+    }
+
+    it('prefers cockpit instances.json names over folder ids', async () => {
+        const cockpitDir = path.join(tempHome, '.antigravity_cockpit');
+        fs.mkdirSync(cockpitDir, { recursive: true });
+        fs.writeFileSync(path.join(cockpitDir, 'instances.json'), JSON.stringify({
+            instances: [
+                {
+                    name: 'work1',
+                    userDataDir: path.join(tempHome, '.antigravity_cockpit', 'instances', 'antigravity', 'abc123'),
+                    extraArgs: '--remote-debugging-port=9333',
+                },
+                {
+                    name: 'default',
+                    userDataDir: path.join(tempHome, 'Library', 'Application Support', 'Antigravity'),
+                    extraArgs: '--remote-debugging-port=9222',
+                },
+            ],
+        }), 'utf-8');
+
+        const discoverAntigravityAccounts = await loadDiscovery();
+        const result = await discoverAntigravityAccounts();
+
+        expect(result.accounts).toEqual([
+            {
+                name: 'default',
+                cdpPort: 9222,
+                userDataDir: path.join(tempHome, 'Library', 'Application Support', 'Antigravity'),
+                source: `file:${path.join(tempHome, '.antigravity_cockpit', 'instances.json')}`,
+            },
+            {
+                name: 'work1',
+                cdpPort: 9333,
+                userDataDir: path.join(tempHome, '.antigravity_cockpit', 'instances', 'antigravity', 'abc123'),
+                source: `file:${path.join(tempHome, '.antigravity_cockpit', 'instances.json')}`,
+            },
+        ]);
+        expect(result.warnings).toEqual([]);
+    });
+
+    it('auto-assigns a unique port and warns when default profile is missing', async () => {
+        const cockpitDir = path.join(tempHome, '.antigravity_cockpit');
+        fs.mkdirSync(cockpitDir, { recursive: true });
+        fs.writeFileSync(path.join(cockpitDir, 'instances.json'), JSON.stringify({
+            instances: [
+                {
+                    name: 'work1',
+                    userDataDir: path.join(tempHome, '.antigravity_cockpit', 'instances', 'antigravity', 'abc123'),
+                    extraArgs: '--remote-debugging-port=9333',
+                },
+                {
+                    name: 'work2',
+                    userDataDir: path.join(tempHome, '.antigravity_cockpit', 'instances', 'antigravity', 'def456'),
+                    extraArgs: '--new-window',
+                },
+            ],
+        }), 'utf-8');
+
+        const discoverAntigravityAccounts = await loadDiscovery();
+        const result = await discoverAntigravityAccounts([{ name: 'existing', cdpPort: 9222 }]);
+
+        expect(result.accounts).toEqual([
+            {
+                name: 'work1',
+                cdpPort: 9333,
+                userDataDir: path.join(tempHome, '.antigravity_cockpit', 'instances', 'antigravity', 'abc123'),
+                source: `file:${path.join(tempHome, '.antigravity_cockpit', 'instances.json')}`,
+            },
+            {
+                name: 'work2',
+                cdpPort: 9223,
+                userDataDir: path.join(tempHome, '.antigravity_cockpit', 'instances', 'antigravity', 'def456'),
+                source: `file:${path.join(tempHome, '.antigravity_cockpit', 'instances.json')}`,
+            },
+        ]);
+        expect(result.warnings).toEqual(expect.arrayContaining([
+            'Auto-assigned CDP port 9223 for "work2" because cockpit extraArgs did not set --remote-debugging-port.',
+            expect.stringContaining('No cockpit instance explicitly uses the default Antigravity profile directory'),
+        ]));
+    });
+
+    it('does not truncate running-process user-data-dir values that contain spaces', async () => {
+        jest.doMock('os', () => {
+            const actual = jest.requireActual('os');
+            return {
+                ...actual,
+                homedir: () => tempHome,
+            };
+        });
+
+        jest.doMock('child_process', () => ({
+            execFile: jest.fn((
+                _command: string,
+                _args: string[],
+                _options: unknown,
+                callback: (error: Error | null, stdout: string) => void,
+            ) => {
+                callback(
+                    null,
+                    '/Applications/Antigravity.app/Contents/MacOS/Antigravity --user-data-dir /Users/test/Library/Application Support/Antigravity --remote-debugging-port=9222\n',
+                );
+            }),
+        }));
+
+        const mod = await import('../../src/services/antigravityAccountDiscovery');
+        const result = await mod.discoverAntigravityAccounts();
+
+        expect(result.accounts).toEqual([
+            {
+                name: 'antigravity',
+                cdpPort: 9222,
+                userDataDir: '/Users/test/Library/Application Support/Antigravity',
+                source: 'running-process',
+            },
+        ]);
+    });
+
+    it('ignores json files reached through symlinks', async () => {
+        const cockpitDir = path.join(tempHome, '.antigravity_cockpit');
+        const externalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ag-discovery-outside-'));
+        fs.mkdirSync(cockpitDir, { recursive: true });
+        fs.writeFileSync(
+            path.join(externalDir, 'linked.json'),
+            JSON.stringify({
+                instances: [
+                    {
+                        name: 'linked',
+                        userDataDir: '/tmp/linked',
+                        extraArgs: '--remote-debugging-port=9555',
+                    },
+                ],
+            }),
+            'utf8',
+        );
+        fs.symlinkSync(externalDir, path.join(cockpitDir, 'linked-dir'));
+
+        const discoverAntigravityAccounts = await loadDiscovery();
+        const result = await discoverAntigravityAccounts();
+
+        expect(result.accounts).toEqual([]);
+        fs.rmSync(externalDir, { recursive: true, force: true });
+    });
+});

--- a/tests/services/cdpConnectionPool.test.ts
+++ b/tests/services/cdpConnectionPool.test.ts
@@ -96,6 +96,55 @@ describe('CdpConnectionPool', () => {
             expect(pool.getActiveWorkspaceNames()).toEqual(expect.arrayContaining(['ProjectA', 'ProjectB']));
         });
 
+        it('creates separate instances for the same workspace on different accounts', async () => {
+            (CdpService as jest.MockedClass<typeof CdpService>).mockReset();
+            let callCount = 0;
+            (CdpService as jest.MockedClass<typeof CdpService>).mockImplementation(() => {
+                callCount += 1;
+                return {
+                    isConnected: jest.fn().mockReturnValue(true),
+                    discoverAndConnectForWorkspace: jest.fn().mockResolvedValue(true),
+                    on: jest.fn(),
+                    disconnect: jest.fn().mockResolvedValue(undefined),
+                    _id: callCount,
+                } as any;
+            });
+
+            const cdpDefault = await pool.getOrConnect('/path/to/ProjectA', { name: 'default' });
+            const cdpWork = await pool.getOrConnect('/path/to/ProjectA', { name: 'work' });
+
+            expect(cdpDefault).not.toBe(cdpWork);
+            expect(CdpService).toHaveBeenCalledTimes(2);
+            expect(pool.getConnected('ProjectA', 'work')).toBe(cdpWork);
+
+            pool.setPreferredAccountForWorkspace('/path/to/ProjectA', 'default');
+            expect(pool.getConnected('ProjectA')).toBe(cdpDefault);
+        });
+
+        it('honors an explicit switch back to default even when a preferred workspace account exists', async () => {
+            (CdpService as jest.MockedClass<typeof CdpService>).mockReset();
+            let callCount = 0;
+            (CdpService as jest.MockedClass<typeof CdpService>).mockImplementation(() => {
+                callCount += 1;
+                return {
+                    isConnected: jest.fn().mockReturnValue(true),
+                    discoverAndConnectForWorkspace: jest.fn().mockResolvedValue(true),
+                    on: jest.fn(),
+                    disconnect: jest.fn().mockResolvedValue(undefined),
+                    _id: callCount,
+                } as any;
+            });
+
+            const cdpWork4 = await pool.getOrConnect('/path/to/VPN', { name: 'work4' });
+            expect(CdpService).toHaveBeenLastCalledWith(expect.objectContaining({ accountName: 'work4' }));
+
+            const cdpDefault = await pool.getOrConnect('/path/to/VPN', { name: 'default' });
+
+            expect(cdpDefault).not.toBe(cdpWork4);
+            expect(CdpService).toHaveBeenLastCalledWith(expect.objectContaining({ accountName: 'default' }));
+            expect(pool.getConnected('VPN', 'default')).toBe(cdpDefault);
+        });
+
         it('prevents concurrent connections with a Promise lock', async () => {
             // Reset mock counter for this test
             (CdpService as jest.MockedClass<typeof CdpService>).mockReset();
@@ -151,6 +200,21 @@ describe('CdpConnectionPool', () => {
         it('returns null when not connected', () => {
             const result = pool.getConnected('NonExistent');
             expect(result).toBeNull();
+        });
+
+        it('uses the preferred workspace account when resolving default lookups', async () => {
+            const mockCdp = {
+                isConnected: jest.fn().mockReturnValue(true),
+                discoverAndConnectForWorkspace: jest.fn().mockResolvedValue(true),
+                on: jest.fn(),
+                disconnect: jest.fn().mockResolvedValue(undefined),
+            };
+            (CdpService as jest.MockedClass<typeof CdpService>).mockImplementation(() => mockCdp as any);
+
+            pool.setPreferredAccountForWorkspace('/path/to/ProjectA', 'work');
+            await pool.getOrConnect('/path/to/ProjectA', { name: 'work' });
+
+            expect(pool.getConnected('ProjectA')).toBe(mockCdp);
         });
     });
 

--- a/tests/services/cdpService.uiSync.test.ts
+++ b/tests/services/cdpService.uiSync.test.ts
@@ -120,13 +120,16 @@ describe('CdpService - UI sync (Step 9)', () => {
             (cdpService as any).isConnectedFlag = true;
             (cdpService as any).ws = mockWsInstance;
 
-            callSpy.mockResolvedValue({
-                result: { value: { ok: true, mode: 'Planning' } }
-            });
+            callSpy
+                .mockResolvedValueOnce({ result: { value: true } })
+                .mockResolvedValueOnce({ result: { value: { ok: true, mode: 'Planning' } } });
 
             await cdpService.setUiMode('plan');
 
-            const callArgs = callSpy.mock.calls[0][1];
+            const runtimeEvaluateCalls = callSpy.mock.calls.filter(
+                (call) => call[0] === 'Runtime.evaluate' && String(call[1]?.expression || '').includes('role=\\"dialog\\"'),
+            );
+            const callArgs = runtimeEvaluateCalls[0][1];
             // Verify dialog-based search is used
             expect(callArgs.expression).toContain('role=\\"dialog\\"');
             expect(callArgs.expression).toContain('.font-medium');
@@ -145,6 +148,23 @@ describe('CdpService - UI sync (Step 9)', () => {
 
             expect(result.ok).toBe(false);
             expect(result.error).toBeDefined();
+        });
+
+        it('retries once when the mode toggle is not ready yet', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy
+                .mockResolvedValueOnce({ result: { value: true } })
+                .mockResolvedValueOnce({ result: { value: { ok: false, error: 'Mode toggle button not found' } } })
+                .mockResolvedValueOnce({ result: { value: true } })
+                .mockResolvedValueOnce({ result: { value: { ok: true, mode: 'Planning' } } });
+
+            const result = await cdpService.setUiMode('plan');
+
+            expect(result.ok).toBe(true);
+            expect(result.mode).toBe('Planning');
+            expect(callSpy).toHaveBeenCalledTimes(4);
         });
 
         it('returns ok: false without crashing when a CDP error occurs', async () => {
@@ -251,6 +271,28 @@ describe('CdpService - UI sync (Step 9)', () => {
                     contextId: 42,
                 })
             );
+        });
+
+        it('uses semantic menu and option selectors instead of only exact class matching', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockResolvedValue({
+                result: { value: { ok: true, model: 'Claude Opus 4.6 (Thinking)' } }
+            });
+
+            await cdpService.setUiModel('Claude Opus 4.6 (Thinking)');
+
+            const callArgs = callSpy.mock.calls[0][1];
+            expect(callArgs.expression).toContain('[role="option"]');
+            expect(callArgs.expression).toContain('[role="listbox"]');
+            expect(callArgs.expression).toContain('Model click did not update selected state.');
+            expect(callArgs.expression).toContain('diagnostics');
+            expect(callArgs.expression).toContain('open in terminal');
+            expect(callArgs.expression).toContain('claude code');
+            expect(callArgs.expression).toContain('select model|current:');
+            expect(callArgs.expression).toContain('ariaHaspopup');
+            expect(callArgs.expression).toContain('openPicker');
         });
     });
 });

--- a/tests/services/chatSessionService.test.ts
+++ b/tests/services/chatSessionService.test.ts
@@ -18,7 +18,7 @@ describe('ChatSessionService', () => {
     });
 
     describe('startNewChat()', () => {
-        it('opens a new chat via coordinate click when the button is enabled', async () => {
+        it('opens a new chat via keyboard shortcut when the button is enabled', async () => {
             // 1st call: button enabled (cursor:pointer), 2nd call: button disabled (cursor:not-allowed)
             let callCount = 0;
             mockCdpService.call.mockImplementation(async (method: string) => {
@@ -39,8 +39,8 @@ describe('ChatSessionService', () => {
 
             expect(result.ok).toBe(true);
             expect(mockCdpService.call).toHaveBeenCalledWith(
-                'Input.dispatchMouseEvent',
-                expect.objectContaining({ type: 'mousePressed', x: 100, y: 50 })
+                'Input.dispatchKeyEvent',
+                expect.objectContaining({ type: 'keyDown', key: 'L', code: 'KeyL' })
             );
         });
 
@@ -101,7 +101,7 @@ describe('ChatSessionService', () => {
             const result = await service.startNewChat(mockCdpService);
 
             expect(result.ok).toBe(false);
-            expect(result.error).toContain('state did not change');
+            expect(result.error).toContain('did not change state');
         });
     });
 
@@ -179,8 +179,10 @@ describe('ChatSessionService', () => {
         });
 
         it('falls back to Past Conversations flow when direct side-panel search cannot find the chat', async () => {
+            const calls: Array<{ method: string; params?: any }> = [];
             let infoCallCount = 0;
-            mockCdpService.call.mockImplementation(async (_method: string, params: any) => {
+            mockCdpService.call.mockImplementation(async (method: string, params: any) => {
+                calls.push({ method, params });
                 const expression = String(params?.expression || '');
 
                 if (expression.includes('const header = panel.querySelector(\'div[class*="border-b"]\');')) {
@@ -204,6 +206,10 @@ describe('ChatSessionService', () => {
 
             const result = await service.activateSessionByTitle(mockCdpService, 'target-session');
             expect(result).toEqual({ ok: true });
+            const escapeCall = calls.find(
+                (c) => c.method === 'Input.dispatchKeyEvent' && c.params?.key === 'Escape',
+            );
+            expect(escapeCall).toBeDefined();
         });
 
         it('retries activation while UI is still loading and eventually succeeds', async () => {
@@ -250,6 +256,125 @@ describe('ChatSessionService', () => {
             expect(result.ok).toBe(false);
             expect(result.error).toContain('empty');
         });
+
+        it('refreshes a stuck loading session by opening a new conversation and reopening the target', async () => {
+            const stateSpy = jest.spyOn(service, 'getCurrentSessionViewState');
+            const startSpy = jest.spyOn(service, 'startNewChat').mockResolvedValue({ ok: true });
+            const activateSpy = jest.spyOn(service, 'activateSessionByTitle').mockResolvedValue({ ok: true });
+            const listSpy = jest.spyOn(service, 'listAllSessions');
+
+            stateSpy
+                .mockResolvedValueOnce({
+                    title: 'target-session',
+                    hasActiveChat: true,
+                    panelFound: true,
+                    hasLoadingIndicator: true,
+                    hasRenderableContent: false,
+                    renderablePreview: [],
+                })
+                .mockResolvedValueOnce({
+                    title: 'target-session',
+                    hasActiveChat: true,
+                    panelFound: true,
+                    hasLoadingIndicator: true,
+                    hasRenderableContent: false,
+                    renderablePreview: [],
+                })
+                .mockResolvedValueOnce({
+                    title: 'target-session',
+                    hasActiveChat: true,
+                    panelFound: true,
+                    hasLoadingIndicator: false,
+                    hasRenderableContent: true,
+                    renderablePreview: [{ tag: 'DIV', className: 'prose', text: 'Recovered content' }],
+                });
+
+            const result = await service.refreshSessionViewIfStuck(mockCdpService, 'target-session');
+
+            expect(result).toEqual({ ok: true });
+            expect(listSpy).not.toHaveBeenCalled();
+            expect(startSpy).toHaveBeenCalledTimes(1);
+            expect(activateSpy).toHaveBeenCalledTimes(1);
+            expect(activateSpy).toHaveBeenCalledWith(
+                mockCdpService,
+                'target-session',
+                expect.objectContaining({ maxWaitMs: 8000, retryIntervalMs: 300, allowVisibilityWarmupMs: 1000 }),
+            );
+        });
+
+        it('skips the refresh step when the session already has renderable content', async () => {
+            const stateSpy = jest.spyOn(service, 'getCurrentSessionViewState').mockResolvedValue({
+                title: 'target-session',
+                hasActiveChat: true,
+                panelFound: true,
+                hasLoadingIndicator: false,
+                hasRenderableContent: true,
+                renderablePreview: [{ tag: 'DIV', className: 'prose', text: 'Ready content' }],
+            });
+            const startSpy = jest.spyOn(service, 'startNewChat');
+            const activateSpy = jest.spyOn(service, 'activateSessionByTitle');
+            const listSpy = jest.spyOn(service, 'listAllSessions');
+
+            const result = await service.refreshSessionViewIfStuck(mockCdpService, 'target-session');
+
+            expect(result).toEqual({ ok: true });
+            expect(stateSpy).toHaveBeenCalledTimes(1);
+            expect(listSpy).not.toHaveBeenCalled();
+            expect(startSpy).not.toHaveBeenCalled();
+            expect(activateSpy).not.toHaveBeenCalled();
+        });
+
+        it('returns an error after bounded new-conversation retries stay stuck', async () => {
+            const stateSpy = jest.spyOn(service, 'getCurrentSessionViewState');
+            const startSpy = jest.spyOn(service, 'startNewChat').mockResolvedValue({ ok: true });
+            const activateSpy = jest.spyOn(service, 'activateSessionByTitle').mockResolvedValue({ ok: true });
+
+            stateSpy
+                .mockResolvedValueOnce({
+                    title: 'target-session',
+                    hasActiveChat: true,
+                    panelFound: true,
+                    hasLoadingIndicator: true,
+                    hasRenderableContent: false,
+                    renderablePreview: [],
+                })
+                .mockResolvedValueOnce({
+                    title: 'target-session',
+                    hasActiveChat: true,
+                    panelFound: true,
+                    hasLoadingIndicator: true,
+                    hasRenderableContent: false,
+                    renderablePreview: [],
+                })
+                .mockResolvedValueOnce({
+                    title: 'target-session',
+                    hasActiveChat: true,
+                    panelFound: true,
+                    hasLoadingIndicator: true,
+                    hasRenderableContent: false,
+                    renderablePreview: [],
+                })
+                .mockResolvedValueOnce({
+                    title: 'target-session',
+                    hasActiveChat: true,
+                    panelFound: true,
+                    hasLoadingIndicator: true,
+                    hasRenderableContent: false,
+                    renderablePreview: [],
+                });
+
+            const result = await service.recoverSessionViewWithNewConversationBounce(
+                mockCdpService,
+                'target-session',
+                { maxAttempts: 2, newChatDelayMs: 0, reopenDelayMs: 0 },
+            );
+
+            expect(result.ok).toBe(false);
+            expect(result.error).toContain('Attempt 2/2');
+            expect(startSpy).toHaveBeenCalledTimes(2);
+            expect(activateSpy).toHaveBeenCalledTimes(2);
+        });
+
         it('returns direct and past errors when both activation paths fail', async () => {
             mockCdpService.call.mockImplementation(async (_method: string, params: any) => {
                 const expression = String(params?.expression || '');

--- a/tests/services/conversationTransferService.test.ts
+++ b/tests/services/conversationTransferService.test.ts
@@ -1,0 +1,393 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import Database from 'better-sqlite3';
+import {
+    exportConversationBundleByTitle,
+    exportConversationBundleByConversationId,
+    findLatestTrajectoryEntryByTitle,
+    importConversationBundleToProfile,
+    parseTrajectorySummariesBase64,
+    transferConversationByTitle,
+    waitForConversationPersistence,
+} from '../../src/services/conversationTransferService';
+
+function encodeVarint(value: number): Buffer {
+    const bytes: number[] = [];
+    let remaining = value >>> 0;
+    while (remaining >= 0x80) {
+        bytes.push((remaining & 0x7f) | 0x80);
+        remaining >>>= 7;
+    }
+    bytes.push(remaining);
+    return Buffer.from(bytes);
+}
+
+function encodeLengthDelimited(fieldNumber: number, payload: Buffer): Buffer {
+    return Buffer.concat([
+        encodeVarint((fieldNumber << 3) | 2),
+        encodeVarint(payload.length),
+        payload,
+    ]);
+}
+
+function buildTrajectoryEntry(conversationId: string, title: string): Buffer {
+    const inner = encodeLengthDelimited(1, Buffer.from(title, 'utf8'));
+    const field2Ascii = Buffer.from(inner.toString('base64'), 'utf8');
+    const entryPayload = Buffer.concat([
+        encodeLengthDelimited(1, Buffer.from(conversationId, 'utf8')),
+        encodeLengthDelimited(2, field2Ascii),
+    ]);
+    return encodeLengthDelimited(1, entryPayload);
+}
+
+function buildTrajectoryEntryWithRawInner(conversationId: string, title: string): Buffer {
+    const inner = encodeLengthDelimited(1, Buffer.from(title, 'utf8'));
+    const entryPayload = Buffer.concat([
+        encodeLengthDelimited(1, Buffer.from(conversationId, 'utf8')),
+        encodeLengthDelimited(2, inner),
+    ]);
+    return encodeLengthDelimited(1, entryPayload);
+}
+
+function buildTrajectoryEntryWithNestedBase64Title(conversationId: string, title: string): Buffer {
+    const nestedInner = encodeLengthDelimited(1, Buffer.from(title, 'utf8'));
+    const outerInner = encodeLengthDelimited(1, Buffer.from(nestedInner.toString('base64'), 'utf8'));
+    const entryPayload = Buffer.concat([
+        encodeLengthDelimited(1, Buffer.from(conversationId, 'utf8')),
+        encodeLengthDelimited(2, outerInner),
+    ]);
+    return encodeLengthDelimited(1, entryPayload);
+}
+
+describe('conversationTransferService', () => {
+    let tempRoot: string;
+
+    beforeEach(() => {
+        tempRoot = fs.mkdtempSync(path.join(require('os').tmpdir(), 'lazy-gravity-transfer-'));
+        process.env.LAZY_GRAVITY_TEST_HOME = tempRoot;
+    });
+
+    afterEach(() => {
+        delete process.env.LAZY_GRAVITY_TEST_HOME;
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+    });
+
+    function createDb(dbPath: string, trajectoryBase64: string = ''): void {
+        fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+        const db = new Database(dbPath);
+        db.exec('CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value BLOB)');
+        if (trajectoryBase64) {
+            db.prepare('INSERT INTO ItemTable (key, value) VALUES (?, ?)').run(
+                'antigravityUnifiedStateSync.trajectorySummaries',
+                trajectoryBase64,
+            );
+        }
+        db.close();
+    }
+
+    it('exports a bundle with trajectory entry and related files', () => {
+        const conversationId = '11111111-2222-3333-4444-555555555555';
+        const title = 'Listing DevTools Directory';
+        const entry = buildTrajectoryEntry(conversationId, title);
+        const trajectoryBase64 = entry.toString('base64');
+
+        const defaultDb = path.join(
+            tempRoot,
+            'Library',
+            'Application Support',
+            'Antigravity',
+            'User',
+            'globalStorage',
+            'state.vscdb',
+        );
+        createDb(defaultDb, trajectoryBase64);
+
+        const sharedRoot = path.join(tempRoot, '.gemini', 'antigravity');
+        fs.mkdirSync(path.join(sharedRoot, 'conversations'), { recursive: true });
+        fs.mkdirSync(path.join(sharedRoot, 'annotations'), { recursive: true });
+        fs.mkdirSync(path.join(sharedRoot, 'brain', conversationId), { recursive: true });
+        fs.writeFileSync(path.join(sharedRoot, 'conversations', `${conversationId}.pb`), 'conversation');
+        fs.writeFileSync(path.join(sharedRoot, 'annotations', `${conversationId}.pbtxt`), 'annotation');
+        fs.writeFileSync(path.join(sharedRoot, 'brain', conversationId, 'artifact.txt'), 'artifact');
+
+        const outDir = path.join(tempRoot, 'exports');
+        const bundleDir = exportConversationBundleByTitle('default', title, outDir);
+        const manifestPath = path.join(bundleDir, 'manifest.json');
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+            conversationId: string;
+            title: string;
+            trajectoryEntryBase64: string;
+            files: { conversationPb?: string; annotationsPbtxt?: string; brainDir?: string };
+        };
+
+        expect(manifest.conversationId).toBe(conversationId);
+        expect(manifest.title).toBe(title);
+        expect(manifest.trajectoryEntryBase64).toBe(entry.toString('base64'));
+        expect(fs.existsSync(path.join(bundleDir, manifest.files.conversationPb!))).toBe(true);
+        expect(fs.existsSync(path.join(bundleDir, manifest.files.annotationsPbtxt!))).toBe(true);
+        expect(fs.existsSync(path.join(bundleDir, manifest.files.brainDir!, 'artifact.txt'))).toBe(true);
+    });
+
+    it('imports a bundle into another profile by appending trajectory entry', () => {
+        const conversationId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+        const title = 'Listing DevTools Directory';
+        const entry = buildTrajectoryEntry(conversationId, title);
+        const defaultDb = path.join(
+            tempRoot,
+            'Library',
+            'Application Support',
+            'Antigravity',
+            'User',
+            'globalStorage',
+            'state.vscdb',
+        );
+        createDb(defaultDb, entry.toString('base64'));
+
+        const sharedRoot = path.join(tempRoot, '.gemini', 'antigravity');
+        fs.mkdirSync(path.join(sharedRoot, 'conversations'), { recursive: true });
+        fs.writeFileSync(path.join(sharedRoot, 'conversations', `${conversationId}.pb`), 'conversation');
+
+        const bundleDir = exportConversationBundleByTitle('default', title, path.join(tempRoot, 'exports'));
+
+        const work3UserDataDir = path.join(tempRoot, '.antigravity_cockpit', 'instances', 'antigravity', 'work3-data');
+        fs.mkdirSync(path.dirname(path.join(tempRoot, '.antigravity_cockpit', 'instances.json')), { recursive: true });
+        fs.writeFileSync(
+            path.join(tempRoot, '.antigravity_cockpit', 'instances.json'),
+            JSON.stringify({
+                instances: [
+                    {
+                        name: 'work3',
+                        userDataDir: work3UserDataDir,
+                    },
+                ],
+            }),
+            'utf8',
+        );
+
+        const work3Db = path.join(work3UserDataDir, 'User', 'globalStorage', 'state.vscdb');
+        createDb(work3Db, '');
+
+        const result = importConversationBundleToProfile(bundleDir, 'work3');
+        expect(result.conversationId).toBe(conversationId);
+        expect(fs.existsSync(result.dbBackupPath)).toBe(true);
+
+        const db = new Database(work3Db, { readonly: true });
+        const row = db
+            .prepare('SELECT value FROM ItemTable WHERE key = ?')
+            .get('antigravityUnifiedStateSync.trajectorySummaries') as { value: string };
+        db.close();
+
+        const parsed = parseTrajectorySummariesBase64(String(row.value));
+        expect(parsed).toHaveLength(1);
+        expect(parsed[0].conversationId).toBe(conversationId);
+        expect(parsed[0].title).toBe(title);
+    });
+
+    it('rejects bundle manifests that escape the bundle directory', () => {
+        const bundleDir = path.join(tempRoot, 'exports', 'unsafe-bundle');
+        fs.mkdirSync(bundleDir, { recursive: true });
+        fs.writeFileSync(
+            path.join(bundleDir, 'manifest.json'),
+            JSON.stringify({
+                conversationId: 'unsafe-conversation',
+                title: 'Unsafe Bundle',
+                trajectoryEntryBase64: buildTrajectoryEntry('unsafe-conversation', 'Unsafe Bundle').toString('base64'),
+                files: {
+                    conversationPb: '../../outside.pb',
+                },
+            }),
+            'utf8',
+        );
+
+        const work3UserDataDir = path.join(tempRoot, '.antigravity_cockpit', 'instances', 'antigravity', 'work3-data');
+        fs.mkdirSync(path.dirname(path.join(tempRoot, '.antigravity_cockpit', 'instances.json')), { recursive: true });
+        fs.writeFileSync(
+            path.join(tempRoot, '.antigravity_cockpit', 'instances.json'),
+            JSON.stringify({
+                instances: [
+                    {
+                        name: 'work3',
+                        userDataDir: work3UserDataDir,
+                    },
+                ],
+            }),
+            'utf8',
+        );
+        createDb(path.join(work3UserDataDir, 'User', 'globalStorage', 'state.vscdb'), '');
+
+        expect(() => importConversationBundleToProfile(bundleDir, 'work3')).toThrow(
+            'Bundle manifest field "conversationPb" points outside the bundle directory.',
+        );
+    });
+
+    it('parses trajectory entries whose inner payload is stored as raw protobuf bytes', () => {
+        const conversationId = 'bbbbbbbb-cccc-dddd-eeee-ffffffffffff';
+        const title = 'Raw Trajectory Title';
+        const entry = buildTrajectoryEntryWithRawInner(conversationId, title);
+
+        const parsed = parseTrajectorySummariesBase64(entry.toString('base64'));
+        expect(parsed).toHaveLength(1);
+        expect(parsed[0].conversationId).toBe(conversationId);
+        expect(parsed[0].title).toBe(title);
+    });
+
+    it('parses trajectory entries whose title payload is nested base64 protobuf', () => {
+        const conversationId = 'cccccccc-dddd-eeee-ffff-000000000000';
+        const title = 'Listing DevTools Directory';
+        const entry = buildTrajectoryEntryWithNestedBase64Title(conversationId, title);
+
+        const parsed = parseTrajectorySummariesBase64(entry.toString('base64'));
+        expect(parsed).toHaveLength(1);
+        expect(parsed[0].conversationId).toBe(conversationId);
+        expect(parsed[0].title).toBe(title);
+    });
+
+    it('transfers a conversation by title across profiles', () => {
+        const conversationId = 'dddddddd-eeee-ffff-0000-111111111111';
+        const title = 'Imported Across Profiles';
+        const entry = buildTrajectoryEntry(conversationId, title);
+        const defaultDb = path.join(
+            tempRoot,
+            'Library',
+            'Application Support',
+            'Antigravity',
+            'User',
+            'globalStorage',
+            'state.vscdb',
+        );
+        createDb(defaultDb, entry.toString('base64'));
+
+        const sharedRoot = path.join(tempRoot, '.gemini', 'antigravity');
+        fs.mkdirSync(path.join(sharedRoot, 'conversations'), { recursive: true });
+        fs.writeFileSync(path.join(sharedRoot, 'conversations', `${conversationId}.pb`), 'conversation');
+
+        const work3UserDataDir = path.join(tempRoot, '.antigravity_cockpit', 'instances', 'antigravity', 'work3-data');
+        fs.mkdirSync(path.dirname(path.join(tempRoot, '.antigravity_cockpit', 'instances.json')), { recursive: true });
+        fs.writeFileSync(
+            path.join(tempRoot, '.antigravity_cockpit', 'instances.json'),
+            JSON.stringify({
+                instances: [
+                    {
+                        name: 'work3',
+                        userDataDir: work3UserDataDir,
+                    },
+                ],
+            }),
+            'utf8',
+        );
+        const work3Db = path.join(work3UserDataDir, 'User', 'globalStorage', 'state.vscdb');
+        createDb(work3Db, '');
+
+        const result = transferConversationByTitle('default', 'work3', title);
+        expect(result.conversationId).toBe(conversationId);
+        expect(fs.existsSync(result.dbBackupPath)).toBe(true);
+
+        const db = new Database(work3Db, { readonly: true });
+        const row = db
+            .prepare('SELECT value FROM ItemTable WHERE key = ?')
+            .get('antigravityUnifiedStateSync.trajectorySummaries') as { value: string };
+        db.close();
+
+        const parsed = parseTrajectorySummariesBase64(String(row.value));
+        expect(parsed).toHaveLength(1);
+        expect(parsed[0].title).toBe(title);
+    });
+
+    it('prefers the latest matching trajectory entry when titles collide', () => {
+        const olderId = '11111111-aaaa-bbbb-cccc-000000000001';
+        const newerId = '11111111-aaaa-bbbb-cccc-000000000002';
+        const title = 'Analyzing Project Directory';
+        const trajectoryBase64 = Buffer.concat([
+            buildTrajectoryEntry(olderId, title),
+            buildTrajectoryEntry(newerId, title),
+        ]).toString('base64');
+
+        const defaultDb = path.join(
+            tempRoot,
+            'Library',
+            'Application Support',
+            'Antigravity',
+            'User',
+            'globalStorage',
+            'state.vscdb',
+        );
+        createDb(defaultDb, trajectoryBase64);
+
+        const latest = findLatestTrajectoryEntryByTitle('default', title);
+        expect(latest?.conversationId).toBe(newerId);
+    });
+
+    it('exports the exact requested conversation id even when titles collide', () => {
+        const olderId = '21111111-aaaa-bbbb-cccc-000000000001';
+        const newerId = '21111111-aaaa-bbbb-cccc-000000000002';
+        const title = 'Analyzing Project Directory';
+        const trajectoryBase64 = Buffer.concat([
+            buildTrajectoryEntry(olderId, title),
+            buildTrajectoryEntry(newerId, title),
+        ]).toString('base64');
+
+        const defaultDb = path.join(
+            tempRoot,
+            'Library',
+            'Application Support',
+            'Antigravity',
+            'User',
+            'globalStorage',
+            'state.vscdb',
+        );
+        createDb(defaultDb, trajectoryBase64);
+
+        const sharedRoot = path.join(tempRoot, '.gemini', 'antigravity');
+        fs.mkdirSync(path.join(sharedRoot, 'conversations'), { recursive: true });
+        fs.writeFileSync(path.join(sharedRoot, 'conversations', `${olderId}.pb`), 'older-conversation');
+        fs.writeFileSync(path.join(sharedRoot, 'conversations', `${newerId}.pb`), 'newer-conversation');
+
+        const bundleDir = exportConversationBundleByConversationId('default', olderId, path.join(tempRoot, 'exports'));
+        const manifest = JSON.parse(fs.readFileSync(path.join(bundleDir, 'manifest.json'), 'utf8')) as {
+            conversationId: string;
+            title: string;
+            files: { conversationPb?: string };
+        };
+
+        expect(manifest.conversationId).toBe(olderId);
+        expect(manifest.title).toBe(title);
+        expect(fs.readFileSync(path.join(bundleDir, manifest.files.conversationPb!), 'utf8')).toBe('older-conversation');
+    });
+
+    it('waits until a conversation appears in trajectory summaries', async () => {
+        const conversationId = 'eeeeeeee-ffff-0000-1111-222222222222';
+        const title = 'Eventually Persisted';
+        const defaultDb = path.join(
+            tempRoot,
+            'Library',
+            'Application Support',
+            'Antigravity',
+            'User',
+            'globalStorage',
+            'state.vscdb',
+        );
+        createDb(defaultDb, Buffer.alloc(0).toString('base64'));
+
+        const delayedEntry = buildTrajectoryEntry(conversationId, title).toString('base64');
+        setTimeout(() => {
+            const db = new Database(defaultDb);
+            db.prepare(`
+                INSERT INTO ItemTable (key, value)
+                VALUES (?, ?)
+                ON CONFLICT(key) DO UPDATE SET value = excluded.value
+            `).run(
+                'antigravityUnifiedStateSync.trajectorySummaries',
+                delayedEntry,
+            );
+            db.close();
+        }, 10);
+
+        const entry = await waitForConversationPersistence('default', title, {
+            timeoutMs: 1000,
+            pollIntervalMs: 5,
+        });
+
+        expect(entry.conversationId).toBe(conversationId);
+        expect(entry.title).toBe(title);
+    });
+});

--- a/tests/ui/accountUi.test.ts
+++ b/tests/ui/accountUi.test.ts
@@ -1,0 +1,17 @@
+import { sendAccountUI, ACCOUNT_SELECT_ID } from '../../src/ui/accountUi';
+
+describe('accountUi', () => {
+    it('passes account selector UI to editReply', async () => {
+        const target = { editReply: jest.fn().mockResolvedValue(undefined) };
+
+        await sendAccountUI(target, 'work1', ['default', 'work1']);
+
+        expect(target.editReply).toHaveBeenCalledTimes(1);
+        const payload = target.editReply.mock.calls[0][0];
+        expect(payload.embeds?.length).toBeGreaterThan(0);
+        expect(payload.components?.length).toBeGreaterThan(0);
+
+        const select = payload.components[0]?.components?.[0];
+        expect(select?.data?.custom_id).toBe(ACCOUNT_SELECT_ID);
+    });
+});

--- a/tests/utils/accountUtils.test.ts
+++ b/tests/utils/accountUtils.test.ts
@@ -1,0 +1,92 @@
+import {
+    inferParentScopeChannelId,
+    listAccountNames,
+    resolveScopedAccountName,
+    resolveValidAccountName,
+} from '../../src/utils/accountUtils';
+
+describe('accountUtils', () => {
+    it('falls back to the first configured account when requested is invalid', () => {
+        const accounts = [
+            { name: 'default', cdpPort: 9222 },
+            { name: 'work', cdpPort: 9333 },
+        ];
+
+        expect(resolveValidAccountName('missing', accounts)).toBe('default');
+    });
+
+    it('returns the requested account when it exists', () => {
+        const accounts = [
+            { name: 'default', cdpPort: 9222 },
+            { name: 'work', cdpPort: 9333 },
+        ];
+
+        expect(resolveValidAccountName('work', accounts)).toBe('work');
+    });
+
+    it('lists the default account when config is empty', () => {
+        expect(listAccountNames(undefined)).toEqual(['default']);
+    });
+
+    it('uses the parent channel account when the conversation has no explicit override', () => {
+        const channelPrefRepo = {
+            getAccountName: jest.fn((channelId: string) => {
+                if (channelId === 'parent-channel') return 'work';
+                return null;
+            }),
+        };
+        const accountPrefRepo = {
+            getAccountName: jest.fn().mockReturnValue('default'),
+        };
+
+        expect(resolveScopedAccountName({
+            channelId: 'thread-channel',
+            userId: 'user-1',
+            parentChannelId: 'parent-channel',
+            channelPrefRepo,
+            accountPrefRepo,
+            accounts: [
+                { name: 'default', cdpPort: 9222 },
+                { name: 'work', cdpPort: 9333 },
+            ],
+        })).toBe('work');
+    });
+
+    it('infers the Telegram base chat as parent scope for topic ids', () => {
+        const channelPrefRepo = {
+            getAccountName: jest.fn((channelId: string) => {
+                if (channelId === '1001') return 'work';
+                return null;
+            }),
+        };
+
+        expect(inferParentScopeChannelId('1001_77')).toBe('1001');
+        expect(resolveScopedAccountName({
+            channelId: '1001_77',
+            userId: 'user-1',
+            channelPrefRepo,
+            accountPrefRepo: { getAccountName: jest.fn().mockReturnValue('default') },
+            accounts: [
+                { name: 'default', cdpPort: 9222 },
+                { name: 'work', cdpPort: 9333 },
+            ],
+        })).toBe('work');
+    });
+
+    it('prefers an explicit session account over channel and user defaults', () => {
+        expect(resolveScopedAccountName({
+            channelId: 'session-channel',
+            userId: 'user-1',
+            sessionAccountName: 'work4',
+            selectedAccountByChannel: new Map([['session-channel', 'work1']]),
+            channelPrefRepo: { getAccountName: jest.fn().mockReturnValue('work2') },
+            accountPrefRepo: { getAccountName: jest.fn().mockReturnValue('default') },
+            accounts: [
+                { name: 'default', cdpPort: 9222 },
+                { name: 'work1', cdpPort: 9333 },
+                { name: 'work2', cdpPort: 9444 },
+                { name: 'work4', cdpPort: 9666 },
+            ],
+        })).toBe('work4');
+    });
+});

--- a/tests/utils/cdpPorts.test.ts
+++ b/tests/utils/cdpPorts.test.ts
@@ -1,0 +1,32 @@
+import {
+    normalizeAntigravityAccounts,
+    parseAntigravityAccounts,
+    serializeAntigravityAccounts,
+} from '../../src/utils/cdpPorts';
+
+describe('cdpPorts', () => {
+    it('parses ANTIGRAVITY_ACCOUNTS entries with optional user-data-dir', () => {
+        expect(parseAntigravityAccounts('default:9222,work:9333@/Users/test/work')).toEqual([
+            { name: 'default', cdpPort: 9222 },
+            { name: 'work', cdpPort: 9333, userDataDir: '/Users/test/work' },
+        ]);
+    });
+
+    it('serializes accounts back into ANTIGRAVITY_ACCOUNTS format', () => {
+        expect(serializeAntigravityAccounts([
+            { name: 'default', cdpPort: 9222 },
+            { name: 'work', cdpPort: 9333, userDataDir: '/Users/test/work' },
+        ])).toBe('default:9222,work:9333@/Users/test/work');
+    });
+
+    it('drops duplicate names during normalization and keeps optional user-data-dir', () => {
+        expect(normalizeAntigravityAccounts([
+            { name: 'default', cdpPort: 9222 },
+            { name: 'default', cdpPort: 9333, userDataDir: '/tmp/ignored' },
+            { name: 'work', cdpPort: 9444, userDataDir: '/tmp/work' },
+        ])).toEqual([
+            { name: 'default', cdpPort: 9222 },
+            { name: 'work', cdpPort: 9444, userDataDir: '/tmp/work' },
+        ]);
+    });
+});


### PR DESCRIPTION
## Description
Split from #94 to isolate CDP multi-account reopen, conversation transfer, and Antigravity discovery/process handling.

## Included
- CDP multi-account reopen/session recovery flow
- Antigravity account discovery/process inspection
- conversation transfer helpers
- security hardening for manifest path validation and symlink traversal
- minimal shared Telegram support needed for branch buildability

## Verification (March 31, 2026)
- `npm run build` ✅
- `npm test -- tests/bot/telegramJoinCommand.test.ts tests/bot/telegramProjectCommand.test.ts tests/bot/telegramStartupTarget.test.ts tests/services/antigravityAccountDiscovery.test.ts tests/services/cdpService.uiSync.test.ts` ✅
- `PATH=/Users/cyrilchan/.nvm/versions/node/v22.18.0/bin:$PATH node ./node_modules/jest/bin/jest.js tests/services/conversationTransferService.test.ts --runInBand` ✅

## Related
- Closely related to #114 and #119.

## Notes
- Local SQLite-backed Jest suites require forcing `PATH` to the nvm Node binary so Jest uses the same ABI (`127`) as the rebuilt `better-sqlite3` addon.
