### PR TITLE
feat(discord): Add /artifacts command with persistent thread rendering and user preferences

### DIFF
--- a/launch_dev.bat
+++ b/launch_dev.bat
@@ -1,0 +1,36 @@
+@echo off
+setlocal
+
+:: Find an available port for CDP starting from 9222
+set "AG_PORT=9222"
+
+:find_port
+netstat -ano | findstr ":%AG_PORT% " >nul
+if %errorlevel% equ 0 (
+    set /a AG_PORT=%AG_PORT%+1
+    goto find_port
+)
+
+echo [LazyLaunch] Found available CDP port: %AG_PORT%
+
+:: Path to Antigravity executable
+set "AG_PATH=%LOCALAPPDATA%\Programs\Antigravity\Antigravity.exe"
+
+if not exist "%AG_PATH%" (
+    echo [ERROR] Antigravity executable not found at: %AG_PATH%
+    pause
+    exit /b 1
+)
+
+echo [LazyLaunch] Starting Antigravity with --remote-debugging-port=%AG_PORT%...
+start "" "%AG_PATH%" --remote-debugging-port=%AG_PORT%
+
+:: Wait a moment for Antigravity to initialize the port
+timeout /t 3 /nobreak >nul
+
+:: Set environment variable to tell LazyGravity which account/port to use
+:: Format: "name:port,name:port" or just "name:port"
+set "ANTIGRAVITY_ACCOUNTS=local:%AG_PORT%"
+
+echo [LazyLaunch] Starting LazyGravity (Dev Mode)...
+npm run dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "ts-jest": "^29.4.6",
         "ts-morph": "^28.0.0",
         "ts-node": "^10.9.2",
+        "ts-node-dev": "^2.0.0",
         "typescript": "^5.9.3",
         "undici": "^8.0.3"
       },
@@ -3618,6 +3619,20 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
     },
+    "node_modules/@types/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-xevGOReSYGM7g/kUBZzPqCrR/KYAo+F0yiPc85WFTJa0MSLtyFTVTU6cJu/aV4mid7IffDIWqo69THF2o4JiEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/strip-json-comments": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
+      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
@@ -6160,6 +6175,16 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/dynamic-dedupe": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz",
+      "integrity": "sha512-ssuANeD+z97meYOqd50e04Ze5qp4bPqo8cCkI4TRjZkzAUgIDTrXV1R8QCdINpiI+hw14+rYazvTRdQrz0/rFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
       }
     },
     "node_modules/eastasianwidth": {
@@ -10141,6 +10166,19 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -13677,6 +13715,66 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/robust-predicates": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
@@ -15270,6 +15368,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
@@ -15408,6 +15516,64 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-node-dev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
+      "integrity": "sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.1",
+        "dynamic-dedupe": "^0.3.0",
+        "minimist": "^1.2.6",
+        "mkdirp": "^1.0.4",
+        "resolve": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "source-map-support": "^0.5.12",
+        "tree-kill": "^1.2.2",
+        "ts-node": "^10.4.0",
+        "tsconfig": "^7.0.0"
+      },
+      "bin": {
+        "ts-node-dev": "lib/bin.js",
+        "tsnd": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "*",
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsconfig": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
+      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/strip-bom": "^3.0.0",
+        "@types/strip-json-comments": "0.0.30",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "^2.0.0"
+      }
+    },
+    "node_modules/tsconfig/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "ts-jest": "^29.4.6",
     "ts-morph": "^28.0.0",
     "ts-node": "^10.9.2",
+    "ts-node-dev": "^2.0.0",
     "typescript": "^5.9.3",
     "undici": "^8.0.3"
   }

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -91,6 +91,8 @@ import { sendAutoAcceptUI } from '../ui/autoAcceptUi';
 import { sendAccountUI } from '../ui/accountUi';
 import { sendOutputUI, OUTPUT_BTN_EMBED, OUTPUT_BTN_PLAIN } from '../ui/outputUi';
 import { handleScreenshot } from '../ui/screenshotUi';
+import { sendArtifactsUI, ARTIFACT_SELECT_ID } from '../ui/artifactsUi';
+import { ArtifactService } from '../services/artifactService';
 import { UserPreferenceRepository, OutputFormat } from '../database/userPreferenceRepository';
 import { inferParentScopeChannelId, listAccountNames, resolveScopedAccountName } from '../utils/accountUtils';
 import { formatAsPlainText, splitPlainText } from '../utils/plainTextFormatter';
@@ -1572,6 +1574,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                 { command: 'stop', description: 'Interrupt active LLM generation' },
                 { command: 'help', description: 'Show available commands' },
                 { command: 'ping', description: 'Check bot latency' },
+                { command: 'artifacts', description: 'Browse session artifacts' },
             ]).catch((e: unknown) => {
                 logger.warn('Failed to register Telegram commands:', e instanceof Error ? e.message : e);
             });
@@ -1830,6 +1833,11 @@ export async function handleSlashInteraction(
                         '`/logs [lines] [level]` — View recent bot logs',
                         '`/cleanup [days]` — Clean up unused channels/categories',
                         '`/help` — Show this help',
+                    ].join('\n')
+                },
+                {
+                    name: '📂 Artifacts', value: [
+                        '`/artifacts` — Browse and render generated artifacts from the active session',
                     ].join('\n')
                 },
             ];
@@ -2231,6 +2239,40 @@ export async function handleSlashInteraction(
                 : `\`\`\`\n${formatted.slice(0, MAX_CONTENT)}\n\`\`\`\n(truncated — showing ${MAX_CONTENT} chars of ${formatted.length})`;
 
             await interaction.editReply({ content: codeBlock });
+            break;
+        }
+
+        case 'artifacts': {
+            const artifactService = new ArtifactService();
+            const sessionTitle = chatSessionRepo?.findByChannelId(interaction.channelId)?.displayName?.trim() ?? '';
+
+            let conversationId: string | null = null;
+            if (sessionTitle) {
+                conversationId = artifactService.findConversationByTitle(sessionTitle);
+                if (conversationId) {
+                    logger.info(
+                        `[ArtifactsCommand] channel=${interaction.channelId} matched conversationId=${conversationId} title="${sessionTitle}"`,
+                    );
+                } else {
+                    logger.info(
+                        `[ArtifactsCommand] channel=${interaction.channelId} no conversation matched title="${sessionTitle}", falling back to latest`,
+                    );
+                }
+            }
+
+            if (!conversationId) {
+                conversationId = artifactService.getLatestConversationWithArtifacts();
+            }
+
+            if (!conversationId) {
+                await interaction.editReply({
+                    content: '📂 No artifacts found. Artifacts are created during Antigravity sessions.',
+                });
+                break;
+            }
+
+            const artifacts = artifactService.listArtifacts(conversationId);
+            await sendArtifactsUI(interaction, artifacts, conversationId);
             break;
         }
 

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -92,7 +92,7 @@ import { sendAutoAcceptUI } from '../ui/autoAcceptUi';
 import { sendAccountUI } from '../ui/accountUi';
 import { sendOutputUI, OUTPUT_BTN_EMBED, OUTPUT_BTN_PLAIN } from '../ui/outputUi';
 import { handleScreenshot } from '../ui/screenshotUi';
-import { sendArtifactsUI, ARTIFACT_SELECT_ID } from '../ui/artifactsUi';
+import { sendArtifactsUI, sendArtifactPickerUI, ARTIFACT_SELECT_ID } from '../ui/artifactsUi';
 import { ArtifactService } from '../services/artifactService';
 import { UserPreferenceRepository, OutputFormat } from '../database/userPreferenceRepository';
 import { inferParentScopeChannelId, listAccountNames, resolveScopedAccountName } from '../utils/accountUtils';
@@ -208,10 +208,12 @@ async function sendPromptToAntigravity(
         channelManager: ChannelManager;
         titleGenerator: TitleGeneratorService;
         userPrefRepo?: UserPreferenceRepository;
+        artifactService?: ArtifactService;
         onFullCompletion?: () => void;
         extractionMode?: ExtractionMode;
         responseTimeoutMs?: number;
     }
+
 ): Promise<void> {
     // Completion signal — called exactly once when the entire prompt lifecycle ends
     let completionSignaled = false;
@@ -866,6 +868,14 @@ async function sendPromptToAntigravity(
                                     await options.channelManager.renameChannel(message.guild, message.channelId, formattedName);
                                     options.chatSessionRepo.updateDisplayName(message.channelId, sessionInfo.title);
                                 }
+
+                                // Persist conversation_id for artifact picker resolution
+                                if (options.artifactService) {
+                                    const convId = options.artifactService.findConversationByTitle(sessionInfo.title);
+                                    if (convId) {
+                                        options.chatSessionRepo.setConversationId(message.channelId, convId);
+                                    }
+                                }
                             }
                         } catch (e) {
                             logger.error('[Rename] Failed to get title from Antigravity and rename:', e);
@@ -1000,6 +1010,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
     const workspaceBindingRepo = new WorkspaceBindingRepository(db);
     const chatSessionRepo = new ChatSessionRepository(db);
     const artifactThreadRepo = new ArtifactThreadRepository(db);
+    const artifactService = new ArtifactService();
     const workspaceService = new WorkspaceService(config.workspaceBaseDir);
     const channelManager = new ChannelManager();
 
@@ -1214,6 +1225,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         chatSessionRepo,
         chatSessionService,
         artifactThreadRepo,
+        artifactService,
         antigravityAccounts: config.antigravityAccounts,
         handleSlashInteraction: async (
             interaction,
@@ -1249,6 +1261,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             channelPrefRepoArg,
             antigravityAccountsArg,
             chatSessionRepo,
+            artifactService,
         ),
         handleTemplateUse: async (interaction, templateId) => {
             const template = templateRepo.findById(templateId);
@@ -1346,6 +1359,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                         channelManager,
                         titleGenerator,
                         userPrefRepo,
+                        artifactService,
                         extractionMode: config.extractionMode,
                     },
                 });
@@ -1365,6 +1379,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         chatSessionRepo,
         channelManager,
         titleGenerator,
