### PR TITLE
fix: upgrade artifact folder resolution with fuzzy keyword fallback

### DIFF
--- a/src/services/artifactService.ts
+++ b/src/services/artifactService.ts
@@ -193,8 +193,8 @@ export class ArtifactService {
         const cleanNeedleWords = needle.replace(/[^a-z0-9]/g, ' ').split(/\s+/).filter(w => w.length > 2 && !commonWords.has(w));
         const uniqueNeedleWords = Array.from(new Set(cleanNeedleWords));
         
-        // If query has multiple meaningful terms, require a stronger minimum score of 2.
-        const minScore = uniqueNeedleWords.length >= 2 ? 2 : 1;
+        // Require a stronger minimum score of 2 to prevent weak one-word matches.
+        const minScore = 2;
 
         for (const id of sortedIds) {
             const overviewPath = path.join(

--- a/src/services/artifactService.ts
+++ b/src/services/artifactService.ts
@@ -189,8 +189,12 @@ export class ArtifactService {
         let bestId: string | null = null;
         let bestScore = 0;
 
-        const cleanNeedle = needle.replace(/[^a-z0-9]/g, ' ').split(/\s+/).filter(w => w.length > 2);
         const commonWords = new Set(['the', 'and', 'for', 'with', 'from', 'this', 'that', 'fixing', 'adding', 'updating', 'project']);
+        const cleanNeedleWords = needle.replace(/[^a-z0-9]/g, ' ').split(/\s+/).filter(w => w.length > 2 && !commonWords.has(w));
+        const uniqueNeedleWords = Array.from(new Set(cleanNeedleWords));
+        
+        // If query has multiple meaningful terms, require a stronger minimum score of 2.
+        const minScore = uniqueNeedleWords.length >= 2 ? 2 : 1;
 
         for (const id of sortedIds) {
             const overviewPath = path.join(
@@ -214,10 +218,11 @@ export class ArtifactService {
                         return id; // Exact match takes precedence
                     }
 
+                    const headerTokens = new Set(header.replace(/[^a-z0-9]/g, ' ').split(/\s+/));
+                    
                     let score = 0;
-                    for (const word of cleanNeedle) {
-                        if (commonWords.has(word)) continue;
-                        if (header.includes(word)) score++;
+                    for (const word of uniqueNeedleWords) {
+                        if (headerTokens.has(word)) score++;
                     }
                     if (score > bestScore) {
                         bestScore = score;
@@ -231,7 +236,7 @@ export class ArtifactService {
             }
         }
 
-        if (bestScore > 0) {
+        if (bestScore >= minScore) {
             return bestId;
         }
 

--- a/src/services/artifactService.ts
+++ b/src/services/artifactService.ts
@@ -165,6 +165,7 @@ export class ArtifactService {
 
     /**
      * Try to find a conversation UUID whose overview.txt contains the given session title.
+     * Uses an exact match first, falling back to keyword overlap scoring.
      * Returns the UUID or null if not found.
      */
     findConversationByTitle(title: string): string | null {
@@ -185,6 +186,12 @@ export class ArtifactService {
             .sort((a, b) => b.mtime - a.mtime)
             .map(x => x.id);
 
+        let bestId: string | null = null;
+        let bestScore = 0;
+
+        const cleanNeedle = needle.replace(/[^a-z0-9]/g, ' ').split(/\s+/).filter(w => w.length > 2);
+        const commonWords = new Set(['the', 'and', 'for', 'with', 'from', 'this', 'that', 'fixing', 'adding', 'updating', 'project']);
+
         for (const id of sortedIds) {
             const overviewPath = path.join(
                 this.brainBasePath,
@@ -202,8 +209,19 @@ export class ArtifactService {
                     const buf = Buffer.alloc(4096);
                     const bytesRead = fs.readSync(fd, buf, 0, buf.length, 0);
                     const header = buf.slice(0, bytesRead).toString('utf-8').toLowerCase();
+                    
                     if (header.includes(needle)) {
-                        return id;
+                        return id; // Exact match takes precedence
+                    }
+
+                    let score = 0;
+                    for (const word of cleanNeedle) {
+                        if (commonWords.has(word)) continue;
+                        if (header.includes(word)) score++;
+                    }
+                    if (score > bestScore) {
+                        bestScore = score;
+                        bestId = id;
                     }
                 } finally {
                     if (fd !== null) fs.closeSync(fd);
@@ -212,6 +230,11 @@ export class ArtifactService {
                 // Skip unreadable files
             }
         }
+
+        if (bestScore > 0) {
+            return bestId;
+        }
+
         return null;
     }
 

--- a/src/services/artifactService.ts
+++ b/src/services/artifactService.ts
@@ -69,6 +69,9 @@ export function artifactTypeLabel(type: ArtifactType): string {
 // ArtifactService
 // ---------------------------------------------------------------------------
 
+/** Common words to ignore when scoring fuzzy title matches */
+const COMMON_WORDS = new Set(['the', 'and', 'for', 'with', 'from', 'this', 'that']);
+
 export class ArtifactService {
     private readonly brainBasePath: string;
 
@@ -189,8 +192,17 @@ export class ArtifactService {
         let bestId: string | null = null;
         let bestScore = 0;
 
-        const commonWords = new Set(['the', 'and', 'for', 'with', 'from', 'this', 'that', 'fixing', 'adding', 'updating', 'project']);
-        const cleanNeedleWords = needle.replace(/[^a-z0-9]/g, ' ').split(/\s+/).filter(w => w.length > 2 && !commonWords.has(w));
+        // Unicode-aware split to support CJK. Preserve CJK characters (len 1) but filter short Latin words.
+        const cleanNeedleWords = needle
+            .replace(/[^\p{L}\p{N}]+/gu, ' ')
+            .split(/\s+/)
+            .filter(w => {
+                if (COMMON_WORDS.has(w)) return false;
+                // Allow CJK characters (Scripts: Han, Hiragana, Katakana, Hangul) even if length 1.
+                const isCJK = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(w);
+                return isCJK || w.length > 2;
+            });
+            
         const uniqueNeedleWords = Array.from(new Set(cleanNeedleWords));
         
         // Require a stronger minimum score of 2 to prevent weak one-word matches.
@@ -218,7 +230,8 @@ export class ArtifactService {
                         return id; // Exact match takes precedence
                     }
 
-                    const headerTokens = new Set(header.replace(/[^a-z0-9]/g, ' ').split(/\s+/));
+                    // Use same Unicode-aware split for header tokens
+                    const headerTokens = new Set(header.replace(/[^\p{L}\p{N}]+/gu, ' ').split(/\s+/));
                     
                     let score = 0;
                     for (const word of uniqueNeedleWords) {

--- a/tests/services/artifactService.test.ts
+++ b/tests/services/artifactService.test.ts
@@ -88,4 +88,57 @@ describe('ArtifactService', () => {
             expect(artifacts).toEqual([]);
         });
     });
+    describe('findConversationByTitle', () => {
+        const conversationId = '00000000-0000-0000-0000-000000000001';
+        let convDir: string;
+        let logDir: string;
+
+        beforeEach(() => {
+            convDir = path.join(tmpBrainPath, conversationId);
+            logDir = path.join(convDir, '.system_generated', 'logs');
+            fs.mkdirSync(logDir, { recursive: true });
+        });
+
+        it('should find by exact match', () => {
+            fs.writeFileSync(path.join(logDir, 'overview.txt'), 'Session Title: Fix Deployment Bug');
+            const found = artifactService.findConversationByTitle('Fix Deployment Bug');
+            expect(found).toBe(conversationId);
+        });
+
+        it('should find by fuzzy match with high score', () => {
+            fs.writeFileSync(path.join(logDir, 'overview.txt'), 'Context: fixing memory leak in production');
+            // "memory" and "leak" are meaningful (score 2). "fixing" is no longer a stopword.
+            const found = artifactService.findConversationByTitle('Memory Leak Issue');
+            expect(found).toBe(conversationId);
+        });
+
+        it('should reject fuzzy match with low score (minScore=2)', () => {
+            fs.writeFileSync(path.join(logDir, 'overview.txt'), 'Context: fix production bug');
+            // only "production" matches. score 1 < minScore 2.
+            const found = artifactService.findConversationByTitle('Production Release');
+            expect(found).toBeNull();
+        });
+
+        it('should ignore common stopwords in fuzzy match', () => {
+            fs.writeFileSync(path.join(logDir, 'overview.txt'), 'Context: the production for this that');
+            // "the", "for", "this", "that" are stopwords. "production" matches but score is 1.
+            const found = artifactService.findConversationByTitle('The Production System');
+            expect(found).toBeNull();
+        });
+
+        it('should support CJK characters in fuzzy match', () => {
+            fs.writeFileSync(path.join(logDir, 'overview.txt'), 'Session: ログイン機能の修正 (Login fix)');
+            // "ログイン" (login), "機能" (function), "修正" (fix). 
+            // Matching "ログイン" and "機能" should score 2.
+            const found = artifactService.findConversationByTitle('ログイン機能');
+            expect(found).toBe(conversationId);
+        });
+        
+        it('should support Chinese characters', () => {
+            fs.writeFileSync(path.join(logDir, 'overview.txt'), 'Session: 修复部署错误');
+            // "修复" (fix), "部署" (deploy), "错误" (error).
+            const found = artifactService.findConversationByTitle('修复部署');
+            expect(found).toBe(conversationId);
+        });
+    });
 });


### PR DESCRIPTION
Resolves an ongoing heuristic issue in the codebase where the \/artifacts\ command failed to correctly locate associated chat sessions due to overly strict verbatim matching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation search: prefers exact phrase matches, then falls back to a smarter best-match that analyzes and scores query keywords with a minimum score threshold to reduce false positives.
* **Tests**
  * Added tests covering exact matches, fuzzy/high-score matches, low-score rejection, stopword-only cases, and non-Latin (CJK) queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->