### PR TITLE
fix(cdp): add span-based selectors for Antigravity v1.107+ model picker

### DIFF
--- a/docs/ANTIGRAVITY_DOM_SELECTORS.md
+++ b/docs/ANTIGRAVITY_DOM_SELECTORS.md
@@ -2,7 +2,7 @@
 
 Central reference for all CSS selectors and DOM structures used to interact with the Antigravity (Windsurf/Cascade) UI via CDP.
 
-> **Last verified**: 2025-02 (against live Antigravity DOM)
+> **Last verified**: 2026-04 (model picker updated for Antigravity v1.107.0+; other selectors verified 2025-02)
 
 ---
 
@@ -324,6 +324,89 @@ Terminal command execution confirmation dialog (Run/Reject).
 The `<pre>` element contains: `<working-directory> $ <command>`. Split on ` $ ` to extract:
 - `workingDirectory`: e.g. `~/Code/login`
 - `commandText`: e.g. `python3 -m http.server 8000`
+
+---
+
+## 13. Model Picker (Dropdown)
+
+Model list retrieval, current model detection, and model switching.
+
+> **Last verified**: 2026-04 (reported by user in [#120](https://github.com/tokyoweb3/LazyGravity/issues/120))
+
+### DOM Structure (v1.107.0+)
+
+```html
+<!-- Model trigger (shows current model) -->
+<span class="select-none overflow-hidden text-ellipsis text-xs">
+  gemini-2.5-pro
+</span>
+
+<!-- Model list items (inside dropdown) -->
+<div class="text-xs font-medium">
+  <span>gemini-2.5-pro</span>
+  <span>claude-3-opus</span>
+  <span>gpt-4o</span>
+</div>
+```
+
+### Legacy DOM Structure (pre-v1.107)
+
+```html
+<div class="cursor-pointer px-2 py-1 flex items-center justify-between">
+  model-name
+</div>
+<!-- Selected item has class: bg-gray-500/20 -->
+```
+
+### Item Selectors (ordered by priority)
+
+| Selector | Purpose | Version | File |
+|----------|---------|---------|------|
+| `[role="option"]` | ARIA option element | Universal | `cdpService.ts` |
+| `[role="menuitem"]` | ARIA menu item | Universal | `cdpService.ts` |
+| `[aria-selected]` | ARIA selected attribute | Universal | `cdpService.ts` |
+| `[aria-checked]` | ARIA checked attribute | Universal | `cdpService.ts` |
+| `button` | Button elements | Universal | `cdpService.ts` |
+| `[role="button"]` | ARIA button role | Universal | `cdpService.ts` |
+| `div.cursor-pointer` | Legacy clickable div | Pre-v1.107 | `cdpService.ts` |
+| `span[class*="select-none"]` | Span model display | v1.107+ | `cdpService.ts` |
+| `span[class*="text-xs"]` | Span model item | v1.107+ | `cdpService.ts` |
+
+### Selection Detection (scoring-based)
+
+| Signal | Score | Version |
+|--------|-------|---------|
+| `aria-selected="true"` | +5 | Universal |
+| `aria-checked="true"` | +5 | Universal |
+| `aria-current="true"` | +4 | Universal |
+| `data-state` matches `checked\|active\|selected\|on\|open` | +4 | Universal |
+| `className` includes `bg-gray-500/20` | +3 | Pre-v1.107 |
+| `className` includes `selected` | +3 | Universal |
+| `className` includes `active` | +2 | Universal |
+
+### Trigger Selectors (to open dropdown)
+
+| Selector | Purpose | File |
+|----------|---------|------|
+| `[role="combobox"]` | ARIA combobox | `cdpService.ts` |
+| `[aria-haspopup="listbox"]` | ARIA popup hint | `cdpService.ts` |
+| `[aria-expanded]` | Expandable element | `cdpService.ts` |
+| `span[class*="select-none"]` | v1.107+ model display | `cdpService.ts` |
+| `span[class*="overflow-hidden"]` | v1.107+ ellipsis model | `cdpService.ts` |
+
+### Scope Selectors (dropdown container)
+
+| Selector | Purpose |
+|----------|---------|
+| `[role="dialog"]` | Dialog container |
+| `[role="listbox"]` | Listbox container |
+| `[role="menu"]` | Menu container |
+| `[data-radix-popper-content-wrapper]` | Radix popover |
+| `[data-state="open"]` | Open state container |
+
+> **Note**: All candidates are filtered by `looksLikeModel()` regex (`/gemini|gpt|claude/i`) to avoid false positives. Adding broad selectors like `span` is safe because the model name filter provides specificity.
+
+**Used by**: `cdpService.ts` (`getUiModels()`, `getCurrentModel()`, `setUiModel()`)
 
 ---
 

--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -2132,6 +2132,8 @@ export class CdpService extends EventEmitter {
                 '[role="button"]',
                 'div.cursor-pointer',
                 'div[class*="cursor-pointer"]',
+                'span[class*="select-none"]',
+                'span[class*="text-xs"]',
             ];
             const getScopes = () => {
                 const scopes = [document];
@@ -2176,6 +2178,8 @@ export class CdpService extends EventEmitter {
                 '[role="button"]',
                 'div.cursor-pointer',
                 'div[class*="cursor-pointer"]',
+                'span[class*="select-none"]',
+                'span[class*="overflow-hidden"]',
             ];
 
             let models = collectModels();
@@ -2292,7 +2296,8 @@ export class CdpService extends EventEmitter {
             };
             const candidates = Array.from(document.querySelectorAll(
                 '[role="option"], [role="menuitem"], [role="combobox"], [aria-selected], [aria-checked], ' +
-                '[aria-current], button, [role="button"], div.cursor-pointer, div[class*="cursor-pointer"]'
+                '[aria-current], button, [role="button"], div.cursor-pointer, div[class*="cursor-pointer"], ' +
+                'span[class*="select-none"], span[class*="text-xs"]'
             ))
                 .filter(isVisible)
                 .map((el) => ({ el, label: getLabel(el), score: getScore(el) }))
@@ -2341,10 +2346,10 @@ export class CdpService extends EventEmitter {
             await this.reconnectOnDemand();
         }
 
-        // DOM manipulation script: based on actual Antigravity UI DOM structure
-        // Model list uses div.cursor-pointer elements with class 'px-2 py-1 flex items-center justify-between'
-        // Currently selected has 'bg-gray-500/20', others have 'hover:bg-gray-500/10'
-        // textContent may have "New" suffix
+        // DOM manipulation script: adaptive Antigravity UI model picker
+        // Legacy (<v1.107): div.cursor-pointer with class 'px-2 py-1 flex items-center justify-between'
+        // v1.107+: span elements with classes 'select-none', 'text-xs', 'overflow-hidden'
+        // Selection detected via ARIA attributes, data-state, or bg-gray-500/20 class
         const safeModel = JSON.stringify(modelName);
         const expression = `(async () => {
             const targetModel = ${safeModel};
@@ -2383,6 +2388,8 @@ export class CdpService extends EventEmitter {
                 '[role="button"]',
                 'div.cursor-pointer',
                 'div[class*="cursor-pointer"]',
+                'span[class*="select-none"]',
+                'span[class*="text-xs"]',
             ];
             const triggerSelectors = [
                 '[role="combobox"]',
@@ -2393,6 +2400,8 @@ export class CdpService extends EventEmitter {
                 '[role="button"]',
                 'div.cursor-pointer',
                 'div[class*="cursor-pointer"]',
+                'span[class*="select-none"]',
+                'span[class*="overflow-hidden"]',
             ];
             const scopeSelectors = [
                 '[role="dialog"]',

--- a/tests/services/cdpService.uiSync.test.ts
+++ b/tests/services/cdpService.uiSync.test.ts
@@ -294,5 +294,147 @@ describe('CdpService - UI sync (Step 9)', () => {
             expect(callArgs.expression).toContain('ariaHaspopup');
             expect(callArgs.expression).toContain('openPicker');
         });
+
+        it('includes span-based selectors for Antigravity v1.107+ DOM', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockResolvedValue({
+                result: { value: { ok: true, model: 'gemini-2.5-pro' } }
+            });
+
+            await cdpService.setUiModel('gemini-2.5-pro');
+
+            const callArgs = callSpy.mock.calls[0][1];
+            // v1.107+ uses span elements instead of div.cursor-pointer
+            expect(callArgs.expression).toContain('span[class*="select-none"]');
+            expect(callArgs.expression).toContain('span[class*="text-xs"]');
+            expect(callArgs.expression).toContain('span[class*="overflow-hidden"]');
+        });
+    });
+
+    // ========== getUiModels tests ==========
+
+    describe('getUiModels - model list retrieval', () => {
+
+        it('throws when not connected', async () => {
+            await expect(cdpService.getUiModels()).rejects.toThrow('Not connected to CDP.');
+        });
+
+        it('returns model list from CDP evaluation', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockResolvedValue({
+                result: { value: ['gemini-2.5-pro', 'claude-3-opus', 'gpt-4o'] }
+            });
+
+            const models = await cdpService.getUiModels();
+
+            expect(models).toEqual(['gemini-2.5-pro', 'claude-3-opus', 'gpt-4o']);
+            expect(callSpy).toHaveBeenCalledWith(
+                'Runtime.evaluate',
+                expect.objectContaining({
+                    returnByValue: true,
+                    awaitPromise: true,
+                })
+            );
+        });
+
+        it('returns empty array when no models found', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockResolvedValue({
+                result: { value: [] }
+            });
+
+            const models = await cdpService.getUiModels();
+            expect(models).toEqual([]);
+        });
+
+        it('includes span-based selectors for Antigravity v1.107+ DOM', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockResolvedValue({
+                result: { value: ['gemini-2.5-pro'] }
+            });
+
+            await cdpService.getUiModels();
+
+            const callArgs = callSpy.mock.calls[0][1];
+            expect(callArgs.expression).toContain('span[class*="select-none"]');
+            expect(callArgs.expression).toContain('span[class*="text-xs"]');
+        });
+
+        it('returns empty array on CDP error', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockRejectedValue(new Error('CDP timeout'));
+
+            const models = await cdpService.getUiModels();
+            expect(models).toEqual([]);
+        });
+    });
+
+    // ========== getCurrentModel tests ==========
+
+    describe('getCurrentModel - selected model detection', () => {
+
+        it('returns null when not connected', async () => {
+            const model = await cdpService.getCurrentModel();
+            expect(model).toBeNull();
+        });
+
+        it('returns model name when found', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockResolvedValue({
+                result: { value: 'claude-3-opus' }
+            });
+
+            const model = await cdpService.getCurrentModel();
+            expect(model).toBe('claude-3-opus');
+        });
+
+        it('returns null when no model is selected', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockResolvedValue({
+                result: { value: null }
+            });
+
+            const model = await cdpService.getCurrentModel();
+            expect(model).toBeNull();
+        });
+
+        it('includes span-based selectors for Antigravity v1.107+ DOM', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockResolvedValue({
+                result: { value: 'gemini-2.5-pro' }
+            });
+
+            await cdpService.getCurrentModel();
+
+            const callArgs = callSpy.mock.calls[0][1];
+            expect(callArgs.expression).toContain('span[class*="select-none"]');
+            expect(callArgs.expression).toContain('span[class*="text-xs"]');
+        });
+
+        it('returns null on CDP error', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockRejectedValue(new Error('CDP error'));
+
+            const model = await cdpService.getCurrentModel();
+            expect(model).toBeNull();
+        });
     });
 });


### PR DESCRIPTION
## Summary

- Add `span[class*="select-none"]`, `span[class*="text-xs"]`, and `span[class*="overflow-hidden"]` to item/trigger selector arrays in `getUiModels()`, `getCurrentModel()`, and `setUiModel()`
- Keep existing `div.cursor-pointer` selectors as legacy fallback for pre-v1.107 Antigravity
- Document model picker selectors in `docs/ANTIGRAVITY_DOM_SELECTORS.md` (Section 13)
- Add tests covering new selector inclusion and all three model methods

## Context

Antigravity v1.107.0 changed the model picker DOM from `div.cursor-pointer` elements to `span` elements with classes like `select-none`, `text-xs`, and `overflow-hidden`. The `looksLikeModel()` regex filter (`/gemini|gpt|claude/i`) prevents false positives from the broader span selectors.

## Test plan

- [x] All 1394 existing tests pass
- [x] TypeScript build succeeds with no errors
- [x] New tests verify span-based selectors exist in CDP expressions for all three methods
- [ ] Manual verification with Antigravity v1.107.0 (requires reporter confirmation)

closes #120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated model picker reference documentation with comprehensive version-specific information on DOM structures, selector patterns, and implementation guidance to improve clarity for developers.

* **Tests**
  * Added extensive test coverage for model picker functionality, thoroughly validating model list retrieval, current model detection, model switching operations, and comprehensive error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->