+        artifactService,
         client,
         sendPromptToAntigravity: async (
             _bridge,
@@ -1697,6 +1712,7 @@ export async function handleSlashInteraction(
     channelPrefRepo?: ChannelPreferenceRepository,
     antigravityAccounts: AntigravityAccountConfig[] = [{ name: 'default', cdpPort: 9222 }],
     chatSessionRepo?: ChatSessionRepository,
+    artifactService?: ArtifactService,
 ): Promise<void> {
     const commandName = interaction.commandName;
     const getAccountPort = (accountName: string): number | null => {
@@ -2246,36 +2262,11 @@ export async function handleSlashInteraction(
         }
 
         case 'artifacts': {
-            const artifactService = new ArtifactService();
-            const sessionTitle = chatSessionRepo?.findByChannelId(interaction.channelId)?.displayName?.trim() ?? '';
-
-            let conversationId: string | null = null;
-            if (sessionTitle) {
-                conversationId = artifactService.findConversationByTitle(sessionTitle);
-                if (conversationId) {
-                    logger.info(
-                        `[ArtifactsCommand] channel=${interaction.channelId} matched conversationId=${conversationId} title="${sessionTitle}"`,
-                    );
-                } else {
-                    logger.info(
-                        `[ArtifactsCommand] channel=${interaction.channelId} no conversation matched title="${sessionTitle}", falling back to latest`,
-                    );
-                }
-            }
-
-            if (!conversationId) {
-                conversationId = artifactService.getLatestConversationWithArtifacts();
-            }
-
-            if (!conversationId) {
-                await interaction.editReply({
-                    content: '📂 No artifacts found. Artifacts are created during Antigravity sessions.',
-                });
-                break;
-            }
-
-            const artifacts = artifactService.listArtifacts(conversationId);
-            await sendArtifactsUI(interaction, artifacts, conversationId);
+            await sendArtifactPickerUI(interaction, { 
+                userPrefRepo, 
+                chatSessionRepo, 
+                artifactService 
+            });
             break;
         }
 

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -31,6 +31,7 @@ import { AccountPreferenceRepository } from '../database/accountPreferenceReposi
 import { WorkspaceBindingRepository } from '../database/workspaceBindingRepository';
 import { ChannelPreferenceRepository } from '../database/channelPreferenceRepository';
 import { ChatSessionRepository } from '../database/chatSessionRepository';
+import { ArtifactThreadRepository } from '../database/artifactThreadRepository';
 import { WorkspaceService } from '../services/workspaceService';
 import {
     WorkspaceCommandHandler,
@@ -998,6 +999,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
     }
     const workspaceBindingRepo = new WorkspaceBindingRepository(db);
     const chatSessionRepo = new ChatSessionRepository(db);
+    const artifactThreadRepo = new ArtifactThreadRepository(db);
     const workspaceService = new WorkspaceService(config.workspaceBaseDir);
     const channelManager = new ChannelManager();
 
@@ -1211,6 +1213,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         channelPrefRepo,
         chatSessionRepo,
         chatSessionService,
+        artifactThreadRepo,
         antigravityAccounts: config.antigravityAccounts,
         handleSlashInteraction: async (
             interaction,

--- a/src/commands/registerSlashCommands.ts
+++ b/src/commands/registerSlashCommands.ts
@@ -207,6 +207,11 @@ const pingCommand = new SlashCommandBuilder()
     .setName('ping')
     .setDescription(t('Check bot latency'));
 
+/** /artifacts command definition */
+const artifactsCommand = new SlashCommandBuilder()
+    .setName('artifacts')
+    .setDescription(t('Browse and view generated artifacts from the active session'));
+
 /** Array of commands to register */
 export const slashCommands = [
     helpCommand,
@@ -227,6 +232,7 @@ export const slashCommands = [
     outputCommand,
     pingCommand,
     logsCommand,
+    artifactsCommand,
 ];
 
 /**

--- a/src/database/artifactThreadRepository.ts
+++ b/src/database/artifactThreadRepository.ts
@@ -1,0 +1,55 @@
+import Database from 'better-sqlite3';
+
+/**
+ * Repository for mapping (channel_id, filename) to Discord thread ID.
+ * This allows reusing the same thread for multiple renders of the same file.
+ */
+export class ArtifactThreadRepository {
+    private readonly db: Database.Database;
+
+    constructor(db: Database.Database) {
+        this.db = db;
+        this.initialize();
+    }
+
+    private initialize(): void {
+        this.db.exec(`
+            CREATE TABLE IF NOT EXISTS artifact_threads (
+                channel_id TEXT NOT NULL,
+                filename TEXT NOT NULL,
+                thread_id TEXT NOT NULL,
+                PRIMARY KEY (channel_id, filename)
+            )
+        `);
+    }
+
+    /**
+     * Get the stored thread ID for a specific file in a channel.
+     */
+    public getThreadId(channelId: string, filename: string): string | null {
+        const row = this.db.prepare(
+            'SELECT thread_id FROM artifact_threads WHERE channel_id = ? AND filename = ?'
+        ).get(channelId, filename) as { thread_id: string } | undefined;
+        
+        return row?.thread_id ?? null;
+    }
+
+    /**
+     * Set the thread ID for a specific file in a channel.
+     */
+    public setThreadId(channelId: string, filename: string, threadId: string): void {
+        this.db.prepare(`
+            INSERT OR REPLACE INTO artifact_threads (channel_id, filename, thread_id)
+            VALUES (?, ?, ?)
+        `).run(channelId, filename, threadId);
+    }
+
+    /**
+     * Remove a stored thread ID.
+     */
+    public deleteThreadId(channelId: string, filename: string): void {
+        this.db.prepare(
+            'DELETE FROM artifact_threads WHERE channel_id = ? AND filename = ?'
+        ).run(channelId, filename);
+    }
+}

--- a/src/database/artifactThreadRepository.ts
+++ b/src/database/artifactThreadRepository.ts
@@ -1,7 +1,7 @@
 import Database from 'better-sqlite3';
 
 /**
- * Repository for mapping (channel_id, filename) to Discord thread ID.
+ * Repository for mapping (channel_id, conversation_id, filename) to Discord thread ID.
  * This allows reusing the same thread for multiple renders of the same file.
  */
 export class ArtifactThreadRepository {
@@ -13,43 +13,66 @@ export class ArtifactThreadRepository {
     }
 
     private initialize(): void {
-        this.db.exec(`
-            CREATE TABLE IF NOT EXISTS artifact_threads (
-                channel_id TEXT NOT NULL,
-                filename TEXT NOT NULL,
-                thread_id TEXT NOT NULL,
-                PRIMARY KEY (channel_id, filename)
-            )
-        `);
+        const tableInfo = this.db.prepare("PRAGMA table_info('artifact_threads')").all() as any[];
+        
+        if (tableInfo.length === 0) {
+            this.db.exec(`
+                CREATE TABLE artifact_threads (
+                    channel_id TEXT NOT NULL,
+                    conversation_id TEXT NOT NULL,
+                    filename TEXT NOT NULL,
+                    thread_id TEXT NOT NULL,
+                    PRIMARY KEY (channel_id, conversation_id, filename)
+                )
+            `);
+        } else {
+            const hasConvId = tableInfo.some(col => col.name === 'conversation_id');
+            if (!hasConvId) {
+                // To safely migrate in sqlite, we recreate the table, since we need to change the primary key
+                this.db.exec(`
+                    CREATE TABLE artifact_threads_new (
+                        channel_id TEXT NOT NULL,
+                        conversation_id TEXT NOT NULL DEFAULT '',
+                        filename TEXT NOT NULL,
+                        thread_id TEXT NOT NULL,
+                        PRIMARY KEY (channel_id, conversation_id, filename)
+                    );
+                    INSERT INTO artifact_threads_new (channel_id, conversation_id, filename, thread_id)
+                    SELECT channel_id, '', filename, thread_id FROM artifact_threads;
+                    DROP TABLE artifact_threads;
+                    ALTER TABLE artifact_threads_new RENAME TO artifact_threads;
+                `);
+            }
+        }
     }
 
     /**
-     * Get the stored thread ID for a specific file in a channel.
+     * Get the stored thread ID for a specific file in a channel and conversation.
      */
-    public getThreadId(channelId: string, filename: string): string | null {
+    public getThreadId(channelId: string, conversationId: string, filename: string): string | null {
         const row = this.db.prepare(
-            'SELECT thread_id FROM artifact_threads WHERE channel_id = ? AND filename = ?'
-        ).get(channelId, filename) as { thread_id: string } | undefined;
+            'SELECT thread_id FROM artifact_threads WHERE channel_id = ? AND conversation_id = ? AND filename = ?'
+        ).get(channelId, conversationId, filename) as { thread_id: string } | undefined;
         
         return row?.thread_id ?? null;
     }
 
     /**
-     * Set the thread ID for a specific file in a channel.
+     * Set the thread ID for a specific file in a channel and conversation.
      */
-    public setThreadId(channelId: string, filename: string, threadId: string): void {
+    public setThreadId(channelId: string, conversationId: string, filename: string, threadId: string): void {
         this.db.prepare(`
-            INSERT OR REPLACE INTO artifact_threads (channel_id, filename, thread_id)
-            VALUES (?, ?, ?)
-        `).run(channelId, filename, threadId);
+            INSERT OR REPLACE INTO artifact_threads (channel_id, conversation_id, filename, thread_id)
+            VALUES (?, ?, ?, ?)
+        `).run(channelId, conversationId, filename, threadId);
     }
 
     /**
      * Remove a stored thread ID.
      */
-    public deleteThreadId(channelId: string, filename: string): void {
+    public deleteThreadId(channelId: string, conversationId: string, filename: string): void {
         this.db.prepare(
-            'DELETE FROM artifact_threads WHERE channel_id = ? AND filename = ?'
-        ).run(channelId, filename);
+            'DELETE FROM artifact_threads WHERE channel_id = ? AND conversation_id = ? AND filename = ?'
+        ).run(channelId, conversationId, filename);
     }
 }

--- a/src/database/userPreferenceRepository.ts
+++ b/src/database/userPreferenceRepository.ts
@@ -22,7 +22,7 @@ export interface UserPreferenceRecord {
     /** Last update timestamp (ISO string) */
     updatedAt?: string;
     /** Artifact render mode (thread vs inline) */
-    artifactRenderMode: 'thread' | 'inline';
+    artifactRenderMode?: 'thread' | 'inline';
 }
 
 /**

--- a/src/database/userPreferenceRepository.ts
+++ b/src/database/userPreferenceRepository.ts
@@ -21,6 +21,8 @@ export interface UserPreferenceRecord {
     createdAt?: string;
     /** Last update timestamp (ISO string) */
     updatedAt?: string;
+    /** Artifact render mode (thread vs inline) */
+    artifactRenderMode: 'thread' | 'inline';
 }
 
 /**
@@ -49,6 +51,7 @@ export class UserPreferenceRepository {
             )
         `);
         this.migrateDefaultModel();
+        this.migrateArtifactRenderMode();
     }
 
     /**
@@ -69,6 +72,17 @@ export class UserPreferenceRepository {
             } catch {
                 // Column already exists — safe to ignore
             }
+        }
+    }
+
+    /**
+     * Migration: add artifact_render_mode column.
+     * Default is 'thread'.
+     */
+    private migrateArtifactRenderMode(): void {
+        const columns = this.db.pragma('table_info(user_preferences)') as { name: string }[];
+        if (!columns.some(c => c.name === 'artifact_render_mode')) {
+            this.db.exec("ALTER TABLE user_preferences ADD COLUMN artifact_render_mode TEXT DEFAULT 'thread'");
         }
     }
 
@@ -111,6 +125,32 @@ export class UserPreferenceRepository {
     }
 
     /**
+     * Get the artifact render mode preference for a user.
+     * Returns 'thread' as default.
+     */
+    public getArtifactRenderMode(userId: string): 'thread' | 'inline' {
+        const row = this.db.prepare(
+            'SELECT artifact_render_mode FROM user_preferences WHERE user_id = ?'
+        ).get(userId) as { artifact_render_mode: string } | undefined;
+
+        if (!row || row.artifact_render_mode === 'thread') return 'thread';
+        return 'inline';
+    }
+
+    /**
+     * Set the artifact render mode preference (upsert).
+     */
+    public setArtifactRenderMode(userId: string, mode: 'thread' | 'inline'): void {
+        this.db.prepare(`
+            INSERT INTO user_preferences (user_id, artifact_render_mode)
+            VALUES (?, ?)
+            ON CONFLICT(user_id)
+            DO UPDATE SET artifact_render_mode = excluded.artifact_render_mode,
+                          updated_at = datetime('now')
+        `).run(userId, mode);
+    }
+
+    /**
      * Set the default model for a user (upsert).
      * Pass null to clear the default.
      */
@@ -147,6 +187,7 @@ export class UserPreferenceRepository {
             defaultModel: row.default_model ?? null,
             createdAt: row.created_at,
             updatedAt: row.updated_at,
+            artifactRenderMode: (row.artifact_render_mode as 'thread' | 'inline') ?? 'thread',
         };
     }
 }

--- a/src/events/interactionCreateHandler.ts
+++ b/src/events/interactionCreateHandler.ts
@@ -45,6 +45,8 @@ import { AutoAcceptService } from '../services/autoAcceptService';
 import { ChatSessionService } from '../services/chatSessionService';
 import { JoinCommandHandler } from '../commands/joinCommandHandler';
 import { isSessionSelectId } from '../ui/sessionPickerUi';
+import { ARTIFACT_SELECT_ID } from '../ui/artifactsUi';
+import { ArtifactService } from '../services/artifactService';
 import type { AntigravityAccountConfig } from '../utils/configLoader';
 import { inferParentScopeChannelId, listAccountNames, resolveScopedAccountName } from '../utils/accountUtils';
 import { ACCOUNT_SELECT_ID, sendAccountUI } from '../ui/accountUi';
@@ -1017,6 +1019,87 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                 }
             } catch (error) {
                 logger.error('Session selection error:', error);
+            }
+            return;
+        }
+
+        if (interaction.isStringSelectMenu() && interaction.customId === ARTIFACT_SELECT_ID) {
+            if (!deps.config.allowedUserIds.includes(interaction.user.id)) {
+                await interaction.reply({ content: t('You do not have permission.'), flags: MessageFlags.Ephemeral }).catch(logger.error);
+                return;
+            }
+
+            try {
+                await interaction.deferUpdate();
+            } catch (deferError: any) {
+                if (deferError?.code === 10062 || deferError?.code === 40060) {
+                    logger.warn('[ArtifactSelect] deferUpdate expired. Skipping.');
+                    return;
+                }
+                logger.error('[ArtifactSelect] deferUpdate failed:', deferError);
+                return;
+            }
+
+            const selectedValue = interaction.values[0];
+            if (!selectedValue) {
+                await interaction.editReply({ content: 'No artifact selected.', components: [] }).catch(logger.error);
+                return;
+            }
+
+            try {
+                const artifactService = new ArtifactService();
+
+                // Resolve the selected artifact by rescanning and matching the encoded value
+                const channelId = (interaction as any).channelId as string;
+                const sessionTitle = deps.chatSessionRepo?.findByChannelId(channelId)?.displayName?.trim() ?? '';
+                let conversationId = sessionTitle ? artifactService.findConversationByTitle(sessionTitle) : null;
+                if (!conversationId) conversationId = artifactService.getLatestConversationWithArtifacts();
+
+                if (!conversationId) {
+                    await interaction.editReply({ content: '📂 No artifacts found.', components: [] }).catch(logger.error);
+                    return;
+                }
+
+                const artifacts = artifactService.listArtifacts(conversationId);
+                const decoded = artifactService.decodeSelectValue(selectedValue, artifacts);
+
+                if (!decoded) {
+                    logger.warn(`[ArtifactSelect] Could not decode value: ${selectedValue}`);
+                    await interaction.editReply({ content: '⚠️ Could not identify the selected artifact.', components: [] }).catch(logger.error);
+                    return;
+                }
+
+                const content = artifactService.getArtifactContent(decoded.conversationId, decoded.filename);
+
+                if (!content) {
+                    await interaction.editReply({ content: '⚠️ Could not read artifact content.', components: [] }).catch(logger.error);
+                    return;
+                }
+
+                // Acknowledge success; send content as follow-up chunks
+                await interaction.editReply({ content: `📂 **${decoded.filename}**`, components: [] }).catch(logger.error);
+
+                // Split into 2000-char chunks and send as follow-ups
+                const MAX_CHUNK = 1990;
+                let remaining = content;
+                while (remaining.length > 0) {
+                    // Try to split on newline boundary
+                    let chunk: string;
+                    if (remaining.length <= MAX_CHUNK) {
+                        chunk = remaining;
+                        remaining = '';
+                    } else {
+                        const splitAt = remaining.lastIndexOf('\n', MAX_CHUNK);
+                        chunk = splitAt > 0 ? remaining.slice(0, splitAt) : remaining.slice(0, MAX_CHUNK);
+                        remaining = remaining.slice(chunk.length).replace(/^\n/, '');
+                    }
+                    await interaction.followUp({ content: chunk }).catch(logger.error);
+                }
+
+                logger.info(`[ArtifactSelect] Served artifact ${decoded.conversationId}/${decoded.filename} to channel=${channelId}`);
+            } catch (error) {
+                logger.error('[ArtifactSelect] Error serving artifact:', error);
+                await interaction.editReply({ content: '❌ Error reading artifact.', components: [] }).catch(logger.error);
             }
             return;
         }

--- a/src/events/interactionCreateHandler.ts
+++ b/src/events/interactionCreateHandler.ts
@@ -45,8 +45,9 @@ import { AutoAcceptService } from '../services/autoAcceptService';
 import { ChatSessionService } from '../services/chatSessionService';
 import { JoinCommandHandler } from '../commands/joinCommandHandler';
 import { isSessionSelectId } from '../ui/sessionPickerUi';
-import { ARTIFACT_SELECT_ID } from '../ui/artifactsUi';
+import { ARTIFACT_SELECT_ID, ARTIFACT_THREAD_BTN, ARTIFACT_INLINE_BTN, buildArtifactPickerUI, sendArtifactPickerUI } from '../ui/artifactsUi';
 import { ArtifactService } from '../services/artifactService';
+import { ArtifactThreadRepository } from '../database/artifactThreadRepository';
 import type { AntigravityAccountConfig } from '../utils/configLoader';
 import { inferParentScopeChannelId, listAccountNames, resolveScopedAccountName } from '../utils/accountUtils';
 import { ACCOUNT_SELECT_ID, sendAccountUI } from '../ui/accountUi';
@@ -97,6 +98,7 @@ export interface InteractionCreateHandlerDeps {
     userPrefRepo?: UserPreferenceRepository;
     accountPrefRepo?: AccountPreferenceRepository;
     channelPrefRepo?: ChannelPreferenceRepository;
+    artifactThreadRepo?: ArtifactThreadRepository;
     antigravityAccounts?: AntigravityAccountConfig[];
     chatSessionRepo?: ChatSessionRepository;
     chatSessionService?: ChatSessionService;
@@ -855,6 +857,19 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                     }
                     return;
                 }
