### PR TITLE
fix(lockfile): skip POSIX permission check on Windows

### DIFF
--- a/src/utils/lockfile.ts
+++ b/src/utils/lockfile.ts
@@ -33,7 +33,7 @@ export function acquireLock(): () => void {
     if (typeof process.getuid === 'function' && dirStat.uid !== process.getuid()) {
         throw new Error(`Lock directory is not owned by current user: ${LOCK_DIR}`);
     }
-    if ((dirStat.mode & 0o077) !== 0) {
+    if (process.platform !== 'win32' && (dirStat.mode & 0o077) !== 0) {
         throw new Error(`Lock directory has overly permissive permissions: ${LOCK_DIR}`);
     }
 

--- a/tests/utils/lockfile.test.ts
+++ b/tests/utils/lockfile.test.ts
@@ -1,0 +1,63 @@
+import fs from 'fs';
+import { acquireLock } from '../../src/utils/lockfile';
+
+jest.mock('fs');
+jest.mock('../../src/utils/logger', () => ({
+    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockedFs = fs as jest.Mocked<typeof fs>;
+
+function withPlatform(platform: NodeJS.Platform, fn: () => void): void {
+    const original = Object.getOwnPropertyDescriptor(process, 'platform')!;
+    Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+    try {
+        fn();
+    } finally {
+        Object.defineProperty(process, 'platform', original);
+    }
+}
+
+function stubStat(overrides: Partial<fs.Stats>): fs.Stats {
+    return {
+        isDirectory: () => true,
+        mode: 0o40700,
+        uid: process.getuid ? process.getuid() : 0,
+        ...overrides,
+    } as fs.Stats;
+}
+
+describe('acquireLock()', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockedFs.mkdirSync.mockReturnValue(undefined);
+        mockedFs.existsSync.mockReturnValue(false);
+        mockedFs.openSync.mockReturnValue(3 as unknown as number);
+        mockedFs.writeFileSync.mockReturnValue(undefined);
+        mockedFs.closeSync.mockReturnValue(undefined);
+    });
+
+    it('skips POSIX permission-bit check on Windows (issue #137)', () => {
+        mockedFs.lstatSync.mockReturnValue(stubStat({ mode: 0o40777 }));
+
+        withPlatform('win32', () => {
+            expect(() => acquireLock()).not.toThrow();
+        });
+    });
+
+    it('enforces POSIX permission-bit check on Linux', () => {
+        mockedFs.lstatSync.mockReturnValue(stubStat({ mode: 0o40777 }));
+
+        withPlatform('linux', () => {
+            expect(() => acquireLock()).toThrow(/overly permissive permissions/);
+        });
+    });
+
+    it('accepts correctly-permissioned directory on Linux', () => {
+        mockedFs.lstatSync.mockReturnValue(stubStat({ mode: 0o40700 }));
+
+        withPlatform('linux', () => {
+            expect(() => acquireLock()).not.toThrow();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Fixes startup crash on Windows where `lazy-gravity start` fails with a false `Lock directory has overly permissive permissions` error
- On Windows, `fs.lstatSync()` returns synthesized mode bits that don't map to NTFS ACLs, making the POSIX permission-bit check unreliable
- Adds a `process.platform !== 'win32'` guard, matching the pattern already used for the ownership check

## Root Cause
`src/utils/lockfile.ts:36` ran `(dirStat.mode & 0o077) !== 0` unconditionally. On Windows, any normal per-user temp dir reports mode bits that trigger this check, so 100% of Windows users crashed on startup.

## Test plan
- [x] New unit tests cover the Windows/Linux platform branches
- [x] `npm test` — 1397 tests pass (3 new)
- [x] `npm run build` passes

closes #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted lock directory permission validation to properly handle Windows systems

* **Tests**
  * Added comprehensive test coverage for lock behavior across different platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->