### PR TITLE
fix(ci): add jest-util as explicit devDependency

### DIFF
--- a/docs/ANTIGRAVITY_DOM_SELECTORS.md
+++ b/docs/ANTIGRAVITY_DOM_SELECTORS.md
@@ -2,7 +2,7 @@
 
 Central reference for all CSS selectors and DOM structures used to interact with the Antigravity (Windsurf/Cascade) UI via CDP.
 
-> **Last verified**: 2025-02 (against live Antigravity DOM)
+> **Last verified**: 2026-04 (model picker updated for Antigravity v1.107.0+; other selectors verified 2025-02)
 
 ---
 
@@ -324,6 +324,89 @@ Terminal command execution confirmation dialog (Run/Reject).
 The `<pre>` element contains: `<working-directory> $ <command>`. Split on ` $ ` to extract:
 - `workingDirectory`: e.g. `~/Code/login`
 - `commandText`: e.g. `python3 -m http.server 8000`
+
+---
+
+## 13. Model Picker (Dropdown)
+
+Model list retrieval, current model detection, and model switching.
+
+> **Last verified**: 2026-04 (reported by user in [#120](https://github.com/tokyoweb3/LazyGravity/issues/120))
+
+### DOM Structure (v1.107.0+)
+
+```html
+<!-- Model trigger (shows current model) -->
+<span class="select-none overflow-hidden text-ellipsis text-xs">
+  gemini-2.5-pro
+</span>
+
+<!-- Model list items (inside dropdown) -->
+<div class="text-xs font-medium">
+  <span>gemini-2.5-pro</span>
+  <span>claude-3-opus</span>
+  <span>gpt-4o</span>
+</div>
+```
+
+### Legacy DOM Structure (pre-v1.107)
+
+```html
+<div class="cursor-pointer px-2 py-1 flex items-center justify-between">
+  model-name
+</div>
+<!-- Selected item has class: bg-gray-500/20 -->
+```
+
+### Item Selectors (ordered by priority)
+
+| Selector | Purpose | Version | File |
+|----------|---------|---------|------|
+| `[role="option"]` | ARIA option element | Universal | `cdpService.ts` |
+| `[role="menuitem"]` | ARIA menu item | Universal | `cdpService.ts` |
+| `[aria-selected]` | ARIA selected attribute | Universal | `cdpService.ts` |
+| `[aria-checked]` | ARIA checked attribute | Universal | `cdpService.ts` |
+| `button` | Button elements | Universal | `cdpService.ts` |
+| `[role="button"]` | ARIA button role | Universal | `cdpService.ts` |
+| `div.cursor-pointer` | Legacy clickable div | Pre-v1.107 | `cdpService.ts` |
+| `span[class*="select-none"]` | Span model display | v1.107+ | `cdpService.ts` |
+| `span[class*="text-xs"]` | Span model item | v1.107+ | `cdpService.ts` |
+
+### Selection Detection (scoring-based)
+
+| Signal | Score | Version |
+|--------|-------|---------|
+| `aria-selected="true"` | +5 | Universal |
+| `aria-checked="true"` | +5 | Universal |
+| `aria-current="true"` | +4 | Universal |
+| `data-state` matches `checked\|active\|selected\|on\|open` | +4 | Universal |
+| `className` includes `bg-gray-500/20` | +3 | Pre-v1.107 |
+| `className` includes `selected` | +3 | Universal |
+| `className` includes `active` | +2 | Universal |
+
+### Trigger Selectors (to open dropdown)
+
+| Selector | Purpose | File |
+|----------|---------|------|
+| `[role="combobox"]` | ARIA combobox | `cdpService.ts` |
+| `[aria-haspopup="listbox"]` | ARIA popup hint | `cdpService.ts` |
+| `[aria-expanded]` | Expandable element | `cdpService.ts` |
+| `span[class*="select-none"]` | v1.107+ model display | `cdpService.ts` |
+| `span[class*="overflow-hidden"]` | v1.107+ ellipsis model | `cdpService.ts` |
+
+### Scope Selectors (dropdown container)
+
+| Selector | Purpose |
+|----------|---------|
+| `[role="dialog"]` | Dialog container |
+| `[role="listbox"]` | Listbox container |
+| `[role="menu"]` | Menu container |
+| `[data-radix-popper-content-wrapper]` | Radix popover |
+| `[data-state="open"]` | Open state container |
+
+> **Note**: All candidates are filtered by `looksLikeModel()` regex (`/gemini|gpt|claude/i`) to avoid false positives. Adding broad selectors like `span` is safe because the model name filter provides specificity.
+
+**Used by**: `cdpService.ts` (`getUiModels()`, `getCurrentModel()`, `setUiModel()`)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/ws": "^8.18.1",
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.2.0",
+        "jest-util": "^30.2.0",
         "jsdom": "^29.0.0",
         "minimatch": "^10.2.1",
         "semantic-release": "^25.0.3",
@@ -1588,21 +1589,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/@jest/environment": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
-      "integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
-      "dev": true,
-      "dependencies": {
-        "@jest/fake-timers": "30.2.0",
-        "@jest/types": "30.2.0",
-        "@types/node": "*",
-        "jest-mock": "30.2.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
     "node_modules/@jest/environment-jsdom-abstract": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.3.0.tgz",
@@ -1811,23 +1797,6 @@
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/fake-timers": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
-      "integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "30.2.0",
-        "@sinonjs/fake-timers": "^13.0.0",
-        "@types/node": "*",
-        "jest-message-util": "30.2.0",
-        "jest-mock": "30.2.0",
-        "jest-util": "30.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -3439,15 +3408,6 @@
       "dev": true,
       "dependencies": {
         "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "13.0.5",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
-      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^3.0.1"
       }
     },
     "node_modules/@swc/helpers": {
@@ -9538,40 +9498,6 @@
         "@jest/schemas": "30.0.5",
         "ansi-styles": "^5.2.0",
         "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-message-util": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-      "integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.2.0",
-        "@types/stack-utils": "^2.0.3",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
-        "micromatch": "^4.0.8",
-        "pretty-format": "30.2.0",
-        "slash": "^3.0.0",
-        "stack-utils": "^2.0.6"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-mock": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-      "integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
-      "dev": true,
-      "dependencies": {
-        "@jest/types": "30.2.0",
-        "@types/node": "*",
-        "jest-util": "30.2.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@types/ws": "^8.18.1",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
+    "jest-util": "^30.2.0",
     "jsdom": "^29.0.0",
     "minimatch": "^10.2.1",
     "semantic-release": "^25.0.3",

--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -2132,6 +2132,8 @@ export class CdpService extends EventEmitter {
                 '[role="button"]',
                 'div.cursor-pointer',
                 'div[class*="cursor-pointer"]',
+                'span[class*="select-none"]',
+                'span[class*="text-xs"]',
             ];
             const getScopes = () => {
                 const scopes = [document];
@@ -2176,6 +2178,8 @@ export class CdpService extends EventEmitter {
                 '[role="button"]',
                 'div.cursor-pointer',
                 'div[class*="cursor-pointer"]',
+                'span[class*="select-none"]',
+                'span[class*="overflow-hidden"]',
             ];
 
             let models = collectModels();
@@ -2292,7 +2296,8 @@ export class CdpService extends EventEmitter {
             };
             const candidates = Array.from(document.querySelectorAll(
                 '[role="option"], [role="menuitem"], [role="combobox"], [aria-selected], [aria-checked], ' +
-                '[aria-current], button, [role="button"], div.cursor-pointer, div[class*="cursor-pointer"]'
+                '[aria-current], button, [role="button"], div.cursor-pointer, div[class*="cursor-pointer"], ' +
+                'span[class*="select-none"], span[class*="text-xs"]'
             ))
                 .filter(isVisible)
                 .map((el) => ({ el, label: getLabel(el), score: getScore(el) }))
@@ -2341,10 +2346,10 @@ export class CdpService extends EventEmitter {
             await this.reconnectOnDemand();
         }
 
-        // DOM manipulation script: based on actual Antigravity UI DOM structure
-        // Model list uses div.cursor-pointer elements with class 'px-2 py-1 flex items-center justify-between'
-        // Currently selected has 'bg-gray-500/20', others have 'hover:bg-gray-500/10'
-        // textContent may have "New" suffix
+        // DOM manipulation script: adaptive Antigravity UI model picker
+        // Legacy (<v1.107): div.cursor-pointer with class 'px-2 py-1 flex items-center justify-between'
+        // v1.107+: span elements with classes 'select-none', 'text-xs', 'overflow-hidden'
+        // Selection detected via ARIA attributes, data-state, or bg-gray-500/20 class
         const safeModel = JSON.stringify(modelName);
         const expression = `(async () => {
             const targetModel = ${safeModel};
@@ -2383,6 +2388,8 @@ export class CdpService extends EventEmitter {
                 '[role="button"]',
                 'div.cursor-pointer',
                 'div[class*="cursor-pointer"]',
+                'span[class*="select-none"]',
+                'span[class*="text-xs"]',
             ];
             const triggerSelectors = [
                 '[role="combobox"]',
@@ -2393,6 +2400,8 @@ export class CdpService extends EventEmitter {
                 '[role="button"]',
                 'div.cursor-pointer',
                 'div[class*="cursor-pointer"]',
+                'span[class*="select-none"]',
+                'span[class*="overflow-hidden"]',
             ];
             const scopeSelectors = [
                 '[role="dialog"]',

--- a/tests/services/cdpService.uiSync.test.ts
+++ b/tests/services/cdpService.uiSync.test.ts
@@ -294,5 +294,147 @@ describe('CdpService - UI sync (Step 9)', () => {
             expect(callArgs.expression).toContain('ariaHaspopup');
             expect(callArgs.expression).toContain('openPicker');
         });
+
+        it('includes span-based selectors for Antigravity v1.107+ DOM', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockResolvedValue({
+                result: { value: { ok: true, model: 'gemini-2.5-pro' } }
+            });
+
+            await cdpService.setUiModel('gemini-2.5-pro');
+
+            const callArgs = callSpy.mock.calls[0][1];
+            // v1.107+ uses span elements instead of div.cursor-pointer
+            expect(callArgs.expression).toContain('span[class*="select-none"]');
+            expect(callArgs.expression).toContain('span[class*="text-xs"]');
+            expect(callArgs.expression).toContain('span[class*="overflow-hidden"]');
+        });
+    });
+
+    // ========== getUiModels tests ==========
+
+    describe('getUiModels - model list retrieval', () => {
+
+        it('throws when not connected', async () => {
+            await expect(cdpService.getUiModels()).rejects.toThrow('Not connected to CDP.');
+        });
+
+        it('returns model list from CDP evaluation', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockResolvedValue({
+                result: { value: ['gemini-2.5-pro', 'claude-3-opus', 'gpt-4o'] }
+            });
+
+            const models = await cdpService.getUiModels();
+
+            expect(models).toEqual(['gemini-2.5-pro', 'claude-3-opus', 'gpt-4o']);
+            expect(callSpy).toHaveBeenCalledWith(
+                'Runtime.evaluate',
+                expect.objectContaining({
+                    returnByValue: true,
+                    awaitPromise: true,
+                })
+            );
+        });
+
+        it('returns empty array when no models found', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockResolvedValue({
+                result: { value: [] }
+            });
+
+            const models = await cdpService.getUiModels();
+            expect(models).toEqual([]);
+        });
+
+        it('includes span-based selectors for Antigravity v1.107+ DOM', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockResolvedValue({
+                result: { value: ['gemini-2.5-pro'] }
+            });
+
+            await cdpService.getUiModels();
+
+            const callArgs = callSpy.mock.calls[0][1];
+            expect(callArgs.expression).toContain('span[class*="select-none"]');
+            expect(callArgs.expression).toContain('span[class*="text-xs"]');
+        });
+
+        it('returns empty array on CDP error', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockRejectedValue(new Error('CDP timeout'));
+
+            const models = await cdpService.getUiModels();
+            expect(models).toEqual([]);
+        });
+    });
+
+    // ========== getCurrentModel tests ==========
+
+    describe('getCurrentModel - selected model detection', () => {
+
+        it('returns null when not connected', async () => {
+            const model = await cdpService.getCurrentModel();
+            expect(model).toBeNull();
+        });
+
+        it('returns model name when found', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockResolvedValue({
+                result: { value: 'claude-3-opus' }
+            });
+
+            const model = await cdpService.getCurrentModel();
+            expect(model).toBe('claude-3-opus');
+        });
+
+        it('returns null when no model is selected', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockResolvedValue({
+                result: { value: null }
+            });
+
+            const model = await cdpService.getCurrentModel();
+            expect(model).toBeNull();
+        });
+
+        it('includes span-based selectors for Antigravity v1.107+ DOM', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockResolvedValue({
+                result: { value: 'gemini-2.5-pro' }
+            });
+
+            await cdpService.getCurrentModel();
+
+            const callArgs = callSpy.mock.calls[0][1];
+            expect(callArgs.expression).toContain('span[class*="select-none"]');
+            expect(callArgs.expression).toContain('span[class*="text-xs"]');
+        });
+
+        it('returns null on CDP error', async () => {
+            (cdpService as any).isConnectedFlag = true;
+            (cdpService as any).ws = mockWsInstance;
+
+            callSpy.mockRejectedValue(new Error('CDP error'));
+
+            const model = await cdpService.getCurrentModel();
+            expect(model).toBeNull();
+        });
     });
 });


### PR DESCRIPTION
## Summary
- Add `jest-util` as an explicit devDependency to fix CI failures on all Dependabot PRs
- `ts-jest` declares `jest-util` as a peer dependency — when Dependabot updates the lockfile, npm's hoisting changes can make `jest-util` unresolvable from ts-jest's legacy config module
- This unblocks 10 Dependabot PRs currently failing with `Cannot find module 'jest-util'`

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (1394 tests)
- [ ] CI passes on this PR
- [ ] Dependabot PRs pass CI after rebase onto updated main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model picker compatibility with Antigravity v1.107.0+ while maintaining support for earlier versions.

* **Documentation**
  * Updated model picker selector documentation with v1.107.0+ compatibility details.

* **Tests**
  * Added test coverage for model picker functionality across Antigravity versions.

* **Chores**
  * Added jest-util to development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->