+
+                if (interaction.customId === ARTIFACT_THREAD_BTN || interaction.customId === ARTIFACT_INLINE_BTN) {
+                    const newMode = interaction.customId === ARTIFACT_THREAD_BTN ? 'thread' : 'inline';
+                    if (deps.userPrefRepo) {
+                        deps.userPrefRepo.setArtifactRenderMode(interaction.user.id, newMode);
+                    }
+                    await interaction.deferUpdate().catch(logger.error);
+                    await sendArtifactPickerUI(interaction, {
+                        userPrefRepo: deps.userPrefRepo,
+                        chatSessionRepo: deps.chatSessionRepo
+                    }, true);
+                    return;
+                }
             } catch (error) {
                 logger.error('Error during button interaction handling:', error);
 
@@ -1076,14 +1091,72 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                     return;
                 }
 
-                // Acknowledge success; send content as follow-up chunks
-                await interaction.editReply({ content: `📂 **${decoded.filename}**`, components: [] }).catch(logger.error);
+                // Get user render mode
+                const renderMode = deps.userPrefRepo?.getArtifactRenderMode(interaction.user.id) ?? 'thread';
 
-                // Split into 2000-char chunks and send as follow-ups
+                let targetChannel: any = interaction.channel;
+
+                if (renderMode === 'thread' && deps.artifactThreadRepo && (interaction as any).channel?.threads) {
+                    try {
+                        const existingThreadId = deps.artifactThreadRepo.getThreadId(channelId, decoded.filename);
+                        let thread: any = null;
+
+                        if (existingThreadId) {
+                            try {
+                                thread = await interaction.client.channels.fetch(existingThreadId);
+                                if (thread && thread.archived) {
+                                    await thread.setArchived(false);
+                                }
+                            } catch (fetchError) {
+                                logger.warn(`[ArtifactSelect] Could not fetch existing thread ${existingThreadId}:`, fetchError);
+                                deps.artifactThreadRepo.deleteThreadId(channelId, decoded.filename);
+                            }
+                        }
+
+                        if (!thread) {
+                            // Create new thread from the prompt message
+                            const message = await interaction.editReply({ 
+                                content: `📂 **Artifact: ${decoded.filename}**\n*Creating thread for persistent viewing...*`, 
+                                components: [] 
+                            });
+                            
+                            thread = await message.startThread({
+                                name: `artifact: ${decoded.filename}`,
+                                autoArchiveDuration: 60,
+                            });
+                            
+                            deps.artifactThreadRepo.setThreadId(channelId, decoded.filename, thread.id);
+                            
+                            // Update the main message to link to the thread
+                            await interaction.editReply({ 
+                                content: `📂 **Artifact: ${decoded.filename}**\n*Thread created: <#${thread.id}>*`, 
+                                components: [] 
+                            }).catch(logger.error);
+                        } else {
+                            // Reuse existing thread
+                            await interaction.editReply({ 
+                                content: `📂 **Artifact: ${decoded.filename}**\n*Updated in existing thread: <#${thread.id}>*`, 
+                                components: [] 
+                            }).catch(logger.error);
+                            
+                            // Send a visual spacer to separate content
+                            const now = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+                            await thread.send(`─────────────────────────\n🔄 **Artifact Re-rendered at ${now}**`).catch(logger.error);
+                        }
+                        targetChannel = thread;
+                    } catch (threadError) {
+                        logger.error('[ArtifactSelect] Thread creation/resume failed, falling back to inline:', threadError);
+                        await interaction.editReply({ content: `📂 **${decoded.filename}**`, components: [] }).catch(logger.error);
+                    }
+                } else {
+                    // Inline rendering
+                    await interaction.editReply({ content: `📂 **${decoded.filename}**`, components: [] }).catch(logger.error);
+                }
+
+                // Split into 2000-char chunks and send as follow-ups or thread messages
                 const MAX_CHUNK = 1990;
                 let remaining = content;
                 while (remaining.length > 0) {
-                    // Try to split on newline boundary
                     let chunk: string;
                     if (remaining.length <= MAX_CHUNK) {
                         chunk = remaining;
@@ -1093,10 +1166,15 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                         chunk = splitAt > 0 ? remaining.slice(0, splitAt) : remaining.slice(0, MAX_CHUNK);
                         remaining = remaining.slice(chunk.length).replace(/^\n/, '');
                     }
-                    await interaction.followUp({ content: chunk }).catch(logger.error);
+                    
+                    if (targetChannel && targetChannel.send) {
+                        await targetChannel.send({ content: chunk }).catch(logger.error);
+                    } else {
+                        await interaction.followUp({ content: chunk }).catch(logger.error);
+                    }
                 }
 
