### PR TITLE
fix: harden telegram startup and first-send flow

### DIFF
--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1,3 +1,5 @@
+import { SESSION_SELECT_ID } from '../ui/sessionPickerUi';
+import { handleTelegramJoinSelect } from './telegramJoinCommand';
 import { t } from "../utils/i18n";
 import { logger } from '../utils/logger';
 import type { LogLevel } from '../utils/logger';
@@ -10,6 +12,7 @@ import {
     StringSelectMenuBuilder, MessageFlags,
 } from 'discord.js';
 import Database from 'better-sqlite3';
+import fs from 'fs';
 
 import { wrapDiscordChannel } from '../platform/discord/wrappers';
 import type { PlatformType } from '../platform/types';
@@ -23,7 +26,9 @@ import { ModeService, AVAILABLE_MODES, MODE_DISPLAY_NAMES, MODE_DESCRIPTIONS, MO
 import { ModelService } from '../services/modelService';
 import { applyDefaultModel } from '../services/defaultModelApplicator';
 import { TemplateRepository } from '../database/templateRepository';
+import { AccountPreferenceRepository } from '../database/accountPreferenceRepository';
 import { WorkspaceBindingRepository } from '../database/workspaceBindingRepository';
+import { ChannelPreferenceRepository } from '../database/channelPreferenceRepository';
 import { ChatSessionRepository } from '../database/chatSessionRepository';
 import { WorkspaceService } from '../services/workspaceService';
 import {
@@ -82,9 +87,11 @@ import { sendModeUI } from '../ui/modeUi';
 import { sendModelsUI, buildModelsUI } from '../ui/modelsUi';
 import { sendTemplateUI } from '../ui/templateUi';
 import { sendAutoAcceptUI } from '../ui/autoAcceptUi';
+import { sendAccountUI } from '../ui/accountUi';
 import { sendOutputUI, OUTPUT_BTN_EMBED, OUTPUT_BTN_PLAIN } from '../ui/outputUi';
 import { handleScreenshot } from '../ui/screenshotUi';
 import { UserPreferenceRepository, OutputFormat } from '../database/userPreferenceRepository';
+import { listAccountNames, resolveValidAccountName } from '../utils/accountUtils';
 import { formatAsPlainText, splitPlainText } from '../utils/plainTextFormatter';
 import { createInteractionCreateHandler } from '../events/interactionCreateHandler';
 import { createMessageCreateHandler } from '../events/messageCreateHandler';
@@ -106,6 +113,8 @@ import { createModelButtonAction } from '../handlers/modelButtonAction';
 import { createAutoAcceptButtonAction } from '../handlers/autoAcceptButtonAction';
 import { createTemplateButtonAction } from '../handlers/templateButtonAction';
 import { createModeSelectAction } from '../handlers/modeSelectAction';
+import { createAccountSelectAction } from '../handlers/accountSelectAction';
+import { selectTelegramStartupChatId } from './telegramStartupTarget';
 
 // =============================================================================
 // Embed color palette (color-coded by phase)
@@ -910,6 +919,8 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
     const modelService = new ModelService();
     const templateRepo = new TemplateRepository(db);
     const userPrefRepo = new UserPreferenceRepository(db);
+    const accountPrefRepo = new AccountPreferenceRepository(db);
+    const channelPrefRepo = new ChannelPreferenceRepository(db);
 
     // Eagerly load default model from DB (single-user bot optimization)
     try {
@@ -930,7 +941,10 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
     await ensureAntigravityRunning();
 
     // Initialize CDP bridge (lazy connection: pool creation only)
-    const bridge = initCdpBridge(config.autoApproveFileEdits);
+    const accountPorts = Object.fromEntries(
+        (config.antigravityAccounts ?? []).map((account) => [account.name, account.cdpPort]),
+    );
+    const bridge = initCdpBridge(config.autoApproveFileEdits, accountPorts);
 
     // Initialize CDP-dependent services (constructor CDP dependency removed)
     const chatSessionService = new ChatSessionService();
@@ -1044,6 +1058,9 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         parseRunCommandCustomId,
         joinHandler,
         userPrefRepo,
+        accountPrefRepo,
+        channelPrefRepo,
+        antigravityAccounts: config.antigravityAccounts,
         handleSlashInteraction: async (
             interaction,
             handler,
@@ -1055,6 +1072,9 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             modelServiceArg,
             autoAcceptServiceArg,
             clientArg,
+            accountPrefRepoArg,
+            channelPrefRepoArg,
+            antigravityAccountsArg,
         ) => handleSlashInteraction(
             interaction,
             handler,
@@ -1070,6 +1090,9 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             templateRepo,
             joinHandler,
             userPrefRepo,
+            accountPrefRepoArg,
+            channelPrefRepoArg,
+            antigravityAccountsArg,
         ),
         handleTemplateUse: async (interaction, templateId) => {
             const template = templateRepo.findById(templateId);
@@ -1088,7 +1111,17 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             let cdp: CdpService | null = null;
             if (workspacePath) {
                 try {
-                    cdp = await bridge.pool.getOrConnect(workspacePath);
+                    const selectedAccount = resolveValidAccountName(
+                        bridge.selectedAccountByChannel?.get(channelId)
+                            ?? channelPrefRepo.getAccountName(channelId)
+                            ?? accountPrefRepo.getAccountName(interaction.user.id)
+                            ?? 'default',
+                        config.antigravityAccounts,
+                    );
+                    bridge.selectedAccountByChannel?.set(channelId, selectedAccount);
+                    bridge.pool.setPreferredAccountForWorkspace?.(workspacePath, selectedAccount);
+
+                    cdp = await bridge.pool.getOrConnect(workspacePath, { name: selectedAccount });
                     const projectName = bridge.pool.extractProjectName(workspacePath);
                     bridge.lastActiveWorkspace = projectName;
                     const platformCh = wrapDiscordChannel(interaction.channel as any);
@@ -1176,6 +1209,9 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         autoRenameChannel,
         handleScreenshot,
         userPrefRepo,
+        accountPrefRepo,
+        channelPrefRepo,
+        antigravityAccounts: config.antigravityAccounts,
     }));
 
     await client.login(discordToken);
@@ -1221,22 +1257,54 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                 botApi: telegramBot.api as any,
                 chatSessionService,
                 responseTimeoutMs: config.responseTimeoutMs,
+                accountPrefRepo,
+                channelPrefRepo,
+                antigravityAccounts: config.antigravityAccounts,
             });
 
             // Compose select handlers: project select + mode select
             const projectSelectHandler = createTelegramSelectHandler({
+                botApi: telegramBot.api as any,
+                bridge,
                 workspaceService,
                 telegramBindingRepo,
             });
             const modeSelectAction = createModeSelectAction({ bridge, modeService });
+            const accountSelectAction = createAccountSelectAction({
+                bridge,
+                accountPrefRepo,
+                channelPrefRepo,
+                antigravityAccounts: config.antigravityAccounts,
+                getWorkspacePathForChannel: (channelId: string) => {
+                    const binding = telegramBindingRepo.findByChatId(channelId);
+                    if (!binding) return null;
+                    return workspaceService
+                        ? workspaceService.getWorkspacePath(binding.workspacePath)
+                        : binding.workspacePath;
+                },
+            });
             const telegramSelectHandler = createPlatformSelectHandler({
                 actions: [
                     modeSelectAction,
+                    accountSelectAction,
                 ],
             });
             // Composite handler that routes to the right handler
             const compositeSelectHandler = async (interaction: import('../platform/types').PlatformSelectInteraction) => {
-                if (interaction.customId === 'mode_select') {
+                if (interaction.customId === SESSION_SELECT_ID) {
+                    await handleTelegramJoinSelect({
+                        bridge,
+                        botApi: telegramBot.api as any,
+                        telegramBindingRepo,
+                        workspaceService,
+                        chatSessionService,
+                        accountPrefRepo,
+                        channelPrefRepo,
+                        antigravityAccounts: config.antigravityAccounts,
+                    }, interaction);
+                    return;
+                }
+                if (interaction.customId === 'mode_select' || interaction.customId === 'account_select') {
                     await telegramSelectHandler(interaction);
                     return;
                 }
@@ -1279,11 +1347,15 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                 { command: 'model', description: 'Switch LLM model' },
                 { command: 'screenshot', description: 'Capture Antigravity screenshot' },
                 { command: 'autoaccept', description: 'Toggle auto-accept mode' },
+                { command: 'account', description: 'Switch Antigravity account' },
+                { command: 'project_reopen', description: 'Reopen bound project in account' },
                 { command: 'template', description: 'List prompt templates' },
                 { command: 'template_add', description: 'Add a prompt template' },
                 { command: 'template_delete', description: 'Delete a prompt template' },
                 { command: 'project_create', description: 'Create a new workspace' },
                 { command: 'new', description: 'Start a new chat session' },
+                { command: 'join', description: 'Take over an existing session' },
+                { command: 'mirror', description: 'Toggle PC-to-Telegram message mirroring' },
                 { command: 'logs', description: 'Show recent log entries' },
                 { command: 'stop', description: 'Interrupt active LLM generation' },
                 { command: 'help', description: 'Show available commands' },
@@ -1297,7 +1369,8 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
 
             logger.info(`Telegram bot started: @${botInfo.username} (${config.telegramAllowedUserIds?.length ?? 0} allowed users)`);
 
-            // Send startup message to all bound Telegram chats
+            // Send startup message to one Telegram target:
+            // prefer a group named "general", otherwise the first private chat.
             const bindings = telegramBindingRepo.findAll();
             if (bindings.length > 0) {
                 const os = await import('os');
@@ -1340,14 +1413,14 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                     }
                 };
 
-                const results = await Promise.allSettled(
-                    bindings.map((binding) => sendWithRetry(binding.chatId, startupText)),
-                );
-                const failed = results.filter((r) => r.status === 'rejected');
-                if (failed.length > 0) {
-                    logger.warn(`[Telegram] Startup message failed for ${failed.length}/${bindings.length} chat(s) after retries: ${(failed[0] as PromiseRejectedResult).reason?.message ?? 'unknown error'}`);
-                } else {
-                    logger.info(`Telegram startup message sent to ${bindings.length} bound chat(s).`);
+                const targetChatId = await selectTelegramStartupChatId(telegramBot.api, bindings);
+                if (targetChatId) {
+                    try {
+                        await sendWithRetry(targetChatId, startupText);
+                        logger.info(`Telegram startup message sent to chat ${targetChatId}.`);
+                    } catch (error: any) {
+                        logger.warn(`[Telegram] Startup message failed for chat ${targetChatId} after retries: ${error?.message ?? 'unknown error'}`);
+                    }
                 }
             }
         } catch (e: unknown) {
@@ -1386,7 +1459,7 @@ async function autoRenameChannel(
 /**
  * Handle Discord Interactions API slash commands
  */
-async function handleSlashInteraction(
+export async function handleSlashInteraction(
     interaction: ChatInputCommandInteraction,
     handler: SlashCommandHandler,
     bridge: CdpBridge,
@@ -1401,8 +1474,15 @@ async function handleSlashInteraction(
     templateRepo: TemplateRepository,
     joinHandler?: JoinCommandHandler,
     userPrefRepo?: UserPreferenceRepository,
+    accountPrefRepo?: AccountPreferenceRepository,
+    channelPrefRepo?: ChannelPreferenceRepository,
+    antigravityAccounts: { name: string; cdpPort: number }[] = [{ name: 'default', cdpPort: 9222 }],
 ): Promise<void> {
     const commandName = interaction.commandName;
+    const getAccountPort = (accountName: string): number | null => {
+        const match = antigravityAccounts.find((account) => account.name === accountName);
+        return match ? match.cdpPort : null;
+    };
 
     switch (commandName) {
         case 'help': {
@@ -1422,6 +1502,7 @@ async function handleSlashInteraction(
                 {
                     name: '⏹️ Control', value: [
                         '`/stop` — Interrupt active LLM generation',
+                        '`/project reopen` — Reopen the bound project in the selected account',
                         '`/screenshot` — Capture Antigravity screen',
                     ].join('\n')
                 },
@@ -1436,6 +1517,7 @@ async function handleSlashInteraction(
                     name: '📁 Projects', value: [
                         '`/project` — Display project list',
                         '`/project create <name>` — Create a new project',
+                        '`/project reopen` — Reopen the bound project in the selected account',
                     ].join('\n')
                 },
                 {
@@ -1449,6 +1531,7 @@ async function handleSlashInteraction(
                     name: '🔧 System', value: [
                         '`/status` — Display overall bot status',
                         '`/autoaccept` — Toggle auto-approve mode for approval dialogs via buttons',
+                        '`/account` — Show and switch Antigravity account',
                         '`/logs [lines] [level]` — View recent bot logs',
                         '`/cleanup [days]` — Clean up unused channels/categories',
                         '`/help` — Show this help',
@@ -1552,12 +1635,20 @@ async function handleSlashInteraction(
             const mirrorStatus = mirroringWorkspaces.length > 0
                 ? `📡 ON (${mirroringWorkspaces.join(', ')})`
                 : '⚪ OFF';
+            const currentAccount = resolveValidAccountName(
+                bridge.selectedAccountByChannel?.get(interaction.channelId)
+                    ?? channelPrefRepo?.getAccountName(interaction.channelId)
+                    ?? accountPrefRepo?.getAccountName(interaction.user.id)
+                    ?? 'default',
+                antigravityAccounts,
+            );
 
             const statusFields = [
                 { name: 'CDP Connection', value: activeNames.length > 0 ? `🟢 ${activeNames.length} project(s) connected` : '⚪ Disconnected', inline: true },
                 { name: 'Mode', value: MODE_DISPLAY_NAMES[currentMode] || currentMode, inline: true },
                 { name: 'Auto Approve', value: autoAcceptService.isEnabled() ? '🟢 ON' : '⚪ OFF', inline: true },
                 { name: 'Mirroring', value: mirrorStatus, inline: true },
+                { name: 'Account', value: currentAccount, inline: true },
             ];
 
             let statusDescription = '';
@@ -1605,6 +1696,50 @@ async function handleSlashInteraction(
 
             const result = autoAcceptService.handle(requestedMode);
             await interaction.editReply({ content: result.message });
+            break;
+        }
+
+        case 'account': {
+            if (!accountPrefRepo) {
+                await interaction.editReply({ content: 'Account preference service not available.' });
+                break;
+            }
+
+            const requested = interaction.options.getString('name');
+            if (!requested) {
+                const current = resolveValidAccountName(
+                    bridge.selectedAccountByChannel?.get(interaction.channelId)
+                        ?? channelPrefRepo?.getAccountName(interaction.channelId)
+                        ?? accountPrefRepo.getAccountName(interaction.user.id)
+                        ?? 'default',
+                    antigravityAccounts,
+                );
+                const names = listAccountNames(antigravityAccounts);
+                await sendAccountUI(interaction, current, names);
+                break;
+            }
+
+            if (!listAccountNames(antigravityAccounts).includes(requested)) {
+                await interaction.editReply({ content: `⚠️ Unknown account: **${requested}**` });
+                break;
+            }
+
+            accountPrefRepo.setAccountName(interaction.user.id, requested);
+            channelPrefRepo?.setAccountName(interaction.channelId, requested);
+            bridge.selectedAccountByChannel?.set(interaction.channelId, requested);
+
+            const channelWorkspace = wsHandler.getWorkspaceForChannel(interaction.channelId);
+            if (channelWorkspace) {
+                bridge.pool.setPreferredAccountForWorkspace?.(channelWorkspace, requested);
+            }
+
+            logger.info(
+                `[AccountSwitch] source=slash channel=${interaction.channelId} user=${interaction.user.id} ` +
+                `account=${requested} port=${getAccountPort(requested) ?? 'unknown'} ` +
+                `workspace=${channelWorkspace ?? 'unbound'}`,
+            );
+
+            await interaction.editReply({ content: `✅ Switched account to **${requested}**.` });
             break;
         }
 
@@ -1684,6 +1819,67 @@ async function handleSlashInteraction(
                     break;
                 }
                 await wsHandler.handleCreate(interaction, interaction.guild);
+            } else if (wsSub === 'reopen') {
+                const workspacePath = wsHandler.getWorkspaceForChannel(interaction.channelId);
+                if (!workspacePath) {
+                    await interaction.editReply({
+                        content: '⚠️ No project is bound to this channel. Use `/project` first.',
+                    });
+                    break;
+                }
+
+                if (!fs.existsSync(workspacePath) || !fs.statSync(workspacePath).isDirectory()) {
+                    await interaction.editReply({
+                        content: `❌ Project folder does not exist: \`${workspacePath}\``,
+                    });
+                    break;
+                }
+
+                const selectedAccount = resolveValidAccountName(
+                    bridge.selectedAccountByChannel?.get(interaction.channelId)
+                        ?? channelPrefRepo?.getAccountName(interaction.channelId)
+                        ?? accountPrefRepo?.getAccountName(interaction.user.id)
+                        ?? 'default',
+                    antigravityAccounts,
+                );
+                const port = getAccountPort(selectedAccount);
+                const accountPorts = Object.fromEntries(
+                    antigravityAccounts.map((account) => [account.name, account.cdpPort]),
+                );
+                const projectName = bridge.pool.extractProjectName(workspacePath);
+
+                logger.info(
+                    `[ProjectReopenCommand] channel=${interaction.channelId} user=${interaction.user.id} ` +
+                    `project=${projectName} account=${selectedAccount} ` +
+                    `port=${port ?? 'unknown'} workspacePath=${workspacePath}`,
+                );
+
+                try {
+                    const cdp = new CdpService({
+                        accountName: selectedAccount,
+                        accountPorts,
+                        cdpCallTimeout: 15000,
+                        maxReconnectAttempts: 0,
+                    });
+
+                    try {
+                        await cdp.openWorkspace(workspacePath);
+                    } finally {
+                        await cdp.disconnect().catch(() => {});
+                    }
+
+                    bridge.selectedAccountByChannel?.set(interaction.channelId, selectedAccount);
+                    bridge.pool.setPreferredAccountForWorkspace?.(workspacePath, selectedAccount);
+
+                    await interaction.editReply({
+                        content: `✅ Reopened **${projectName}** in account **${selectedAccount}**${port ? ` (CDP ${port})` : ''}.`,
+                    });
+                } catch (error: any) {
+                    logger.error('[ProjectReopenCommand] Failed to reopen workspace:', error);
+                    await interaction.editReply({
+                        content: `❌ Failed to reopen project in account **${selectedAccount}**: ${error?.message || String(error)}`,
+                    });
+                }
             } else {
                 // /project list or /project (default)
                 await wsHandler.handleShow(interaction);

--- a/src/bot/telegramStartupTarget.ts
+++ b/src/bot/telegramStartupTarget.ts
@@ -1,0 +1,73 @@
+import type { TelegramBindingRecord } from '../database/telegramBindingRepository';
+import type { TelegramBotLike } from '../platform/telegram/wrappers';
+
+interface StartupChatCandidate {
+    bindingChatId: string;
+    resolvedChatId: string;
+    type: string;
+    title: string;
+    isDirectBinding: boolean;
+}
+
+function getBaseChatId(chatId: string): string {
+    const sepIdx = chatId.indexOf('_');
+    return sepIdx > 0 ? chatId.slice(0, sepIdx) : chatId;
+}
+
+function normalizeTitle(title: string): string {
+    return title.trim().replace(/^#/, '').toLowerCase();
+}
+
+function isGeneralChat(title: string): boolean {
+    return normalizeTitle(title) === 'general';
+}
+
+export async function selectTelegramStartupChatId(
+    api: TelegramBotLike['api'],
+    bindings: TelegramBindingRecord[],
+): Promise<string | null> {
+    const candidates: StartupChatCandidate[] = [];
+    const seenResolvedIds = new Set<string>();
+
+    for (const binding of bindings) {
+        const resolvedChatId = getBaseChatId(binding.chatId);
+        if (seenResolvedIds.has(resolvedChatId)) continue;
+        seenResolvedIds.add(resolvedChatId);
+
+        try {
+            const chat = await api.getChat(resolvedChatId);
+            candidates.push({
+                bindingChatId: binding.chatId,
+                resolvedChatId,
+                type: String(chat?.type ?? ''),
+                title: String(chat?.title ?? chat?.first_name ?? ''),
+                isDirectBinding: binding.chatId === resolvedChatId,
+            });
+        } catch {
+            candidates.push({
+                bindingChatId: binding.chatId,
+                resolvedChatId,
+                type: '',
+                title: '',
+                isDirectBinding: binding.chatId === resolvedChatId,
+            });
+        }
+    }
+
+    if (candidates.length === 0) return null;
+
+    const generalGroup = candidates.find((candidate) =>
+        candidate.type !== 'private' && isGeneralChat(candidate.title),
+    );
+    if (generalGroup) return generalGroup.resolvedChatId;
+
+    const directGroup = candidates.find((candidate) =>
+        candidate.type !== 'private' && candidate.isDirectBinding,
+    );
+    if (directGroup) return directGroup.resolvedChatId;
+
+    const privateChat = candidates.find((candidate) => candidate.type === 'private');
+    if (privateChat) return privateChat.bindingChatId;
+
+    return candidates[0].resolvedChatId;
+}

--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -2,7 +2,7 @@ import { logger } from '../utils/logger';
 import { CDP_PORTS } from '../utils/cdpPorts';
 import { EventEmitter } from 'events';
 import * as http from 'http';
-import { spawn } from 'child_process';
+import { execFile, spawn } from 'child_process';
 import { getAntigravityCliPath, extractProjectNameFromPath } from '../utils/pathUtils';
 import WebSocket from 'ws';
 
@@ -13,6 +13,8 @@ export interface CdpServiceOptions {
     maxReconnectAttempts?: number;
     /** Delay between reconnect attempts (ms). Default: 2000 */
     reconnectDelayMs?: number;
+    accountName?: string;
+    accountPorts?: Record<string, number>;
 }
 
 export interface CdpContext {
@@ -57,6 +59,13 @@ const SELECTORS = {
     CONTEXT_URL_KEYWORD: 'cascade-panel',
 };
 
+const CHAT_READY_TIMEOUT_MS = 6000;
+const CHAT_READY_POLL_MS = 250;
+const INJECT_RETRY_READY_TIMEOUT_MS = 2500;
+const INJECT_RETRY_BACKOFF_MS = 500;
+const MODE_READY_TIMEOUT_MS = 4000;
+const MODE_RETRY_READY_TIMEOUT_MS = 2000;
+
 export class CdpService extends EventEmitter {
     private ports: number[];
     private isConnectedFlag: boolean = false;
@@ -80,13 +89,25 @@ export class CdpService extends EventEmitter {
     private currentWorkspacePath: string | null = null;
     /** Workspace switching flag (suppresses disconnected event) */
     private isSwitchingWorkspace: boolean = false;
+    private accountName: string;
+    private accountPorts: Record<string, number>;
 
     constructor(options: CdpServiceOptions = {}) {
         super();
-        this.ports = options.portsToScan || [...CDP_PORTS];
+        this.accountName = options.accountName || 'default';
+        this.accountPorts = options.accountPorts || {};
+        this.ports = options.portsToScan || this.resolveAccountPorts(this.accountName);
         if (options.cdpCallTimeout) this.cdpCallTimeout = options.cdpCallTimeout;
         this.maxReconnectAttempts = options.maxReconnectAttempts ?? 3;
         this.reconnectDelayMs = options.reconnectDelayMs ?? 2000;
+    }
+
+    private resolveAccountPorts(accountName: string): number[] {
+        const explicitPort = this.accountPorts[accountName];
+        if (Number.isInteger(explicitPort) && explicitPort > 0) {
+            return [explicitPort];
+        }
+        return [...CDP_PORTS];
     }
 
     private async getJson(url: string): Promise<any[]> {
@@ -322,6 +343,22 @@ export class CdpService extends EventEmitter {
             return await this._discoverAndConnectForWorkspaceImpl(workspacePath, projectName);
         } finally {
             this.isSwitchingWorkspace = false;
+        }
+    }
+
+    async openWorkspace(workspacePath: string): Promise<boolean> {
+        const projectName = extractProjectNameFromPath(workspacePath);
+        this.currentWorkspacePath = workspacePath;
+
+        try {
+            return await this.discoverAndConnectForWorkspace(workspacePath);
+        } catch (error: any) {
+            logger.info(
+                `[CdpService] Explicit open requested for workspace "${projectName}" ` +
+                `on account "${this.accountName}" — retrying with launch ` +
+                `(reason: ${error?.message || String(error)})`,
+            );
+            return this.launchAndConnectWorkspace(workspacePath, projectName, true);
         }
     }
 
@@ -576,20 +613,65 @@ export class CdpService extends EventEmitter {
     private async launchAndConnectWorkspace(
         workspacePath: string,
         projectName: string,
+        explicitOpen: boolean = false,
     ): Promise<boolean> {
+        const targetPort = this.ports[0] ?? null;
+        const resolvedUserDataDir = explicitOpen && targetPort !== null
+            ? await this.resolveRunningUserDataDirForPort(targetPort)
+            : null;
+
+        if (explicitOpen && this.accountName !== 'default' && targetPort !== null && !resolvedUserDataDir) {
+            throw new Error(
+                `Could not determine user-data-dir for running account "${this.accountName}" ` +
+                `(CDP port ${targetPort}). Make sure that Antigravity instance is already running with that port.`,
+            );
+        }
+
+        if (!explicitOpen && this.accountName !== 'default' && targetPort !== null) {
+            logger.warn(
+                `[CdpService] Workspace "${projectName}" not found on account "${this.accountName}" ` +
+                `(port=${targetPort}). Skipping auto-launch to avoid opening the wrong Antigravity instance.`,
+            );
+            throw new Error(
+                `Workspace "${projectName}" is not open in account "${this.accountName}" ` +
+                `(CDP port ${targetPort}). Open it with Antigravity Cockpit or use "/project reopen" ` +
+                `command (Telegram: /project_reopen).`,
+            );
+        }
+
         // Open as folder using Antigravity CLI (not as workspace mode).
         // `open -a Antigravity` may open as workspace, resulting in title "Untitled (Workspace)".
         // CLI --new-window opens as folder, immediately reflecting directory name in title.
         const antigravityCli = getAntigravityCliPath();
 
-        logger.debug(`[CdpService] Launching Antigravity: ${antigravityCli} --new-window ${workspacePath}`);
+        const launchArgs = [
+            ...(resolvedUserDataDir ? ['--user-data-dir', resolvedUserDataDir] : []),
+            ...(targetPort !== null ? [`--remote-debugging-port=${targetPort}`] : []),
+            '--new-window',
+            workspacePath,
+        ];
+
+        logger.debug(
+            `[CdpService] Launching Antigravity for account "${this.accountName}" ` +
+            `(port=${targetPort ?? 'unknown'}, userDataDir=${resolvedUserDataDir ?? 'default'}) ` +
+            `${antigravityCli} ${launchArgs.join(' ')}`,
+        );
         try {
-            await this.runCommand(antigravityCli, ['--new-window', workspacePath]);
+            await this.runCommand(antigravityCli, launchArgs);
         } catch (error: any) {
             // Fall back to open -a if CLI not found (macOS only)
             logger.warn(`[CdpService] CLI launch failed, falling back to open -a (if macOS): ${error?.message || String(error)}`);
             if (process.platform === 'darwin') {
-                await this.runCommand('open', ['-a', 'Antigravity', workspacePath]);
+                const openArgs = [
+                    '-n',
+                    '-a',
+                    'Antigravity',
+                    '--args',
+                    ...(resolvedUserDataDir ? ['--user-data-dir', resolvedUserDataDir] : []),
+                    ...(targetPort !== null ? [`--remote-debugging-port=${targetPort}`] : []),
+                    workspacePath,
+                ];
+                await this.runCommand('open', openArgs);
             } else {
                 throw error;
             }
@@ -782,6 +864,70 @@ export class CdpService extends EventEmitter {
                 reject(new Error(`${command} exited with code ${code ?? 'unknown'}`));
             });
         });
+    }
+
+    private async resolveRunningUserDataDirForPort(port: number): Promise<string | null> {
+        const commandLines = await this.getProcessCommandLines();
+        if (commandLines.length === 0) return null;
+
+        const portPattern = new RegExp(`--remote-debugging-port(?:=|\\s+)${port}(?:\\s|$)`);
+
+        for (const line of commandLines) {
+            const lowerLine = line.toLowerCase();
+            if (!lowerLine.includes('antigravity') || !portPattern.test(line) || !line.includes('--user-data-dir')) {
+                continue;
+            }
+
+            const match = line.match(/--user-data-dir(?:=|\s+)("([^"]+)"|'([^']+)'|([^\s]+))/);
+            const userDataDir = match?.[2] || match?.[3] || match?.[4];
+            if (userDataDir) {
+                logger.info(`[CdpService] Resolved user-data-dir for CDP port ${port}: ${userDataDir}`);
+                return userDataDir;
+            }
+        }
+
+        return null;
+    }
+
+    private async getProcessCommandLines(): Promise<string[]> {
+        const run = (command: string, args: string[]): Promise<string> =>
+            new Promise((resolve, reject) => {
+                execFile(command, args, { windowsHide: true, maxBuffer: 20 * 1024 * 1024 }, (error, stdout) => {
+                    if (error) {
+                        reject(error);
+                        return;
+                    }
+                    resolve(stdout);
+                });
+            });
+
+        const parseLines = (output: string): string[] =>
+            output
+                .split('\n')
+                .map((line) => line.trim())
+                .filter((line) => line.length > 0);
+
+        try {
+            if (process.platform === 'win32') {
+                try {
+                    const psOutput = await run('powershell.exe', [
+                        '-NoProfile',
+                        '-Command',
+                        'Get-CimInstance Win32_Process | Select-Object -ExpandProperty CommandLine | Where-Object { $_ }',
+                    ]);
+                    return parseLines(psOutput);
+                } catch {
+                    const wmicOutput = await run('wmic', ['process', 'get', 'CommandLine']);
+                    return parseLines(wmicOutput).filter((line) => line !== 'CommandLine');
+                }
+            }
+
+            const psOutput = await run('ps', ['-axo', 'command=']);
+            return parseLines(psOutput);
+        } catch (error) {
+            logger.warn(`[CdpService] Failed to inspect Antigravity processes: ${error instanceof Error ? error.message : String(error)}`);
+            return [];
+        }
     }
 
     /**
@@ -1010,6 +1156,130 @@ export class CdpService extends EventEmitter {
         return { ok: false, error: 'Chat input field not found' };
     }
 
+    private async waitForChatInputReady(timeoutMs = CHAT_READY_TIMEOUT_MS): Promise<{ ok: boolean; contextId?: number; error?: string }> {
+        const deadline = Date.now() + timeoutMs;
+        let lastError = 'Chat input field not found';
+
+        while (Date.now() < deadline) {
+            const focusResult = await this.focusChatInput();
+            if (focusResult.ok) {
+                return focusResult;
+            }
+            lastError = focusResult.error || lastError;
+            await new Promise((r) => setTimeout(r, CHAT_READY_POLL_MS));
+        }
+
+        return { ok: false, error: lastError };
+    }
+
+    private isTransientInjectError(error?: string): boolean {
+        const message = String(error || '');
+        return [
+            'No editor found',
+            'Chat input field not found',
+            'WebSocket is not connected',
+            'WebSocket disconnected',
+        ].some((fragment) => message.includes(fragment));
+    }
+
+    private async isModeToggleReady(): Promise<boolean> {
+        const expression = '(() => {'
+            + ' const uiNameMap = { fast: "Fast", plan: "Planning" };'
+            + ' const knownModes = Object.values(uiNameMap).map(n => n.toLowerCase());'
+            + ' const allBtns = Array.from(document.querySelectorAll("button"));'
+            + ' const visibleBtns = allBtns.filter(b => b.offsetParent !== null);'
+            + ' const modeToggleBtn = visibleBtns.find(b => {'
+            + '   const text = (b.textContent || "").trim().toLowerCase();'
+            + '   const hasChevron = b.querySelector("svg[class*=\\"chevron\\"]");'
+            + '   return knownModes.some(m => text === m) && hasChevron;'
+            + ' });'
+            + ' return !!modeToggleBtn;'
+            + '})()';
+        try {
+            const contextId = this.getPrimaryContextId();
+            const callParams: any = {
+                expression,
+                returnByValue: true,
+                awaitPromise: false,
+            };
+            if (contextId !== null) callParams.contextId = contextId;
+            const res = await this.call('Runtime.evaluate', callParams);
+            return Boolean(res?.result?.value);
+        } catch {
+            return false;
+        }
+    }
+
+    private async waitForModeToggleReady(timeoutMs = MODE_READY_TIMEOUT_MS): Promise<boolean> {
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            if (await this.isModeToggleReady()) {
+                return true;
+            }
+            await new Promise((r) => setTimeout(r, CHAT_READY_POLL_MS));
+        }
+        return false;
+    }
+
+    private isTransientModeError(error?: string): boolean {
+        const message = String(error || '');
+        return [
+            'Mode toggle button not found',
+            'WebSocket is not connected',
+            'WebSocket disconnected',
+        ].some((fragment) => message.includes(fragment));
+    }
+
+    private async injectMessageCore(text: string, imageFilePaths?: string[]): Promise<InjectResult> {
+        const focusResult = await this.waitForChatInputReady();
+        if (!focusResult.ok) {
+            return { ok: false, error: focusResult.error || 'Chat input field not found' };
+        }
+
+        // Clear any existing text in the input field before injecting.
+        await this.clearInputField();
+
+        if (imageFilePaths && imageFilePaths.length > 0) {
+            const attachResult = await this.attachImageFiles(imageFilePaths, focusResult.contextId);
+            if (!attachResult.ok) {
+                return { ok: false, error: attachResult.error || 'Failed to attach images' };
+            }
+        }
+
+        await this.call('Input.insertText', { text });
+        await new Promise(r => setTimeout(r, 200));
+        await this.pressEnterToSend();
+
+        return {
+            ok: true,
+            method: 'enter',
+            contextId: focusResult.contextId,
+        };
+    }
+
+    private async retryInjectOnce(
+        text: string,
+        firstError: string,
+        imageFilePaths?: string[],
+    ): Promise<InjectResult> {
+        logger.warn(`[CdpService] Initial message injection failed: ${firstError}. Retrying once after readiness check...`);
+
+        try {
+            await this.reconnectOnDemand(INJECT_RETRY_READY_TIMEOUT_MS);
+        } catch {
+            // Ignore reconnect failures here; readiness check below will produce the final error.
+        }
+
+        await new Promise((r) => setTimeout(r, INJECT_RETRY_BACKOFF_MS));
+
+        const ready = await this.waitForChatInputReady(INJECT_RETRY_READY_TIMEOUT_MS);
+        if (!ready.ok) {
+            return { ok: false, error: ready.error || firstError };
+        }
+
+        return this.injectMessageCore(text, imageFilePaths);
+    }
+
     /**
      * Select all text in the focused input and delete it to ensure a clean state.
      * Uses Meta+A (select all) then Backspace (delete) via CDP key events.
@@ -1207,22 +1477,12 @@ export class CdpService extends EventEmitter {
             throw new Error('Not connected to CDP. Call connect() first.');
         }
 
-        const focusResult = await this.focusChatInput();
-        if (!focusResult.ok) {
-            return { ok: false, error: focusResult.error || 'Chat input field not found' };
+        const result = await this.injectMessageCore(text);
+        if (result.ok || !this.isTransientInjectError(result.error)) {
+            return result;
         }
 
-        // Clear any existing text in the input field before injecting
-        await this.clearInputField();
-
-        // 1. Input text via CDP Input.insertText
-        await this.call('Input.insertText', { text });
-        await new Promise(r => setTimeout(r, 200));
-
-        // 2. Send via Enter key
-        await this.pressEnterToSend();
-
-        return { ok: true, method: 'enter', contextId: focusResult.contextId };
+        return this.retryInjectOnce(text, result.error || 'Message injection failed');
     }
 
     /**
@@ -1233,24 +1493,12 @@ export class CdpService extends EventEmitter {
             throw new Error('Not connected to CDP. Call connect() first.');
         }
 
-        const focusResult = await this.focusChatInput();
-        if (!focusResult.ok) {
-            return { ok: false, error: focusResult.error || 'Chat input field not found' };
+        const result = await this.injectMessageCore(text, imageFilePaths);
+        if (result.ok || !this.isTransientInjectError(result.error)) {
+            return result;
         }
 
-        // Clear any existing text in the input field before injecting
-        await this.clearInputField();
-
-        const attachResult = await this.attachImageFiles(imageFilePaths, focusResult.contextId);
-        if (!attachResult.ok) {
-            return { ok: false, error: attachResult.error || 'Failed to attach images' };
-        }
-
-        await this.call('Input.insertText', { text });
-        await new Promise(r => setTimeout(r, 200));
-        await this.pressEnterToSend();
-
-        return { ok: true, method: 'enter', contextId: focusResult.contextId };
+        return this.retryInjectOnce(text, result.error || 'Image message injection failed', imageFilePaths);
     }
 
     /**
@@ -1493,6 +1741,8 @@ export class CdpService extends EventEmitter {
             await this.reconnectOnDemand();
         }
 
+        await this.waitForModeToggleReady();
+
         const safeMode = JSON.stringify(modeName);
 
         // Internal mode name -> Antigravity UI display name mapping
@@ -1588,7 +1838,25 @@ export class CdpService extends EventEmitter {
             if (value?.ok) {
                 return { ok: true, mode: value.mode };
             }
-            return { ok: false, error: value?.error || 'UI operation failed (setUiMode)' };
+            const errorMessage = value?.error || 'UI operation failed (setUiMode)';
+            if (!this.isTransientModeError(errorMessage)) {
+                return { ok: false, error: errorMessage };
+            }
+
+            logger.warn(`[CdpService] setUiMode initial attempt failed: ${errorMessage}. Retrying once after readiness check...`);
+            try {
+                await this.reconnectOnDemand(MODE_RETRY_READY_TIMEOUT_MS);
+            } catch {
+                // Fall through to the readiness wait and retry below.
+            }
+            await this.waitForModeToggleReady(MODE_RETRY_READY_TIMEOUT_MS);
+
+            const retryRes = await this.call('Runtime.evaluate', callParams);
+            const retryValue = retryRes?.result?.value;
+            if (retryValue?.ok) {
+                return { ok: true, mode: retryValue.mode };
+            }
+            return { ok: false, error: retryValue?.error || errorMessage };
         } catch (error: any) {
             return { ok: false, error: error?.message || String(error) };
         }

--- a/tests/bot/telegramStartupTarget.test.ts
+++ b/tests/bot/telegramStartupTarget.test.ts
@@ -1,0 +1,78 @@
+import { selectTelegramStartupChatId } from '../../src/bot/telegramStartupTarget';
+
+describe('selectTelegramStartupChatId', () => {
+    it('prefers a group chat named general', async () => {
+        const getChat = jest.fn(async (chatId: string) => {
+            if (chatId === '-1001') return { id: -1001, type: 'private', first_name: 'CY' };
+            if (chatId === '-2002') return { id: -2002, type: 'supergroup', title: 'general' };
+            return { id: chatId, type: 'private' };
+        });
+
+        const chatId = await selectTelegramStartupChatId(
+            { getChat } as any,
+            [
+                { id: 1, chatId: '-1001', workspacePath: 'A' },
+                { id: 2, chatId: '-2002_76', workspacePath: 'B' },
+                { id: 3, chatId: '-2002_126', workspacePath: 'C' },
+            ],
+        );
+
+        expect(chatId).toBe('-2002');
+        expect(getChat).toHaveBeenCalledTimes(2);
+    });
+
+    it('falls back to the first private chat when no general group exists', async () => {
+        const getChat = jest.fn(async (chatId: string) => {
+            if (chatId === '-1001') return { id: -1001, type: 'private', first_name: 'CY' };
+            if (chatId === '-2002') return { id: -2002, type: 'supergroup', title: 'Project Room' };
+            return { id: chatId, type: 'private' };
+        });
+
+        const chatId = await selectTelegramStartupChatId(
+            { getChat } as any,
+            [
+                { id: 1, chatId: '-1001', workspacePath: 'A' },
+                { id: 2, chatId: '-2002_76', workspacePath: 'B' },
+            ],
+        );
+
+        expect(chatId).toBe('-1001');
+    });
+
+    it('prefers a directly bound group chat before private chat', async () => {
+        const getChat = jest.fn(async (chatId: string) => {
+            if (chatId === '-1001') return { id: -1001, type: 'private', first_name: 'CY' };
+            if (chatId === '-2002') return { id: -2002, type: 'supergroup', title: 'Team Forum' };
+            return { id: chatId, type: 'private' };
+        });
+
+        const chatId = await selectTelegramStartupChatId(
+            { getChat } as any,
+            [
+                { id: 1, chatId: '-1001', workspacePath: 'A' },
+                { id: 2, chatId: '-2002', workspacePath: 'B' },
+                { id: 3, chatId: '-2002_76', workspacePath: 'C' },
+            ],
+        );
+
+        expect(chatId).toBe('-2002');
+    });
+
+    it('falls back to the first directly bound group chat when no private chat exists', async () => {
+        const getChat = jest.fn(async (chatId: string) => {
+            if (chatId === '-2002') return { id: -2002, type: 'supergroup', title: 'Project Room' };
+            if (chatId === '-3003') return { id: -3003, type: 'group', title: 'Ops' };
+            return { id: chatId, type: 'group' };
+        });
+
+        const chatId = await selectTelegramStartupChatId(
+            { getChat } as any,
+            [
+                { id: 1, chatId: '-2002_76', workspacePath: 'A' },
+                { id: 2, chatId: '-3003', workspacePath: 'B' },
+            ],
+        );
+
+        expect(chatId).toBe('-3003');
+    });
+});

--- a/tests/services/cdpService.uiSync.test.ts
+++ b/tests/services/cdpService.uiSync.test.ts
@@ -120,13 +120,16 @@ describe('CdpService - UI sync (Step 9)', () => {
             (cdpService as any).isConnectedFlag = true;
             (cdpService as any).ws = mockWsInstance;
 
-            callSpy.mockResolvedValue({
-                result: { value: { ok: true, mode: 'Planning' } }
-            });
+            callSpy
+                .mockResolvedValueOnce({ result: { value: true } })
+                .mockResolvedValueOnce({ result: { value: { ok: true, mode: 'Planning' } } });
 
             await cdpService.setUiMode('plan');
 
-            const callArgs = callSpy.mock.calls[0][1];
+            const runtimeEvaluateCalls = callSpy.mock.calls.filter(
+                (call) => call[0] === 'Runtime.evaluate' && String(call[1]?.expression || '').includes('role=\\"dialog\\"'),
+            );
+            const callArgs = runtimeEvaluateCalls[0][1];
             // Verify dialog-based search is used
             expect(callArgs.expression).toContain('role=\\"dialog\\"');
             expect(callArgs.expression).toContain('.font-medium');
@@ -145,6 +148,23 @@ describe('CdpService - UI sync (Step 9)', () => {
 
             expect(result.ok).toBe(false);
             expect(result.error).toBeDefined();
+        });
+
+        it('retries once when the mode toggle is not ready yet', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy
+                .mockResolvedValueOnce({ result: { value: true } })
+                .mockResolvedValueOnce({ result: { value: { ok: false, error: 'Mode toggle button not found' } } })
+                .mockResolvedValueOnce({ result: { value: true } })
+                .mockResolvedValueOnce({ result: { value: { ok: true, mode: 'Planning' } } });
+
+            const result = await cdpService.setUiMode('plan');
+
+            expect(result.ok).toBe(true);
+            expect(result.mode).toBe('Planning');
+            expect(callSpy).toHaveBeenCalledTimes(4);
         });
 
         it('returns ok: false without crashing when a CDP error occurs', async () => {


### PR DESCRIPTION
## Description
Split from #94 to isolate Telegram startup-target and first-send hardening.

## Included
- `src/bot/index.ts`
- `src/bot/telegramStartupTarget.ts`
- `src/services/cdpService.ts`
- related tests

## Dependency Status
- This draft is intentionally deferred.
- It depends on #114 (`multi-account-infra`) landing first.
- Safest follow-up is to recreate this branch fresh from updated `main` after #114 merges, rather than rebasing the current draft in place.

## Verification (March 31, 2026)
- `npm run build` ❌ against `main`
- Current draft is not independently buildable from `main` because it still assumes the account-aware wiring extracted into #114.

## Follow-Up Verification After Recreate
- `npm run build`
- `npm test -- tests/bot/telegramStartupTarget.test.ts tests/services/cdpService.uiSync.test.ts`
- If `src/bot/index.ts` changes remain non-trivial after reconstruction, also run a targeted smoke pass around startup-target selection behavior.

## Notes
- Keep this draft for tracking/review context only until the clean reconstruction is ready.
