### PR TITLE
Security: Lockfile PID trust can terminate arbitrary local processes

### DIFF
--- a/src/utils/lockfile.ts
+++ b/src/utils/lockfile.ts
@@ -26,6 +26,17 @@ function isProcessRunning(pid: number): boolean {
 export function acquireLock(): () => void {
     fs.mkdirSync(LOCK_DIR, { recursive: true, mode: 0o700 });
 
+    const dirStat = fs.lstatSync(LOCK_DIR);
+    if (!dirStat.isDirectory()) {
+        throw new Error(`Lock path is not a directory: ${LOCK_DIR}`);
+    }
+    if (typeof process.getuid === 'function' && dirStat.uid !== process.getuid()) {
+        throw new Error(`Lock directory is not owned by current user: ${LOCK_DIR}`);
+    }
+    if ((dirStat.mode & 0o077) !== 0) {
+        throw new Error(`Lock directory has overly permissive permissions: ${LOCK_DIR}`);
+    }
+
     // Check existing lock file
     if (fs.existsSync(LOCK_FILE)) {
         const content = fs.readFileSync(LOCK_FILE, 'utf-8').trim();
@@ -39,8 +50,20 @@ export function acquireLock(): () => void {
         }
     }
 
-    // Create new lock file
-    fs.writeFileSync(LOCK_FILE, String(process.pid), { encoding: 'utf-8', mode: 0o600 });
+    // Create new lock file atomically
+    try {
+        const fd = fs.openSync(LOCK_FILE, 'wx', 0o600);
+        try {
+            fs.writeFileSync(fd, String(process.pid), { encoding: 'utf-8' });
+        } finally {
+            fs.closeSync(fd);
+        }
+    } catch (err: any) {
+        if (err?.code === 'EEXIST') {
+            throw new Error('Another Bot process is already running');
+        }
+        throw err;
+    }
     logger.info(`🔒 Lock acquired (PID: ${process.pid})`);
 
     // Cleanup function

--- a/src/utils/lockfile.ts
+++ b/src/utils/lockfile.ts
@@ -1,8 +1,10 @@
 import { logger } from './logger';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
-const LOCK_FILE = path.resolve(process.cwd(), '.bot.lock');
+const LOCK_DIR = process.env.XDG_RUNTIME_DIR || path.join(os.tmpdir(), `lazygravity-${process.getuid ? process.getuid() : 'user'}`);
+const LOCK_FILE = path.join(LOCK_DIR, '.bot.lock');
 
 /**
  * Check if a process with the given PID is running
@@ -17,63 +19,28 @@ function isProcessRunning(pid: number): boolean {
 }
 
 /**
- * Stop an existing process and wait for it to exit
- */
-function killExistingProcess(pid: number): void {
-    logger.warn(`🔄 Stopping existing Bot process (PID: ${pid})...`);
-    try {
-        process.kill(pid, 'SIGTERM');
-    } catch {
-        // Ignore if already terminated
-        return;
-    }
-
-    // Wait up to 5 seconds for process to exit
-    const deadline = Date.now() + 5000;
-    while (Date.now() < deadline) {
-        if (!isProcessRunning(pid)) {
-            logger.info(`✅ Existing process (PID: ${pid}) stopped`);
-            return;
-        }
-        // Wait 50ms (busy wait)
-        const waitUntil = Date.now() + 50;
-        while (Date.now() < waitUntil) { /* spin */ }
-    }
-
-    // Timeout: force kill with SIGKILL
-    logger.warn(`⚠️  Process did not exit with SIGTERM, force killing (SIGKILL)`);
-    try {
-        process.kill(pid, 'SIGKILL');
-    } catch {
-        // ignore
-    }
-}
-
-/**
  * Acquire a lockfile to prevent duplicate bot instances.
- * If another process is already running, stop it before starting.
  *
  * @returns A function to release the lock
  */
 export function acquireLock(): () => void {
+    fs.mkdirSync(LOCK_DIR, { recursive: true, mode: 0o700 });
+
     // Check existing lock file
     if (fs.existsSync(LOCK_FILE)) {
         const content = fs.readFileSync(LOCK_FILE, 'utf-8').trim();
         const existingPid = parseInt(content, 10);
 
         if (!isNaN(existingPid) && existingPid !== process.pid && isProcessRunning(existingPid)) {
-            // Stop existing process and restart
-            killExistingProcess(existingPid);
+            throw new Error(`Another Bot process is already running (PID: ${existingPid})`);
         } else if (!isNaN(existingPid) && !isProcessRunning(existingPid)) {
             logger.warn(`⚠️  Stale lock file detected (PID: ${existingPid} has exited). Cleaning up.`);
+            try { fs.unlinkSync(LOCK_FILE); } catch { /* ignore */ }
         }
-
-        // Remove stale lock file
-        try { fs.unlinkSync(LOCK_FILE); } catch { /* ignore */ }
     }
 
     // Create new lock file
-    fs.writeFileSync(LOCK_FILE, String(process.pid), 'utf-8');
+    fs.writeFileSync(LOCK_FILE, String(process.pid), { encoding: 'utf-8', mode: 0o600 });
     logger.info(`🔒 Lock acquired (PID: ${process.pid})`);
 
     // Cleanup function


### PR DESCRIPTION
## Summary

Security: Lockfile PID trust can terminate arbitrary local processes

## Problem

**Severity**: `High` | **File**: `src/utils/lockfile.ts:L51`

The lockfile logic reads a PID from `.bot.lock` and unconditionally sends `SIGTERM`/`SIGKILL` to that PID if it appears running. Because the lockfile is in `process.cwd()` and its contents are trusted, a local attacker who can write in that directory can plant a PID of another process and cause this application to kill it (local denial of service / abuse of process control).

## Solution

Store lockfiles in a user-private runtime directory with strict permissions (e.g., `$XDG_RUNTIME_DIR` or OS temp dir scoped per-user), and validate lock ownership by storing additional metadata (process command line/start time/user) before killing. Prefer non-destructive lock acquisition (fail if already locked) rather than killing arbitrary PID from file.

## Changes

- `src/utils/lockfile.ts` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lock files now use per-user runtime directories for better isolation
  * Stale lock files are automatically detected and removed
  * Lock file permissions enhanced for improved security
  * Active locks from other processes now trigger an error instead of forced termination

<!-- end of auto-generated comment: release notes by coderabbit.ai -->