-                logger.info(`[ArtifactSelect] Served artifact ${decoded.conversationId}/${decoded.filename} to channel=${channelId}`);
+                logger.info(`[ArtifactSelect] Served artifact ${decoded.conversationId}/${decoded.filename} to channel=${channelId} (mode=${renderMode})`);
             } catch (error) {
                 logger.error('[ArtifactSelect] Error serving artifact:', error);
                 await interaction.editReply({ content: '❌ Error reading artifact.', components: [] }).catch(logger.error);

--- a/src/events/interactionCreateHandler.ts
+++ b/src/events/interactionCreateHandler.ts
@@ -102,14 +102,18 @@ export interface InteractionCreateHandlerDeps {
     antigravityAccounts?: AntigravityAccountConfig[];
     chatSessionRepo?: ChatSessionRepository;
     chatSessionService?: ChatSessionService;
+    artifactService?: ArtifactService;
 }
 
 export function createInteractionCreateHandler(deps: InteractionCreateHandlerDeps) {
-    const getParentChannelId = (interaction: Interaction): string | null =>
-        inferParentScopeChannelId(
-            (interaction as any).channelId,
-            (interaction as any).channel?.parentId ?? null,
-        );
+    const getParentChannelId = (interaction: Interaction): string | null => {
+        const channelId = interaction.channelId;
+        if (!channelId) return null;
+        const parentId = 'channel' in interaction && interaction.channel && 'parentId' in interaction.channel
+            ? interaction.channel.parentId
+            : null;
+        return inferParentScopeChannelId(channelId, parentId);
+    };
     const getSessionAccountName = (channelId: string): string | null =>
         deps.chatSessionRepo?.findByChannelId(channelId)?.activeAccountName ?? null;
     const resolveSelectedAccount = (channelId: string, userId: string, parentChannelId?: string | null): string =>
@@ -858,16 +862,18 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                     return;
                 }
 
-                if (interaction.customId === ARTIFACT_THREAD_BTN || interaction.customId === ARTIFACT_INLINE_BTN) {
-                    const newMode = interaction.customId === ARTIFACT_THREAD_BTN ? 'thread' : 'inline';
+                if (interaction.customId.startsWith(`${ARTIFACT_THREAD_BTN}:`) || interaction.customId.startsWith(`${ARTIFACT_INLINE_BTN}:`)) {
+                    const newMode = interaction.customId.startsWith(`${ARTIFACT_THREAD_BTN}:`) ? 'thread' : 'inline';
+                    const passedConvId = interaction.customId.split(':')[1] || null;
                     if (deps.userPrefRepo) {
                         deps.userPrefRepo.setArtifactRenderMode(interaction.user.id, newMode);
                     }
                     await interaction.deferUpdate().catch(logger.error);
                     await sendArtifactPickerUI(interaction, {
                         userPrefRepo: deps.userPrefRepo,
-                        chatSessionRepo: deps.chatSessionRepo
-                    }, true);
+                        chatSessionRepo: deps.chatSessionRepo,
+                        artifactService: deps.artifactService
+                    }, true, passedConvId);
                     return;
                 }
             } catch (error) {
@@ -1057,7 +1063,7 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
 
             const selectedValue = interaction.values[0];
             if (!selectedValue) {
-                await interaction.editReply({ content: 'No artifact selected.', components: [] }).catch(logger.error);
+                await interaction.editReply({ content: 'No artifact selected.', components: [], allowedMentions: { parse: [] } }).catch(logger.error);
                 return;
             }
 
@@ -1071,7 +1077,7 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                 if (!conversationId) conversationId = artifactService.getLatestConversationWithArtifacts();
 
                 if (!conversationId) {
-                    await interaction.editReply({ content: '📂 No artifacts found.', components: [] }).catch(logger.error);
+                    await interaction.editReply({ content: '📂 No artifacts found.', components: [], allowedMentions: { parse: [] } }).catch(logger.error);
                     return;
                 }
 
@@ -1080,14 +1086,14 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
 
                 if (!decoded) {
                     logger.warn(`[ArtifactSelect] Could not decode value: ${selectedValue}`);
-                    await interaction.editReply({ content: '⚠️ Could not identify the selected artifact.', components: [] }).catch(logger.error);
+                    await interaction.editReply({ content: '⚠️ Could not identify the selected artifact.', components: [], allowedMentions: { parse: [] } }).catch(logger.error);
                     return;
                 }
 
                 const content = artifactService.getArtifactContent(decoded.conversationId, decoded.filename);
 
                 if (!content) {
-                    await interaction.editReply({ content: '⚠️ Could not read artifact content.', components: [] }).catch(logger.error);
+                    await interaction.editReply({ content: '⚠️ Could not read artifact content.', components: [], allowedMentions: { parse: [] } }).catch(logger.error);
                     return;
                 }
 
@@ -1098,7 +1104,7 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
 
                 if (renderMode === 'thread' && deps.artifactThreadRepo && (interaction as any).channel?.threads) {
                     try {
-                        const existingThreadId = deps.artifactThreadRepo.getThreadId(channelId, decoded.filename);
+                        const existingThreadId = deps.artifactThreadRepo.getThreadId(channelId, conversationId, decoded.filename);
                         let thread: any = null;
 
                         if (existingThreadId) {
@@ -1109,7 +1115,7 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                                 }
                             } catch (fetchError) {
                                 logger.warn(`[ArtifactSelect] Could not fetch existing thread ${existingThreadId}:`, fetchError);
-                                deps.artifactThreadRepo.deleteThreadId(channelId, decoded.filename);
+                                deps.artifactThreadRepo.deleteThreadId(channelId, conversationId, decoded.filename);
                             }
                         }
 
@@ -1117,40 +1123,43 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                             // Create new thread from the prompt message
                             const message = await interaction.editReply({ 
                                 content: `📂 **Artifact: ${decoded.filename}**\n*Creating thread for persistent viewing...*`, 
-                                components: [] 
+                                components: [],
+                                allowedMentions: { parse: [] }
                             });
                             
                             thread = await message.startThread({
                                 name: `artifact: ${decoded.filename}`,
-                                autoArchiveDuration: 60,
+                                autoArchiveDuration: 10080,
                             });
                             
-                            deps.artifactThreadRepo.setThreadId(channelId, decoded.filename, thread.id);
+                            deps.artifactThreadRepo.setThreadId(channelId, conversationId, decoded.filename, thread.id);
                             
                             // Update the main message to link to the thread
                             await interaction.editReply({ 
                                 content: `📂 **Artifact: ${decoded.filename}**\n*Thread created: <#${thread.id}>*`, 
-                                components: [] 
+                                components: [],
+                                allowedMentions: { parse: [] }
                             }).catch(logger.error);
                         } else {
                             // Reuse existing thread
                             await interaction.editReply({ 
                                 content: `📂 **Artifact: ${decoded.filename}**\n*Updated in existing thread: <#${thread.id}>*`, 
-                                components: [] 
+                                components: [],
+                                allowedMentions: { parse: [] }
                             }).catch(logger.error);
                             
                             // Send a visual spacer to separate content
                             const now = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-                            await thread.send(`─────────────────────────\n🔄 **Artifact Re-rendered at ${now}**`).catch(logger.error);
+                            await thread.send({ content: `─────────────────────────\n🔄 **Artifact Re-rendered at ${now}**`, allowedMentions: { parse: [] } }).catch(logger.error);
                         }
                         targetChannel = thread;
                     } catch (threadError) {
                         logger.error('[ArtifactSelect] Thread creation/resume failed, falling back to inline:', threadError);
-                        await interaction.editReply({ content: `📂 **${decoded.filename}**`, components: [] }).catch(logger.error);
+                        await interaction.editReply({ content: `📂 **${decoded.filename}**`, components: [], allowedMentions: { parse: [] } }).catch(logger.error);
                     }
                 } else {
                     // Inline rendering
-                    await interaction.editReply({ content: `📂 **${decoded.filename}**`, components: [] }).catch(logger.error);
+                    await interaction.editReply({ content: `📂 **${decoded.filename}**`, components: [], allowedMentions: { parse: [] } }).catch(logger.error);
                 }
 
                 // Split into 2000-char chunks and send as follow-ups or thread messages
@@ -1168,16 +1177,16 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                     }
                     
                     if (targetChannel && targetChannel.send) {
-                        await targetChannel.send({ content: chunk }).catch(logger.error);
+                        await targetChannel.send({ content: chunk, allowedMentions: { parse: [] } }).catch(logger.error);
                     } else {
-                        await interaction.followUp({ content: chunk }).catch(logger.error);
+                        await interaction.followUp({ content: chunk, allowedMentions: { parse: [] } }).catch(logger.error);
                     }
                 }
 
                 logger.info(`[ArtifactSelect] Served artifact ${decoded.conversationId}/${decoded.filename} to channel=${channelId} (mode=${renderMode})`);
             } catch (error) {
                 logger.error('[ArtifactSelect] Error serving artifact:', error);
-                await interaction.editReply({ content: '❌ Error reading artifact.', components: [] }).catch(logger.error);
+                await interaction.editReply({ content: '❌ Error reading artifact.', components: [], allowedMentions: { parse: [] } }).catch(logger.error);
             }
             return;
         }

--- a/src/events/messageCreateHandler.ts
+++ b/src/events/messageCreateHandler.ts
@@ -47,7 +47,7 @@ export interface MessageCreateHandlerDeps {
     chatSessionRepo: ChatSessionRepository;
     channelManager: ChannelManager;
     titleGenerator: TitleGeneratorService;
-    artifactService: ArtifactService;
+    artifactService?: ArtifactService;
     client: any;
     sendPromptToAntigravity: (
         bridge: CdpBridge,

--- a/src/events/messageCreateHandler.ts
+++ b/src/events/messageCreateHandler.ts
@@ -26,6 +26,7 @@ import { ChannelManager } from '../services/channelManager';
 import { MODE_DISPLAY_NAMES, ModeService } from '../services/modeService';
 import { ModelService } from '../services/modelService';
 import { TitleGeneratorService } from '../services/titleGeneratorService';
+import { ArtifactService } from '../services/artifactService';
 import {
     cleanupInboundImageAttachments as cleanupInboundImageAttachmentsFn,
     downloadInboundImageAttachments as downloadInboundImageAttachmentsFn,
@@ -46,6 +47,7 @@ export interface MessageCreateHandlerDeps {
     chatSessionRepo: ChatSessionRepository;
     channelManager: ChannelManager;
     titleGenerator: TitleGeneratorService;
+    artifactService: ArtifactService;
     client: any;
     sendPromptToAntigravity: (
         bridge: CdpBridge,
@@ -277,6 +279,7 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
                         channelManager: deps.channelManager,
                         titleGenerator: deps.titleGenerator,
                         userPrefRepo: deps.userPrefRepo,
+                        artifactService: deps.artifactService,
                         extractionMode: deps.config.extractionMode,
                         responseTimeoutMs: deps.config.responseTimeoutMs,
                     });
@@ -497,6 +500,7 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
                                     channelManager: deps.channelManager,
                                     titleGenerator: deps.titleGenerator,
                                     userPrefRepo: deps.userPrefRepo,
+                                    artifactService: deps.artifactService,
                                     extractionMode: deps.config.extractionMode,
                                     responseTimeoutMs: deps.config.responseTimeoutMs,
                                     onFullCompletion: settle,

--- a/src/services/artifactService.ts
+++ b/src/services/artifactService.ts
@@ -1,0 +1,278 @@
+/**
+ * Artifact Service — reads Antigravity artifacts from the local filesystem.
+ *
+ * Antigravity persists artifacts (implementation plans, tasks, walkthroughs)
+ * as Markdown files with companion `.metadata.json` files in:
+ *   %USERPROFILE%/.gemini/antigravity/brain/<conversation-id>/
+ *
+ * This service locates relevant conversations and surfaces their artifacts
+ * for the /artifacts Discord command.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { logger } from '../utils/logger';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ArtifactType =
+    | 'ARTIFACT_TYPE_IMPLEMENTATION_PLAN'
+    | 'ARTIFACT_TYPE_TASK'
+    | 'ARTIFACT_TYPE_WALKTHROUGH'
+    | 'ARTIFACT_TYPE_OTHER'
+    | string;
+
+export interface ArtifactMetadata {
+    artifactType: ArtifactType;
+    summary?: string;
+    updatedAt?: string;
+    version?: string;
+    requestFeedback?: boolean;
+}
+
+export interface ArtifactInfo {
+    /** The conversation UUID this artifact belongs to */
+    conversationId: string;
+    /** Filename of the artifact (e.g. "implementation_plan.md") */
+    filename: string;
+    /** Artifact type from metadata */
+    artifactType: ArtifactType;
+    /** Short summary from metadata */
+    summary?: string;
+    /** ISO timestamp of last update */
+    updatedAt?: string;
+    /** Display version number */
+    version?: string;
+    /** Full absolute path to the markdown file */
+    absolutePath: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ARTIFACT_TYPE_LABELS: Record<string, string> = {
+    ARTIFACT_TYPE_IMPLEMENTATION_PLAN: '📋 Plan',
+    ARTIFACT_TYPE_TASK: '✅ Task',
+    ARTIFACT_TYPE_WALKTHROUGH: '🚶 Walkthrough',
+    ARTIFACT_TYPE_OTHER: '📄 Other',
+};
+
+export function artifactTypeLabel(type: ArtifactType): string {
+    return ARTIFACT_TYPE_LABELS[type] ?? '📄 Artifact';
+}
+
+// ---------------------------------------------------------------------------
+// ArtifactService
+// ---------------------------------------------------------------------------
+
+export class ArtifactService {
+    private readonly brainBasePath: string;
+
+    constructor(brainBasePath?: string) {
+        this.brainBasePath =
+            brainBasePath ??
+            path.join(os.homedir(), '.gemini', 'antigravity', 'brain');
+    }
+
+    /**
+     * List all conversations in the brain directory (UUIDs).
+     */
+    private listConversationIds(): string[] {
+        try {
+            if (!fs.existsSync(this.brainBasePath)) return [];
+            return fs.readdirSync(this.brainBasePath).filter((entry) => {
+                const full = path.join(this.brainBasePath, entry);
+                return (
+                    fs.statSync(full).isDirectory() &&
+                    /^[0-9a-f-]{36}$/.test(entry)
+                );
+            });
+        } catch (err) {
+            logger.warn(`[ArtifactService] Failed to list brain directory: ${err}`);
+            return [];
+        }
+    }
+
+    /**
+     * Read the .metadata.json file for a given artifact in a conversation.
+     */
+    private readMetadata(
+        conversationId: string,
+        mdFilename: string,
+    ): ArtifactMetadata | null {
+        const metaPath = path.join(
+            this.brainBasePath,
+            conversationId,
+            `${mdFilename}.metadata.json`,
+        );
+        try {
+            if (!fs.existsSync(metaPath)) return null;
+            const raw = fs.readFileSync(metaPath, 'utf-8');
+            return JSON.parse(raw) as ArtifactMetadata;
+        } catch {
+            return null;
+        }
+    }
+
+    /**
+     * List all artifacts in a given conversation directory.
+     * An artifact must be a .md file with a companion .metadata.json.
+     */
+    listArtifacts(conversationId: string): ArtifactInfo[] {
+        const convDir = path.join(this.brainBasePath, conversationId);
+        try {
+            if (!fs.existsSync(convDir)) return [];
+            const entries = fs.readdirSync(convDir);
+            const artifacts: ArtifactInfo[] = [];
+
+            for (const entry of entries) {
+                // Only look at .md files (not .metadata.json, .resolved, etc.)
+                if (!entry.endsWith('.md')) continue;
+
+                const meta = this.readMetadata(conversationId, entry);
+                if (!meta) continue; // Not a tracked artifact — skip
+
+                artifacts.push({
+                    conversationId,
+                    filename: entry,
+                    artifactType: meta.artifactType ?? 'ARTIFACT_TYPE_OTHER',
+                    summary: meta.summary,
+                    updatedAt: meta.updatedAt,
+                    version: meta.version,
+                    absolutePath: path.join(convDir, entry),
+                });
+            }
+
+            // Sort by updatedAt descending (most recent first)
+            artifacts.sort((a, b) => {
+                const ta = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+                const tb = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+                return tb - ta;
+            });
+
+            return artifacts;
+        } catch (err) {
+            logger.warn(
+                `[ArtifactService] Failed to list artifacts for ${conversationId}: ${err}`,
+            );
+            return [];
+        }
+    }
+
+    /**
+     * Try to find a conversation UUID whose overview.txt contains the given session title.
+     * Returns the UUID or null if not found.
+     */
+    findConversationByTitle(title: string): string | null {
+        if (!title || !title.trim()) return null;
+        const needle = title.trim().toLowerCase();
+        const ids = this.listConversationIds();
+
+        for (const id of ids) {
+            const overviewPath = path.join(
+                this.brainBasePath,
+                id,
+                '.system_generated',
+                'logs',
+                'overview.txt',
+            );
+            try {
+                if (!fs.existsSync(overviewPath)) continue;
+                // Only read the first 4KB to avoid huge files
+                const fd = fs.openSync(overviewPath, 'r');
+                const buf = Buffer.alloc(4096);
+                const bytesRead = fs.readSync(fd, buf, 0, buf.length, 0);
+                fs.closeSync(fd);
+                const header = buf.slice(0, bytesRead).toString('utf-8').toLowerCase();
+                if (header.includes(needle)) {
+                    return id;
+                }
+            } catch {
+                // Skip unreadable files
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Return the conversation ID of the most recently modified conversation
+     * that has at least one artifact. Falls back to the most recent conversation
+     * overall if none have artifacts.
+     */
+    getLatestConversationWithArtifacts(): string | null {
+        const ids = this.listConversationIds();
+        if (ids.length === 0) return null;
+
+        // Sort by directory mtime descending
+        const sorted = ids
+            .map((id) => {
+                const full = path.join(this.brainBasePath, id);
+                try {
+                    return { id, mtime: fs.statSync(full).mtimeMs };
+                } catch {
+                    return { id, mtime: 0 };
+                }
+            })
+            .sort((a, b) => b.mtime - a.mtime);
+
+        // Find the first one that has artifacts
+        for (const { id } of sorted) {
+            if (this.listArtifacts(id).length > 0) return id;
+        }
+
+        // Nothing has artifacts — return most recent anyway (caller handles empty list)
+        return sorted[0]?.id ?? null;
+    }
+
+    /**
+     * Read the markdown content of a specific artifact file.
+     * Returns null if the file cannot be read.
+     */
+    getArtifactContent(conversationId: string, filename: string): string | null {
+        // Sanitize: prevent path traversal
+        const safe = path.basename(filename);
+        if (!safe.endsWith('.md')) return null;
+
+        const filePath = path.join(this.brainBasePath, conversationId, safe);
+        try {
+            if (!fs.existsSync(filePath)) return null;
+            return fs.readFileSync(filePath, 'utf-8');
+        } catch (err) {
+            logger.warn(
+                `[ArtifactService] Failed to read artifact ${conversationId}/${safe}: ${err}`,
+            );
+            return null;
+        }
+    }
+
+    /**
+     * Encode a conversationId + filename pair as a Discord select-menu value.
+     * Discord limits option values to 100 characters.
+     */
+    static encodeSelectValue(conversationId: string, filename: string): string {
+        // Use a short ID (first 8 chars of uuid) + filename to stay within limits
+        const shortId = conversationId.replace(/-/g, '').slice(0, 12);
+        return `art_${shortId}_${filename}`.slice(0, 100);
+    }
+
+    /**
+     * Decode a select value back to { conversationId, filename }.
+     * Returns null if the value cannot be resolved.
+     */
+    decodeSelectValue(
+        value: string,
+        artifacts: ArtifactInfo[],
+    ): { conversationId: string; filename: string } | null {
+        // Match against known artifacts by re-encoding and comparing
+        for (const a of artifacts) {
+            if (ArtifactService.encodeSelectValue(a.conversationId, a.filename) === value) {
+                return { conversationId: a.conversationId, filename: a.filename };
+            }
+        }
+        return null;
+    }
+}

--- a/src/services/artifactService.ts
+++ b/src/services/artifactService.ts
@@ -172,7 +172,20 @@ export class ArtifactService {
         const needle = title.trim().toLowerCase();
         const ids = this.listConversationIds();
 
-        for (const id of ids) {
+        // Sort by directory mtime descending (most recent first)
+        const sortedIds = ids
+            .map((id) => {
+                const full = path.join(this.brainBasePath, id);
+                try {
+                    return { id, mtime: fs.statSync(full).mtimeMs };
+                } catch {
+                    return { id, mtime: 0 };
+                }
+            })
+            .sort((a, b) => b.mtime - a.mtime)
+            .map(x => x.id);
+
+        for (const id of sortedIds) {
             const overviewPath = path.join(
                 this.brainBasePath,
                 id,
@@ -183,13 +196,17 @@ export class ArtifactService {
             try {
                 if (!fs.existsSync(overviewPath)) continue;
                 // Only read the first 4KB to avoid huge files
-                const fd = fs.openSync(overviewPath, 'r');
-                const buf = Buffer.alloc(4096);
-                const bytesRead = fs.readSync(fd, buf, 0, buf.length, 0);
-                fs.closeSync(fd);
-                const header = buf.slice(0, bytesRead).toString('utf-8').toLowerCase();
-                if (header.includes(needle)) {
-                    return id;
+                let fd: number | null = null;
+                try {
+                    fd = fs.openSync(overviewPath, 'r');
+                    const buf = Buffer.alloc(4096);
+                    const bytesRead = fs.readSync(fd, buf, 0, buf.length, 0);
+                    const header = buf.slice(0, bytesRead).toString('utf-8').toLowerCase();
+                    if (header.includes(needle)) {
+                        return id;
+                    }
+                } finally {
+                    if (fd !== null) fs.closeSync(fd);
                 }
             } catch {
                 // Skip unreadable files
@@ -250,29 +267,44 @@ export class ArtifactService {
     }
 
     /**
-     * Encode a conversationId + filename pair as a Discord select-menu value.
-     * Discord limits option values to 100 characters.
+     * Encode conversationId and filename into a single string for Discord select menu values.
+     * We use a prefix 'art_', followed by a short slice of the conv ID, and the filename.
+     * Added a short hash of the filename to prevent collisions on long-filename truncation.
      */
     static encodeSelectValue(conversationId: string, filename: string): string {
-        // Use a short ID (first 8 chars of uuid) + filename to stay within limits
-        const shortId = conversationId.replace(/-/g, '').slice(0, 12);
-        return `art_${shortId}_${filename}`.slice(0, 100);
+        const shortConv = conversationId.replace(/-/g, '').slice(0, 12);
+        // Simple hash of the filename
+        let hash = 0;
+        for (let i = 0; i < filename.length; i++) {
+            hash = ((hash << 5) - hash) + filename.charCodeAt(i);
+            hash |= 0; // Convert to 32bit integer
+        }
+        const shortHash = Math.abs(hash).toString(36).slice(0, 4);
+        
+        return `art_${shortConv}_${shortHash}_${filename}`;
     }
 
     /**
-     * Decode a select value back to { conversationId, filename }.
-     * Returns null if the value cannot be resolved.
+     * Decode a select menu value back into conversationId and filename.
+     * Since we only have a slice of the conversationId, we must look it up
+     * in the provided list of artifacts.
      */
-    decodeSelectValue(
-        value: string,
-        artifacts: ArtifactInfo[],
-    ): { conversationId: string; filename: string } | null {
-        // Match against known artifacts by re-encoding and comparing
-        for (const a of artifacts) {
-            if (ArtifactService.encodeSelectValue(a.conversationId, a.filename) === value) {
-                return { conversationId: a.conversationId, filename: a.filename };
-            }
-        }
-        return null;
+    decodeSelectValue(value: string, artifacts: ArtifactInfo[]): { conversationId: string; filename: string } | null {
+        if (!value.startsWith('art_')) return null;
+        
+        // Format: art_CONV_HASH_FILENAME
+        const parts = value.split('_');
+        if (parts.length < 4) return null;
+        
+        const shortConv = parts[1];
+        const filename = parts.slice(3).join('_'); // Filename might contain underscores
+
+        // Find the matching artifact in the current list
+        const found = artifacts.find(a => 
+            a.filename === filename && 
+            a.conversationId.replace(/-/g, '').startsWith(shortConv)
+        );
+
+        return found ? { conversationId: found.conversationId, filename: found.filename } : null;
     }
 }

--- a/src/services/promptDispatcher.ts
+++ b/src/services/promptDispatcher.ts
@@ -11,6 +11,8 @@ import { TitleGeneratorService } from './titleGeneratorService';
 import { InboundImageAttachment } from '../utils/imageHandler';
 import { UserPreferenceRepository } from '../database/userPreferenceRepository';
 
+import { ArtifactService } from './artifactService';
+
 export interface PromptDispatchOptions {
     chatSessionService: ChatSessionService;
     chatSessionRepo: ChatSessionRepository;
@@ -18,7 +20,11 @@ export interface PromptDispatchOptions {
     titleGenerator: TitleGeneratorService;
     userPrefRepo?: UserPreferenceRepository;
     extractionMode?: import('../utils/config').ExtractionMode;
+    artifactService?: ArtifactService;
+    onFullCompletion?: () => void;
+    responseTimeoutMs?: number;
 }
+
 
 export interface PromptDispatchRequest {
     message: Message;

--- a/src/ui/artifactsUi.ts
+++ b/src/ui/artifactsUi.ts
@@ -1,0 +1,138 @@
+/**
+ * Artifacts UI — Discord embed + select menu for the /artifacts command.
+ *
+ * Follows the same pattern as sessionPickerUi.ts.
+ */
+
+import {
+    ActionRowBuilder,
+    ChatInputCommandInteraction,
+    EmbedBuilder,
+    StringSelectMenuBuilder,
+} from 'discord.js';
+
+import type { ArtifactInfo } from '../services/artifactService';
+import { ArtifactService, artifactTypeLabel } from '../services/artifactService';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Custom ID for the artifact select menu */
+export const ARTIFACT_SELECT_ID = 'artifact_select';
+
+/** Discord select menu option limit */
+const MAX_SELECT_OPTIONS = 25;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function truncate(str: string, max: number): string {
+    if (str.length <= max) return str;
+    return str.slice(0, max - 1) + '…';
+}
+
+function formatOptionDescription(artifact: ArtifactInfo): string | undefined {
+    const parts: string[] = [];
+    parts.push(artifactTypeLabel(artifact.artifactType));
+    if (artifact.summary) {
+        parts.push(truncate(artifact.summary, 60));
+    }
+    const combined = parts.join(' · ');
+    // Discord limits descriptions to 100 chars
+    return combined.length > 0 ? truncate(combined, 100) : undefined;
+}
+
+function formatUpdatedAt(iso?: string): string {
+    if (!iso) return '';
+    try {
+        return new Date(iso).toLocaleString('en-US', {
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+        });
+    } catch {
+        return '';
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Discord-specific builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the artifact picker embed + select menu components.
+ */
+export function buildArtifactPickerUI(
+    artifacts: ArtifactInfo[],
+    conversationId?: string,
+): { embeds: EmbedBuilder[]; components: ActionRowBuilder<any>[] } {
+    const embed = new EmbedBuilder()
+        .setTitle('📂 Artifacts')
+        .setColor(0x5865F2)
+        .setTimestamp();
+
+    if (artifacts.length === 0) {
+        embed.setDescription('No artifacts found for the active session.');
+        return { embeds: [embed], components: [] };
+    }
+
+    const displayId = conversationId
+        ? conversationId.slice(0, 8) + '…'
+        : 'current session';
+
+    embed.setDescription(
+        `**${artifacts.length}** artifact(s) found (conversation \`${displayId}\`)\n` +
+        'Select one to render its content below.',
+    );
+
+    const fields = artifacts.map((a) => ({
+        name: a.filename,
+        value: [
+            artifactTypeLabel(a.artifactType),
+            a.summary ? `*${truncate(a.summary, 120)}*` : '',
+            a.updatedAt ? `🕐 v${a.version ?? '?'} · ${formatUpdatedAt(a.updatedAt)}` : '',
+        ].filter(Boolean).join('\n'),
+        inline: false,
+    }));
+
+    // Add summary fields (max 10 to avoid embed limit)
+    embed.addFields(...fields.slice(0, 10));
+
+    const pageItems = artifacts.slice(0, MAX_SELECT_OPTIONS);
+
+    const options = pageItems.map((a) => ({
+        label: truncate(a.filename, 100),
+        value: ArtifactService.encodeSelectValue(a.conversationId, a.filename),
+        description: formatOptionDescription(a),
+    }));
+
+    const selectMenu = new StringSelectMenuBuilder()
+        .setCustomId(ARTIFACT_SELECT_ID)
+        .setPlaceholder('Select an artifact to view…')
+        .addOptions(options);
+
+    const components: ActionRowBuilder<any>[] = [
+        new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(selectMenu),
+    ];
+
+    return { embeds: [embed], components };
+}
+
+// ---------------------------------------------------------------------------
+// Interaction sender
+// ---------------------------------------------------------------------------
+
+/**
+ * Send the artifacts picker UI as an editReply to a slash command interaction.
+ */
+export async function sendArtifactsUI(
+    interaction: ChatInputCommandInteraction,
+    artifacts: ArtifactInfo[],
+    conversationId?: string,
+): Promise<void> {
+    const { embeds, components } = buildArtifactPickerUI(artifacts, conversationId);
+    await interaction.editReply({ embeds, components });
+}

--- a/src/ui/artifactsUi.ts
+++ b/src/ui/artifactsUi.ts
@@ -6,10 +6,16 @@
 
 import {
     ActionRowBuilder,
+    ButtonBuilder,
+    ButtonInteraction,
+    ButtonStyle,
     ChatInputCommandInteraction,
     EmbedBuilder,
     StringSelectMenuBuilder,
+    MessageFlags,
 } from 'discord.js';
+import { UserPreferenceRepository } from '../database/userPreferenceRepository';
+import { ChatSessionRepository } from '../database/chatSessionRepository';
 
 import type { ArtifactInfo } from '../services/artifactService';
 import { ArtifactService, artifactTypeLabel } from '../services/artifactService';
@@ -20,6 +26,10 @@ import { ArtifactService, artifactTypeLabel } from '../services/artifactService'
 
 /** Custom ID for the artifact select menu */
 export const ARTIFACT_SELECT_ID = 'artifact_select';
+
+/** Custom ID for the toggle buttons */
+export const ARTIFACT_THREAD_BTN = 'artifact_mode_thread';
+export const ARTIFACT_INLINE_BTN = 'artifact_mode_inline';
 
 /** Discord select menu option limit */
 const MAX_SELECT_OPTIONS = 25;
@@ -68,6 +78,7 @@ function formatUpdatedAt(iso?: string): string {
 export function buildArtifactPickerUI(
     artifacts: ArtifactInfo[],
     conversationId?: string,
+    renderMode: 'thread' | 'inline' = 'thread',
 ): { embeds: EmbedBuilder[]; components: ActionRowBuilder<any>[] } {
     const embed = new EmbedBuilder()
         .setTitle('📂 Artifacts')
@@ -118,6 +129,26 @@ export function buildArtifactPickerUI(
         new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(selectMenu),
     ];
 
+    // Add toggle button row
+    const toggleButton = new ButtonBuilder();
+    if (renderMode === 'thread') {
+        toggleButton
+            .setCustomId(ARTIFACT_INLINE_BTN)
+            .setLabel('💬 Switch to Inline')
+            .setStyle(ButtonStyle.Secondary)
+            .setEmoji('💬');
+        embed.setFooter({ text: 'Output: Thread (one thread per file)' });
+    } else {
+        toggleButton
+            .setCustomId(ARTIFACT_THREAD_BTN)
+            .setLabel('📌 Switch to Thread')
+            .setStyle(ButtonStyle.Primary)
+            .setEmoji('📌');
+        embed.setFooter({ text: 'Output: Inline' });
+    }
+
+    components.push(new ActionRowBuilder<ButtonBuilder>().addComponents(toggleButton));
+
     return { embeds: [embed], components };
 }
 
@@ -129,10 +160,54 @@ export function buildArtifactPickerUI(
  * Send the artifacts picker UI as an editReply to a slash command interaction.
  */
 export async function sendArtifactsUI(
-    interaction: ChatInputCommandInteraction,
+    interaction: ChatInputCommandInteraction | ButtonInteraction,
     artifacts: ArtifactInfo[],
     conversationId?: string,
+    renderMode: 'thread' | 'inline' = 'thread',
 ): Promise<void> {
-    const { embeds, components } = buildArtifactPickerUI(artifacts, conversationId);
+    const { embeds, components } = buildArtifactPickerUI(artifacts, conversationId, renderMode);
     await interaction.editReply({ embeds, components });
+}
+
+/**
+ * Higher-level helper to send the artifact picker UI, 
+ * automatically discovering artifacts for the current channel.
+ */
+export async function sendArtifactPickerUI(
+    interaction: { reply: (opts: any) => Promise<any>; editReply: (opts: any) => Promise<any>; user: { id: string }; channelId: string },
+    deps: { userPrefRepo?: UserPreferenceRepository; chatSessionRepo?: ChatSessionRepository },
+    edit: boolean = false
+): Promise<void> {
+    const artifactService = new ArtifactService();
+    const sessionTitle = deps.chatSessionRepo?.findByChannelId(interaction.channelId)?.displayName?.trim() ?? '';
+    
+    // 1. Resolve conversation (either matching session title or latest)
+    let conversationId = sessionTitle ? artifactService.findConversationByTitle(sessionTitle) : null;
+    if (!conversationId) conversationId = artifactService.getLatestConversationWithArtifacts();
+
+    if (!conversationId) {
+        const payload = { content: '📂 No artifacts found for this session.', components: [], ephemeral: true };
+        if (edit) await interaction.editReply(payload);
+        else await interaction.reply(payload);
+        return;
+    }
+
+    // 2. List artifacts
+    const artifacts = artifactService.listArtifacts(conversationId);
+    if (artifacts.length === 0) {
+        const payload = { content: '📂 No artifacts found in this conversation.', components: [], ephemeral: true };
+        if (edit) await interaction.editReply(payload);
+        else await interaction.reply(payload);
+        return;
+    }
+
+    // 3. Get user render mode pref
+    const renderMode = deps.userPrefRepo?.getArtifactRenderMode(interaction.user.id) ?? 'thread';
+
+    // 4. Build and send
+    const { embeds, components } = buildArtifactPickerUI(artifacts, conversationId, renderMode);
+    
+    const payload = { embeds, components, ephemeral: true };
+    if (edit) await interaction.editReply(payload);
+    else await interaction.reply(payload);
 }

--- a/src/ui/artifactsUi.ts
+++ b/src/ui/artifactsUi.ts
@@ -57,7 +57,7 @@ function formatOptionDescription(artifact: ArtifactInfo): string | undefined {
 function formatUpdatedAt(iso?: string): string {
     if (!iso) return '';
     try {
-        return new Date(iso).toLocaleString('en-US', {
+        return new Date(iso).toLocaleString(undefined, {
             month: 'short',
             day: 'numeric',
             hour: '2-digit',
@@ -133,14 +133,14 @@ export function buildArtifactPickerUI(
     const toggleButton = new ButtonBuilder();
     if (renderMode === 'thread') {
         toggleButton
-            .setCustomId(ARTIFACT_INLINE_BTN)
+            .setCustomId(`${ARTIFACT_INLINE_BTN}:${conversationId || ''}`)
             .setLabel('💬 Switch to Inline')
             .setStyle(ButtonStyle.Secondary)
             .setEmoji('💬');
         embed.setFooter({ text: 'Output: Thread (one thread per file)' });
     } else {
         toggleButton
-            .setCustomId(ARTIFACT_THREAD_BTN)
+            .setCustomId(`${ARTIFACT_THREAD_BTN}:${conversationId || ''}`)
             .setLabel('📌 Switch to Thread')
             .setStyle(ButtonStyle.Primary)
             .setEmoji('📌');
@@ -174,20 +174,43 @@ export async function sendArtifactsUI(
  * automatically discovering artifacts for the current channel.
  */
 export async function sendArtifactPickerUI(
-    interaction: { reply: (opts: any) => Promise<any>; editReply: (opts: any) => Promise<any>; user: { id: string }; channelId: string },
-    deps: { userPrefRepo?: UserPreferenceRepository; chatSessionRepo?: ChatSessionRepository },
-    edit: boolean = false
+    interaction: { 
+        reply: (opts: any) => Promise<any>; 
+        editReply: (opts: any) => Promise<any>; 
+        user: { id: string }; 
+        channelId: string;
+        deferred?: boolean;
+        replied?: boolean;
+    },
+    deps: { userPrefRepo?: UserPreferenceRepository; chatSessionRepo?: ChatSessionRepository; artifactService?: ArtifactService },
+    edit: boolean = false,
+    resolvedConversationId?: string | null
 ): Promise<void> {
-    const artifactService = new ArtifactService();
-    const sessionTitle = deps.chatSessionRepo?.findByChannelId(interaction.channelId)?.displayName?.trim() ?? '';
+    const artifactService = deps.artifactService || new ArtifactService();
+    let conversationId = resolvedConversationId;
     
-    // 1. Resolve conversation (either matching session title or latest)
-    let conversationId = sessionTitle ? artifactService.findConversationByTitle(sessionTitle) : null;
-    if (!conversationId) conversationId = artifactService.getLatestConversationWithArtifacts();
+    if (!conversationId) {
+        const session = deps.chatSessionRepo?.findByChannelId(interaction.channelId);
+        if (session) {
+            conversationId = session.conversationId ?? null;
+
+            // Fallback to title matching if ID is not in DB or doesn't match a real folder
+            if (!conversationId || !artifactService.listArtifacts(conversationId).length) {
+                const sessionTitle = session.displayName?.trim() ?? '';
+                const matchedId = sessionTitle ? artifactService.findConversationByTitle(sessionTitle) : null;
+                if (matchedId) conversationId = matchedId;
+            }
+            // Note: We do NOT fallback to getLatestConversationWithArtifacts() for managed sessions
+            // to avoid showing artifacts from other projects/chats.
+        } else {
+            // Final fallback: latest overall (only for non-session channels)
+            conversationId = artifactService.getLatestConversationWithArtifacts();
+        }
+    }
 
     if (!conversationId) {
         const payload = { content: '📂 No artifacts found for this session.', components: [], ephemeral: true };
-        if (edit) await interaction.editReply(payload);
+        if (edit || interaction.deferred || interaction.replied) await interaction.editReply(payload);
         else await interaction.reply(payload);
         return;
     }
@@ -196,7 +219,7 @@ export async function sendArtifactPickerUI(
     const artifacts = artifactService.listArtifacts(conversationId);
     if (artifacts.length === 0) {
         const payload = { content: '📂 No artifacts found in this conversation.', components: [], ephemeral: true };
-        if (edit) await interaction.editReply(payload);
+        if (edit || interaction.deferred || interaction.replied) await interaction.editReply(payload);
         else await interaction.reply(payload);
         return;
     }
@@ -208,6 +231,6 @@ export async function sendArtifactPickerUI(
     const { embeds, components } = buildArtifactPickerUI(artifacts, conversationId, renderMode);
     
     const payload = { embeds, components, ephemeral: true };
-    if (edit) await interaction.editReply(payload);
+    if (edit || interaction.deferred || interaction.replied) await interaction.editReply(payload);
     else await interaction.reply(payload);
 }

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -112,6 +112,7 @@ jest.mock('better-sqlite3', () => {
     return jest.fn().mockImplementation(() => {
         return {
             exec: jest.fn(),
+            pragma: jest.fn().mockReturnValue([]),
             prepare: jest.fn().mockReturnValue({ run: jest.fn(), get: jest.fn(), all: jest.fn().mockReturnValue([]) }),
             close: jest.fn(),
         };

--- a/tests/database/artifactThreadRepository.test.ts
+++ b/tests/database/artifactThreadRepository.test.ts
@@ -1,0 +1,62 @@
+import Database from 'better-sqlite3';
+import { ArtifactThreadRepository } from '../../src/database/artifactThreadRepository';
+
+describe('ArtifactThreadRepository', () => {
+    let db: Database.Database;
+    let repo: ArtifactThreadRepository;
+
+    beforeEach(() => {
+        db = new Database(':memory:');
+        repo = new ArtifactThreadRepository(db);
+    });
+
+    afterEach(() => {
+        db.close();
+    });
+
+    describe('table initialization', () => {
+        it('creates the artifact_threads table on initialization with proper columns', () => {
+            const columns = db.prepare('PRAGMA table_info(artifact_threads)').all() as any[];
+            expect(columns).toHaveLength(4);
+            expect(columns.find(c => c.name === 'channel_id')).toBeDefined();
+            expect(columns.find(c => c.name === 'conversation_id')).toBeDefined();
+            expect(columns.find(c => c.name === 'filename')).toBeDefined();
+            expect(columns.find(c => c.name === 'thread_id')).toBeDefined();
+            
+            // Check primary key (cid = 1, 2, 3 indicates part of pk)
+            const pkColumns = columns.filter(c => c.pk > 0);
+            expect(pkColumns).toHaveLength(3);
+        });
+    });
+
+    describe('CRUD operations', () => {
+        it('can set and get a thread ID', () => {
+            repo.setThreadId('ch-1', 'conv-1', 'test.md', 'thread-1');
+            expect(repo.getThreadId('ch-1', 'conv-1', 'test.md')).toBe('thread-1');
+        });
+
+        it('returns null for non-existent thread', () => {
+            expect(repo.getThreadId('ch-1', 'conv-1', 'test.md')).toBeNull();
+        });
+
+        it('replaces existing thread ID when set again', () => {
+            repo.setThreadId('ch-1', 'conv-1', 'test.md', 'thread-1');
+            repo.setThreadId('ch-1', 'conv-1', 'test.md', 'thread-2');
+            expect(repo.getThreadId('ch-1', 'conv-1', 'test.md')).toBe('thread-2');
+        });
+
+        it('can delete a thread ID', () => {
+            repo.setThreadId('ch-1', 'conv-1', 'test.md', 'thread-1');
+            repo.deleteThreadId('ch-1', 'conv-1', 'test.md');
+            expect(repo.getThreadId('ch-1', 'conv-1', 'test.md')).toBeNull();
+        });
+
+        it('distinguishes between conversations in the same channel for the same filename', () => {
+            repo.setThreadId('ch-1', 'conv-1', 'test.md', 'thread-1');
+            repo.setThreadId('ch-1', 'conv-2', 'test.md', 'thread-2');
+            
+            expect(repo.getThreadId('ch-1', 'conv-1', 'test.md')).toBe('thread-1');
+            expect(repo.getThreadId('ch-1', 'conv-2', 'test.md')).toBe('thread-2');
+        });
+    });
+});

--- a/tests/services/artifactService.test.ts
+++ b/tests/services/artifactService.test.ts
@@ -1,0 +1,91 @@
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { ArtifactService, ArtifactInfo } from '../../src/services/artifactService';
+
+describe('ArtifactService', () => {
+    let tmpBrainPath: string;
+    let artifactService: ArtifactService;
+
+    beforeEach(() => {
+        tmpBrainPath = fs.mkdtempSync(path.join(os.tmpdir(), 'brain-test-'));
+        artifactService = new ArtifactService(tmpBrainPath);
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpBrainPath, { recursive: true, force: true });
+    });
+
+    describe('encodeSelectValue / decodeSelectValue', () => {
+        it('should round-trip encode and decode properly', () => {
+            const conversationId = '123e4567-e89b-12d3-a456-426614174000';
+            const filename = 'implementation_plan.md';
+            
+            const encoded = ArtifactService.encodeSelectValue(conversationId, filename);
+            // New format includes a 4-char hash, e.g. art_123e4567e89b_abcd_implementation_plan.md
+            expect(encoded).toMatch(/^art_123e4567e89b_[a-z0-9]{4}_implementation_plan\.md$/);
+
+            const artifacts: ArtifactInfo[] = [
+                {
+                    conversationId,
+                    filename,
+                    artifactType: 'ARTIFACT_TYPE_IMPLEMENTATION_PLAN',
+                    absolutePath: 'ignored'
+                }
+            ];
+
+            const decoded = artifactService.decodeSelectValue(encoded, artifacts);
+            expect(decoded).not.toBeNull();
+            expect(decoded?.conversationId).toBe(conversationId);
+            expect(decoded?.filename).toBe(filename);
+        });
+
+        it('should return null for unknown values', () => {
+            const decoded = artifactService.decodeSelectValue('art_unknown', []);
+            expect(decoded).toBeNull();
+        });
+    });
+
+    describe('listArtifacts', () => {
+        it('should list valid artifacts and sort by updatedAt descending', () => {
+            const conversationId = '00000000-0000-0000-0000-000000000000';
+            const convDir = path.join(tmpBrainPath, conversationId);
+            fs.mkdirSync(convDir, { recursive: true });
+
+            // Artifact 1: Oldest
+            fs.writeFileSync(path.join(convDir, 'plan1.md'), 'content1');
+            fs.writeFileSync(path.join(convDir, 'plan1.md.metadata.json'), JSON.stringify({
+                artifactType: 'ARTIFACT_TYPE_IMPLEMENTATION_PLAN',
+                updatedAt: '2023-01-01T10:00:00Z'
+            }));
+
+            // Artifact 2: Newest
+            fs.writeFileSync(path.join(convDir, 'plan2.md'), 'content2');
+            fs.writeFileSync(path.join(convDir, 'plan2.md.metadata.json'), JSON.stringify({
+                artifactType: 'ARTIFACT_TYPE_TASK',
+                updatedAt: '2023-01-01T12:00:00Z'
+            }));
+
+            // Ignored files
+            fs.writeFileSync(path.join(convDir, 'ignored.txt'), 'not md');
+            fs.writeFileSync(path.join(convDir, 'missing_meta.md'), 'no meta');
+
+            const artifacts = artifactService.listArtifacts(conversationId);
+            
+            expect(artifacts).toHaveLength(2);
+            // First should be plan2.md because it's newest
+            expect(artifacts[0].filename).toBe('plan2.md');
+            expect(artifacts[0].artifactType).toBe('ARTIFACT_TYPE_TASK');
+            
+            // Second should be plan1.md
+            expect(artifacts[1].filename).toBe('plan1.md');
+            expect(artifacts[1].artifactType).toBe('ARTIFACT_TYPE_IMPLEMENTATION_PLAN');
+        });
+
+        it('should return empty array if directory does not exist', () => {
+            const artifacts = artifactService.listArtifacts('non-existent-id');
+            expect(artifacts).toEqual([]);
+        });
+    });
+});


### PR DESCRIPTION
implements a comprehensive artifact management system for Discord, allowing users to browse, view, and organize Antigravity session artifacts directly within the chat interface.

✨ Core Features
📂 /artifacts Command: A new slash command that lets users browse markdown artifacts generated in Antigravity sessions.
🧠 Context-Aware Discovery: The bot automatically identifies the correct session by matching the Discord channel's session title, falling back to the most recent conversation if no match is found.
🧵 Persistent Artifact Threads: To keep the main chat clean, artifacts are rendered in dedicated, persistent threads (one thread per file).
🔄 Smart Thread Management: The bot remembers thread mappings, automatically unarchives threads when needed, and appends new content with visual spacers (─────────────────────────) and timestamps for easy tracking.
⚙️ User Rendering Preferences: Users can toggle between Thread (default) and Inline modes using interactive buttons. Preferences are persisted in the local SQLite database.
🛠️ Technical Summary
Artifact Service: Scans the brain directory for .md and .metadata.json files.
Database Layers:
ArtifactThreadRepository: Tracks (channel_id, filename) -> thread_id mappings.
UserPreferenceRepository: Stores per-user artifact_render_mode.
UI Components: Implemented a custom picker UI with StringSelectMenu for navigation and Button toggles for mode selection.
Robust Delivery: Handles large artifacts by splitting them into 2000-character chunks while maintaining formatting.
📁 Key Files Modified
src/services/artifactService.ts (New)
src/database/artifactThreadRepository.ts (New)
src/ui/artifactsUi.ts (New)
src/database/userPreferenceRepository.ts
src/events/interactionCreateHandler.ts
src/bot/index.ts
src/commands/registerSlashCommands.ts
🧪 Verification
Full build verified with npm run build.
Successfully tested artifact discovery, thread creation/reuse, and preference persistence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /artifacts command with an interactive picker (filename, type, summary, version, updated time) and help listing.
  * Toggleable render modes (thread vs inline) persisted per user (defaults to thread); picker includes render-mode toggle.
  * Artifact selection streams content into a thread or inline, creating/rehydrating threads when available and splitting long artifacts across messages.

* **Tests**
  * Added unit tests for artifact listing, encoding/decoding, and thread-mapping behavior.

* **Chores**
  * Added a developer launch script for local development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->