### PR TITLE
fix: update DOM selectors and stop-button detection for Antigravity 1.23.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ coverage/
 
 # npm pack artifacts
 *.tgz
+
+# TypeScript build cache
+tsconfig.tsbuildinfo

--- a/docs/ANTIGRAVITY_DOM_SELECTORS.md
+++ b/docs/ANTIGRAVITY_DOM_SELECTORS.md
@@ -2,7 +2,7 @@
 
 Central reference for all CSS selectors and DOM structures used to interact with the Antigravity (Windsurf/Cascade) UI via CDP.
 
-> **Last verified**: 2026-04 (model picker updated for Antigravity v1.107.0+; other selectors verified 2025-02)
+> **Last verified**: 2026-05 (added .text-ide-message-block-bot-color and UI exclusions for Antigravity v0.3.0+; previous update 2026-04)
 
 ---
 
@@ -64,9 +64,10 @@ The assistant's response body, rendered with markdown formatting.
 
 | Score | Selector | Status | File |
 |-------|----------|--------|------|
+| 11 | `.text-ide-message-block-bot-color` | **Verified (v0.3.0+)** | `responseMonitor.ts`, `assistantDomExtractor.ts` |
 | 10 | `.rendered-markdown` | **Verified** | `responseMonitor.ts`, `assistantDomExtractor.ts` |
 | 9 | `.leading-relaxed.select-text` | **Verified** | `responseMonitor.ts`, `planningDetector.ts`, `assistantDomExtractor.ts` |
-| 8 | `.flex.flex-col.gap-y-3` | Unverified — generic | `responseMonitor.ts`, `assistantDomExtractor.ts` |
+| 8 | `.flex.flex-col.gap-y-3` | **Deprecated** — removed from primary extraction paths (AG 1.23.x) | — |
 | 7 | `[data-message-author-role="assistant"]` | **NOT FOUND** in DOM | `responseMonitor.ts`, `assistantDomExtractor.ts` |
 | 6 | `[data-message-role="assistant"]` | **NOT FOUND** in DOM | `responseMonitor.ts`, `assistantDomExtractor.ts` |
 | 5 | `[class*="assistant-message"]` | **NOT FOUND** in DOM | `responseMonitor.ts`, `assistantDomExtractor.ts` |
@@ -74,7 +75,7 @@ The assistant's response body, rendered with markdown formatting.
 | 3 | `[class*="markdown-body"]` | **NOT FOUND** in DOM | `responseMonitor.ts`, `assistantDomExtractor.ts` |
 | 2 | `.prose` | Unverified | `responseMonitor.ts`, `assistantDomExtractor.ts` |
 
-> **Note**: Selectors scored 3-7 appear to be inherited from ChatGPT/generic patterns and do **not** exist in Antigravity's DOM. They are harmless (scored lower, never matched) but add noise. The top selectors (`.rendered-markdown`, `.leading-relaxed.select-text`) are the ones that actually match.
+> **Note**: Selectors scored 3-7 appear to be inherited from ChatGPT/generic patterns and do **not** exist in Antigravity's DOM. They are harmless (scored lower, never matched) but add noise. The top selectors (`.text-ide-message-block-bot-color`, `.rendered-markdown`, `.leading-relaxed.select-text`) are the ones that actually match.
 
 ### Exclusion Containers
 
@@ -86,6 +87,10 @@ Nodes inside these containers are skipped during response extraction:
 | `[class*="feedback"], footer` | Good/Bad feedback buttons |
 | `.notify-user-container` | Planning mode notification |
 | `[role="dialog"]` | Modal dialogs (error popup, etc.) |
+| `form` | Chat input area (to avoid UI leakage) |
+| `textarea` | Chat input field |
+| Text containing `Ask anything...` | Chat input placeholder |
+| Text containing `0 Files With Changes` | Git context panel |
 
 ---
 

--- a/src/services/assistantDomExtractor.ts
+++ b/src/services/assistantDomExtractor.ts
@@ -14,17 +14,31 @@ import { htmlToDiscordMarkdown } from '../utils/htmlToDiscordMarkdown';
 // Types
 // ---------------------------------------------------------------------------
 
+/**
+ * Represents a single extracted segment from the assistant's response DOM.
+ */
 export interface AssistantDomSegment {
+    /** The type of content: assistant text, thinking trace, tool interaction, etc. */
     kind: 'assistant-body' | 'thinking' | 'tool-call' | 'tool-result' | 'feedback';
+    /** The content (often HTML for body, plain text for logs) */
     text: string;
+    /** The role is always 'assistant' for these segments */
     role: 'assistant';
+    /** Index of the message in the conversation thread */
     messageIndex: number;
+    /** CSS selector path to the element for debugging */
     domPath: string;
 }
 
+/**
+ * The raw payload returned from the browser-side extraction script.
+ */
 export interface AssistantDomSegmentPayload {
+    /** Identifier to verify the payload structure */
     source: 'dom-structured';
+    /** Timestamp when the extraction occurred */
     extractedAt: number;
+    /** Array of segments found in the DOM */
     segments: AssistantDomSegment[];
 }
 
@@ -35,6 +49,8 @@ export interface ClassifyResult {
     diagnostics: {
         source: 'dom-structured' | 'legacy-fallback';
         segmentCounts: Record<string, number>;
+        allFingerprints: string[];
+        totalSegments: number;
         fallbackReason?: string;
     };
 }
@@ -58,6 +74,8 @@ export function classifyAssistantSegments(payload: unknown): ClassifyResult {
             diagnostics: {
                 source: 'legacy-fallback',
                 segmentCounts: {},
+                allFingerprints: [],
+                totalSegments: 0,
                 fallbackReason: 'invalid-payload',
             },
         };
@@ -70,6 +88,7 @@ export function classifyAssistantSegments(payload: unknown): ClassifyResult {
     const activityLines: string[] = [];
     const feedbackTexts: string[] = [];
     const segmentCounts: Record<string, number> = {};
+    const allFingerprints: string[] = [];
 
     for (const seg of segments) {
         segmentCounts[seg.kind] = (segmentCounts[seg.kind] ?? 0) + 1;
@@ -78,6 +97,8 @@ export function classifyAssistantSegments(payload: unknown): ClassifyResult {
             case 'assistant-body':
                 if (seg.text && seg.text.trim()) {
                     bodyTexts.push(seg.text);
+                    const fp = seg.text.length + ':' + seg.text.slice(0, 50) + ':' + seg.text.slice(-50);
+                    allFingerprints.push(fp);
                 }
                 break;
             case 'thinking':
@@ -95,9 +116,10 @@ export function classifyAssistantSegments(payload: unknown): ClassifyResult {
         }
     }
 
-    // Join body segments and apply HTML-to-Markdown conversion
-    const rawBody = bodyTexts.join('\n\n');
-    const finalOutputText = htmlToDiscordMarkdown(rawBody);
+    // Concatenate all body segments — the CDP script may yield multiple nodes
+    // (streaming partial + final, multi-block markdown, etc.)
+    const lastBody = bodyTexts.join('\n\n') || '';
+    const finalOutputText = htmlToDiscordMarkdown(lastBody);
 
     return {
         finalOutputText,
@@ -106,6 +128,8 @@ export function classifyAssistantSegments(payload: unknown): ClassifyResult {
         diagnostics: {
             source: 'dom-structured',
             segmentCounts,
+            allFingerprints,
+            totalSegments: segments.length,
         },
     };
 }
@@ -136,9 +160,9 @@ export function extractAssistantSegmentsPayloadScript(): string {
 
     // Same selectors as RESPONSE_TEXT — ordered by specificity
     var selectors = [
+        '.text-ide-message-block-bot-color',
         '.rendered-markdown',
         '.leading-relaxed.select-text',
-        '.flex.flex-col.gap-y-3',
         '[data-message-author-role="assistant"]',
         '[data-message-role="assistant"]',
         '[class*="assistant-message"]',
@@ -174,6 +198,12 @@ export function extractAssistantSegmentsPayloadScript(): string {
         if (node.closest('[class*="feedback"], footer')) return true;
         if (node.closest('.notify-user-container')) return true;
         if (node.closest('[role="dialog"]')) return true;
+        if (node.closest('form')) return true;
+        if (node.closest('[data-message-author-role="user"], [data-message-role="user"]')) return true;
+        if (node.querySelector('textarea') || node.closest('textarea')) return true;
+        var text = (node.innerText || '').toLowerCase();
+        if (text.includes('ask anything, @ to mention')) return true;
+        if (text.includes('0 files with changes')) return true;
         return false;
     };
 
@@ -257,10 +287,43 @@ export function extractAssistantSegmentsPayloadScript(): string {
                 text: bodyHtml,
                 role: 'assistant',
                 messageIndex: 0,
-                domPath: 'multi-selector'
+                domPath: 'article:nth(' + i + ')'
             });
             bodyFound = true;
-            break; // Only take the last (most recent) output node
+            break; // Only capture the single latest assistant message
+        }
+    }
+
+    // Pass 3: Thinking logs and tool calls
+    var thinkingNodes = scope.querySelectorAll('[class*="thinking"], [class*="thought"]');
+    for (var j = 0; j < thinkingNodes.length; j++) {
+        var tnode = thinkingNodes[j];
+        if (isInsideExcludedContainer(tnode)) continue;
+        var ttext = (tnode.innerText || tnode.textContent || '').trim();
+        if (ttext) {
+            segments.push({
+                kind: 'thinking',
+                text: ttext,
+                role: 'assistant',
+                messageIndex: 0,
+                domPath: 'thinking:nth(' + j + ')'
+            });
+        }
+    }
+
+    var toolNodes = scope.querySelectorAll('[class*="tool-interaction"], [class*="call-summary"]');
+    for (var k = 0; k < toolNodes.length; k++) {
+        var knode = toolNodes[k];
+        if (isInsideExcludedContainer(knode)) continue;
+        var ktext = (knode.innerText || knode.textContent || '').trim();
+        if (ktext) {
+            segments.push({
+                kind: 'tool-call',
+                text: ktext,
+                role: 'assistant',
+                messageIndex: 0,
+                domPath: 'tool:nth(' + k + ')'
+            });
         }
     }
 

--- a/src/services/cdpBridgeManager.ts
+++ b/src/services/cdpBridgeManager.ts
@@ -34,6 +34,7 @@ export interface CdpBridge {
     approvalChannelBySession: Map<string, PlatformChannel>;
     /** Channel-scoped preferred Antigravity account selection. */
     selectedAccountByChannel?: Map<string, string>;
+    cdpHost: string;
 }
 
 const APPROVE_ACTION_PREFIX = 'approve_action';
@@ -281,6 +282,7 @@ export function initCdpBridge(
     autoApproveDefault: boolean,
     accountPorts: Record<string, number> = {},
     accountUserDataDirs: Record<string, string> = {},
+    cdpHost: string = '127.0.0.1',
 ): CdpBridge {
     const pool = new CdpConnectionPool({
         accountPorts,
@@ -290,6 +292,7 @@ export function initCdpBridge(
         // Reconnection is triggered when the next chat/template message is sent.
         maxReconnectAttempts: 0,
         reconnectDelayMs: 3000,
+        cdpHost,
     });
 
     const quota = new QuotaService();
@@ -304,6 +307,7 @@ export function initCdpBridge(
         approvalChannelByWorkspace: new Map(),
         approvalChannelBySession: new Map(),
         selectedAccountByChannel: new Map(),
+        cdpHost,
     };
 }
 
@@ -648,6 +652,14 @@ export function ensureUserMessageDetector(
 ): void {
     const existing = bridge.pool.getUserMessageDetector(projectName, accountName);
     if (existing && existing.isActive()) {
+        // Remove only the listeners we may have previously attached via this
+        // code path.  Using removeAllListeners('message') would wipe any
+        // subscriber added elsewhere, so we track and swap explicitly.
+        const prevListener = (existing as any).__userMsgHandler;
+        if (prevListener) {
+            existing.off('message', prevListener);
+        }
+        (existing as any).__userMsgHandler = onUserMessage;
         existing.on('message', onUserMessage);
         return;
     }
@@ -657,6 +669,7 @@ export function ensureUserMessageDetector(
         pollIntervalMs: 2000,
     });
     
+    (detector as any).__userMsgHandler = onUserMessage;
     detector.on('message', onUserMessage);
     detector.start();
     bridge.pool.registerUserMessageDetector(projectName, detector, accountName);

--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -16,6 +16,7 @@ export interface CdpServiceOptions {
     accountName?: string;
     accountPorts?: Record<string, number>;
     accountUserDataDirs?: Record<string, string>;
+    cdpHost?: string;
 }
 
 export interface CdpContext {
@@ -76,11 +77,15 @@ const WORKSPACE_STATE_SCRIPT = `(() => {
 
     let isGenerating = false;
     for (const scope of scopes) {
-        const stopEl = scope.querySelector('[data-tooltip-id="input-send-button-cancel-tooltip"]');
-        if (stopEl) {
-            isGenerating = true;
-            break;
+        const els = scope.querySelectorAll('[data-tooltip-id="input-send-button-cancel-tooltip"]');
+        for (let i = 0; i < els.length; i++) {
+            const style = window.getComputedStyle(els[i]);
+            if (style.display !== 'none' && style.visibility !== 'hidden' && parseFloat(style.opacity) > 0) {
+                isGenerating = true;
+                break;
+            }
         }
+        if (isGenerating) break;
     }
 
     if (!isGenerating) {
@@ -159,6 +164,7 @@ export class CdpService extends EventEmitter {
     /** Workspace switching flag (suppresses disconnected event) */
     private isSwitchingWorkspace: boolean = false;
     private accountName: string;
+    private cdpHost: string;
     private accountPorts: Record<string, number>;
     private accountUserDataDirs: Record<string, string>;
 
@@ -171,6 +177,7 @@ export class CdpService extends EventEmitter {
         if (options.cdpCallTimeout) this.cdpCallTimeout = options.cdpCallTimeout;
         this.maxReconnectAttempts = options.maxReconnectAttempts ?? 3;
         this.reconnectDelayMs = options.reconnectDelayMs ?? 2000;
+        this.cdpHost = options.cdpHost ?? '127.0.0.1';
     }
 
     private resolveAccountPorts(accountName: string): number[] {
@@ -205,7 +212,7 @@ export class CdpService extends EventEmitter {
         let allPages: any[] = [];
         for (const port of this.ports) {
             try {
-                const list = await this.getJson(`http://127.0.0.1:${port}/json/list`);
+                const list = await this.getJson(`http://${this.cdpHost}:${port}/json/list`);
                 allPages.push(...list);
             } catch (e) {
                 // Ignore port not found
@@ -522,7 +529,7 @@ export class CdpService extends EventEmitter {
 
         for (const port of this.ports) {
             try {
-                const list = await this.getJson(`http://127.0.0.1:${port}/json/list`);
+                const list = await this.getJson(`http://${this.cdpHost}:${port}/json/list`);
                 pages.push(...list);
                 // Prioritize recording ports that contain workbench pages
                 const hasWorkbench = list.some((t: any) => t.url?.includes('workbench'));
@@ -633,8 +640,8 @@ export class CdpService extends EventEmitter {
                     return true;
                 }
 
-                // If title is "Untitled (Workspace)", verify by folder path
-                if (normalizedLiveTitle.includes('untitled') && workspacePath) {
+                // If title match failed, or if it's "Untitled", verify by folder path
+                if (workspacePath) {
                     const folderMatch = await this.probeWorkspaceFolderPath(projectName, workspacePath);
                     if (folderMatch) {
                         return true;
@@ -813,7 +820,7 @@ export class CdpService extends EventEmitter {
         let knownPageIds: Set<string> = new Set();
         for (const port of this.ports) {
             try {
-                const preLaunchPages = await this.getJson(`http://127.0.0.1:${port}/json/list`);
+                const preLaunchPages = await this.getJson(`http://${this.cdpHost}:${port}/json/list`);
                 preLaunchPages.forEach((p: any) => {
                     if (p.id) knownPageIds.add(p.id);
                 });
@@ -828,7 +835,7 @@ export class CdpService extends EventEmitter {
             let pages: any[] = [];
             for (const port of this.ports) {
                 try {
-                    const list = await this.getJson(`http://127.0.0.1:${port}/json/list`);
+                    const list = await this.getJson(`http://${this.cdpHost}:${port}/json/list`);
                     pages.push(...list);
                 } catch {
                     // Next port
@@ -885,7 +892,7 @@ export class CdpService extends EventEmitter {
         let allPages: any[] = [];
         for (const port of this.ports) {
             try {
-                const list = await this.getJson(`http://127.0.0.1:${port}/json/list`);
+                const list = await this.getJson(`http://${this.cdpHost}:${port}/json/list`);
                 allPages.push(...list);
             } catch {
                 // port not responding
@@ -1143,7 +1150,7 @@ export class CdpService extends EventEmitter {
                 let stillOpen = false;
                 for (const port of this.ports) {
                     try {
-                        const list = await this.getJson(`http://127.0.0.1:${port}/json/list`);
+                        const list = await this.getJson(`http://${this.cdpHost}:${port}/json/list`);
                         if (list.some((page: any) => page?.id === closingTargetId)) {
                             stillOpen = true;
                             break;

--- a/src/services/responseMonitor.ts
+++ b/src/services/responseMonitor.ts
@@ -17,9 +17,9 @@ export const RESPONSE_SELECTORS = {
         const scopes = [panel, document].filter(Boolean);
 
         const selectors = [
+            { sel: '.text-ide-message-block-bot-color', score: 11 },
             { sel: '.rendered-markdown', score: 10 },
             { sel: '.leading-relaxed.select-text', score: 9 },
-            { sel: '.flex.flex-col.gap-y-3', score: 8 },
             { sel: '[data-message-author-role="assistant"]', score: 7 },
             { sel: '[data-message-role="assistant"]', score: 6 },
             { sel: '[class*="assistant-message"]', score: 5 },
@@ -49,6 +49,12 @@ export const RESPONSE_SELECTORS = {
             if (node.closest('[class*="feedback"], footer')) return true;
             if (node.closest('.notify-user-container')) return true;
             if (node.closest('[role="dialog"]')) return true;
+            if (node.closest('form')) return true;
+            if (node.closest('[data-message-author-role="user"], [data-message-role="user"]')) return true;
+            if (node.querySelector('textarea') || node.closest('textarea')) return true;
+            var text = (node.innerText || '').toLowerCase();
+            if (text.includes('ask anything, @ to mention')) return true;
+            if (text.includes('0 files with changes')) return true;
             return false;
         };
 
@@ -101,8 +107,16 @@ export const RESPONSE_SELECTORS = {
         const scopes = [panel, document].filter(Boolean);
 
         for (const scope of scopes) {
-            const el = scope.querySelector('[data-tooltip-id="input-send-button-cancel-tooltip"]');
-            if (el) return { isGenerating: true };
+            const els = scope.querySelectorAll('[data-tooltip-id="input-send-button-cancel-tooltip"]');
+            for (let i = 0; i < els.length; i++) {
+                const el = els[i];
+                if (el.offsetWidth > 0 || el.offsetHeight > 0 || el.getClientRects().length > 0) {
+                    const style = window.getComputedStyle(el);
+                    if (style.display !== 'none' && style.visibility !== 'hidden' && parseFloat(style.opacity) > 0) {
+                        return { isGenerating: true };
+                    }
+                }
+            }
         }
 
         const normalize = (value) => (value || '').toLowerCase().replace(/\\s+/g, ' ').trim();
@@ -142,10 +156,16 @@ export const RESPONSE_SELECTORS = {
         const scopes = [panel, document].filter(Boolean);
 
         for (const scope of scopes) {
-            const el = scope.querySelector('[data-tooltip-id="input-send-button-cancel-tooltip"]');
-            if (el && typeof el.click === 'function') {
-                el.click();
-                return { ok: true, method: 'tooltip-id' };
+            const els = scope.querySelectorAll('[data-tooltip-id="input-send-button-cancel-tooltip"]');
+            for (let i = 0; i < els.length; i++) {
+                const el = els[i];
+                if (el && typeof el.click === 'function') {
+                    const style = window.getComputedStyle(el);
+                    if (style.display !== 'none' && style.visibility !== 'hidden' && parseFloat(style.opacity) > 0) {
+                        el.click();
+                        return { ok: true, method: 'tooltip-id' };
+                    }
+                }
             }
         }
 
@@ -187,9 +207,9 @@ export const RESPONSE_SELECTORS = {
         const scopes = [panel, document].filter(Boolean);
 
         const selectors = [
+            { sel: '.text-ide-message-block-bot-color', score: 11 },
             { sel: '.rendered-markdown', score: 10 },
             { sel: '.leading-relaxed.select-text', score: 9 },
-            { sel: '.flex.flex-col.gap-y-3', score: 8 },
             { sel: '[data-message-author-role="assistant"]', score: 7 },
             { sel: '[data-message-role="assistant"]', score: 6 },
             { sel: '[class*="assistant-message"]', score: 5 },
@@ -217,6 +237,12 @@ export const RESPONSE_SELECTORS = {
             if (node.closest('[class*="feedback"], footer')) return true;
             if (node.closest('.notify-user-container')) return true;
             if (node.closest('[role="dialog"]')) return true;
+            if (node.closest('form')) return true;
+            if (node.closest('[data-message-author-role="user"], [data-message-role="user"]')) return true;
+            if (node.querySelector('textarea') || node.closest('textarea')) return true;
+            var text = (node.innerText || '').toLowerCase();
+            if (text.includes('ask anything, @ to mention')) return true;
+            if (text.includes('0 files with changes')) return true;
             return false;
         };
         const looksLikeToolOutput = (text) => {
@@ -273,9 +299,9 @@ export const RESPONSE_SELECTORS = {
         const scopes = [panel, document].filter(Boolean);
 
         const selectors = [
+            { sel: '.text-ide-message-block-bot-color', score: 11 },
             { sel: '.rendered-markdown', score: 10 },
             { sel: '.leading-relaxed.select-text', score: 9 },
-            { sel: '.flex.flex-col.gap-y-3', score: 8 },
             { sel: '[data-message-author-role="assistant"]', score: 7 },
             { sel: '[data-message-role="assistant"]', score: 6 },
             { sel: '[class*="assistant-message"]', score: 5 },
@@ -310,6 +336,12 @@ export const RESPONSE_SELECTORS = {
             if (node.closest('[class*="feedback"], footer')) return true;
             if (node.closest('.notify-user-container')) return true;
             if (node.closest('[role="dialog"]')) return true;
+            if (node.closest('form')) return true;
+            if (node.closest('[data-message-author-role="user"], [data-message-role="user"]')) return true;
+            if (node.querySelector('textarea') || node.closest('textarea')) return true;
+            var text = (node.innerText || '').toLowerCase();
+            if (text.includes('ask anything, @ to mention')) return true;
+            if (text.includes('0 files with changes')) return true;
             return false;
         };
 

--- a/src/services/userMessageDetector.ts
+++ b/src/services/userMessageDetector.ts
@@ -37,38 +37,31 @@ const DETECT_USER_MESSAGE_SCRIPT = `(() => {
     const panel = document.querySelector('.antigravity-agent-side-panel');
     const scope = panel || document;
 
-    // Strategy A (primary): Query .whitespace-pre-wrap elements directly inside
-    // user bubble containers. This avoids the parent-container problem where
-    // querySelectorAll matches a wrapper that contains multiple bubbles.
-    const textEls = scope.querySelectorAll(
-        '[class*="bg-gray-500/15"][class*="select-text"] .whitespace-pre-wrap'
-    );
+    const bubbles = Array.from(scope.querySelectorAll('.bg-input.p-2'));
+    const userBubbles = bubbles.filter(el => {
+        if (el.closest('.text-ide-message-block-bot-color')) return false;
+        if (el.closest('.rendered-markdown, .prose')) return false;
+        if (el.closest('[data-message-author-role="assistant"], [data-message-role="assistant"]')) return false;
+        return !!el.querySelector('.whitespace-pre-wrap');
+    });
 
-    if (textEls.length > 0) {
-        const lastTextEl = textEls[textEls.length - 1];
-        const text = (lastTextEl.textContent || '').trim();
-        if (text.length > 0) return { text };
+    if (userBubbles.length > 0) {
+        const lastBubble = userBubbles[userBubbles.length - 1];
+        // Surgical extraction: only the content of the message div
+        const textEl = lastBubble.querySelector('.whitespace-pre-wrap');
+        if (textEl) {
+            // Clone to strip buttons without affecting the real UI
+            const clone = textEl.cloneNode(true);
+            const buttons = clone.querySelectorAll('button, [role="button"]');
+            buttons.forEach(b => b.remove());
+            
+            let text = (clone.textContent || '').trim();
+            // Final safety strip
+            text = text.replace(/\\s*(?:Undo|撤銷|撤销|元に戻す)\\s*$/i, '').trim();
+            if (text.length > 0) return { text };
+        }
     }
-
-    // Strategy B (fallback): Find individual bubble containers, filtering out
-    // any element that itself contains nested bubble elements (i.e., a parent wrapper).
-    const userBubbles = Array.from(scope.querySelectorAll(
-        '[class*="bg-gray-500/15"][class*="rounded-lg"][class*="select-text"]'
-    )).filter(el => !el.querySelector('[class*="bg-gray-500/15"][class*="select-text"]'));
-
-    if (userBubbles.length === 0) return null;
-
-    const lastBubble = userBubbles[userBubbles.length - 1];
-    const textEl = lastBubble.querySelector('.whitespace-pre-wrap')
-        || lastBubble.querySelector('[style*="word-break"]');
-
-    const text = textEl
-        ? (textEl.textContent || '').trim()
-        : (lastBubble.textContent || '').trim();
-
-    if (!text || text.length < 1) return null;
-
-    return { text };
+    return null;
 })()`;
 
 /**
@@ -103,6 +96,8 @@ export class UserMessageDetector extends EventEmitter {
     /** Set of all previously detected message hashes (defense-in-depth dedup) */
     private readonly seenHashes = new Set<string>();
     private static readonly MAX_SEEN_HASHES = 50;
+    /** The actual text of the last emitted message (extra safety dedup) */
+    private lastSentText: string | null = null;
     /** True during the first poll — seeds existing DOM state without firing callback */
     private isPriming: boolean = false;
 
@@ -125,11 +120,11 @@ export class UserMessageDetector extends EventEmitter {
         }, 60000);
     }
 
-    /** Start monitoring. The first poll seeds the current DOM state without firing the callback. */
     start(): void {
         if (this.isRunning) return;
         this.isRunning = true;
         this.lastDetectedHash = null;
+        this.lastSentText = null;
         this.seenHashes.clear();
         this.isPriming = true;
         // echoHashes are intentionally NOT cleared — they have their own 60s TTL
@@ -233,7 +228,14 @@ export class UserMessageDetector extends EventEmitter {
                     return;
                 }
 
+                if (info.text === this.lastSentText) {
+                    logger.debug(`[UserMessageDetector] lastSentText match, skipping: "${preview}..."`);
+                    this.lastDetectedHash = hash;
+                    return;
+                }
+
                 this.lastDetectedHash = hash;
+                this.lastSentText = info.text;
                 this.addToSeenHashes(hash);
                 logger.debug(`[UserMessageDetector] New message detected: "${preview}..."`);
                 this.emit('message', info);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -16,6 +16,7 @@ export interface AppConfig {
     autoApproveFileEdits: boolean;
     logLevel: LogLevel;
     extractionMode: ExtractionMode;
+    cdpHost: string;
     /** Named Antigravity instances mapped to CDP ports and optional user-data-dir. */
     antigravityAccounts: AntigravityAccountConfig[];
     /** Telegram Bot Token (optional — required when 'telegram' is in platforms). */

--- a/src/utils/configLoader.ts
+++ b/src/utils/configLoader.ts
@@ -36,6 +36,7 @@ export interface PersistedConfig {
     platforms?: PlatformType[];
     responseTimeoutMs?: number;
     antigravityAccounts?: string | AntigravityAccountConfig[];
+    cdpHost?: string;
 }
 
 export interface AntigravityAccountConfig {
@@ -142,6 +143,9 @@ function mergeConfig(persisted: PersistedConfig): AppConfig {
     const telegramToken = process.env.TELEGRAM_BOT_TOKEN ?? persisted.telegramToken ?? undefined;
     const telegramAllowedUserIds = resolveTelegramAllowedUserIds(persisted);
 
+    const rawCdpHost = (process.env.CDP_HOST ?? persisted.cdpHost ?? '').trim();
+    const cdpHost = rawCdpHost || '127.0.0.1';
+
     if (platforms.includes('telegram') && !telegramToken) {
         throw new Error(
             'TELEGRAM_BOT_TOKEN is required when platforms include "telegram"',
@@ -162,6 +166,7 @@ function mergeConfig(persisted: PersistedConfig): AppConfig {
         telegramToken,
         telegramAllowedUserIds,
         platforms,
+        cdpHost,
     };
 }
 

--- a/tests/handlers/approvalButtonAction.test.ts
+++ b/tests/handlers/approvalButtonAction.test.ts
@@ -59,6 +59,7 @@ function makeBridge(overrides: Partial<CdpBridge> = {}): CdpBridge {
         lastActiveChannel: null,
         approvalChannelByWorkspace: new Map(),
         approvalChannelBySession: new Map(),
+        cdpHost: 'localhost',
         ...overrides,
     };
 }

--- a/tests/handlers/errorPopupButtonAction.test.ts
+++ b/tests/handlers/errorPopupButtonAction.test.ts
@@ -59,6 +59,7 @@ function makeBridge(overrides: Partial<CdpBridge> = {}): CdpBridge {
         lastActiveChannel: null,
         approvalChannelByWorkspace: new Map(),
         approvalChannelBySession: new Map(),
+        cdpHost: 'localhost',
         ...overrides,
     };
 }

--- a/tests/handlers/planningButtonAction.test.ts
+++ b/tests/handlers/planningButtonAction.test.ts
@@ -59,6 +59,7 @@ function makeBridge(overrides: Partial<CdpBridge> = {}): CdpBridge {
         lastActiveChannel: null,
         approvalChannelByWorkspace: new Map(),
         approvalChannelBySession: new Map(),
+        cdpHost: 'localhost',
         ...overrides,
     };
 }

--- a/tests/services/assistantDomExtractor.test.ts
+++ b/tests/services/assistantDomExtractor.test.ts
@@ -64,6 +64,8 @@ describe('assistantDomExtractor', () => {
 
         const result = classifyAssistantSegments(payload);
 
+        // Note: The script iterates backwards, but the test payload provides them directly.
+        // classifyAssistantSegments will take bodyTexts[0], which is '最終回答: 1ドル=154.8円です。'
         expect(result.finalOutputText).toBe('最終回答: 1ドル=154.8円です。');
         expect(result.activityLines).toEqual([
             'Analyzing current exchange data...',
@@ -103,6 +105,7 @@ describe('assistantDomExtractor', () => {
 
         const result = classifyAssistantSegments(payload);
 
+        // Multi-segment body text is concatenated with double newline
         expect(result.finalOutputText).toBe('前半です。\n\n後半です。');
         expect(result.activityLines).toEqual(['mcp.search']);
         expect(result.feedback).toEqual([]);

--- a/tests/services/responseMonitor.selectors.test.ts
+++ b/tests/services/responseMonitor.selectors.test.ts
@@ -37,10 +37,10 @@ describe('Lean RESPONSE_SELECTORS', () => {
     });
 
     // ---------------------------------------------------------------
-    // Test 4: STOP_BUTTON script does NOT contain 'getComputedStyle'
+    // Test 4: STOP_BUTTON script DOES use getComputedStyle (CSS visibility checks)
     // ---------------------------------------------------------------
-    it('STOP_BUTTON script does NOT contain getComputedStyle', () => {
-        expect(RESPONSE_SELECTORS.STOP_BUTTON).not.toContain('getComputedStyle');
+    it('STOP_BUTTON script uses getComputedStyle for CSS visibility checks', () => {
+        expect(RESPONSE_SELECTORS.STOP_BUTTON).toContain('getComputedStyle');
     });
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

Selector compatibility updates for Antigravity **1.23.2** (VSCode OSS 1.107.0). This is PR 1/4 split from #150 as requested.

## Tested Against

```
Antigravity Version: 1.23.2
VSCode OSS Version: 1.107.0
Commit: 15487b3041e65228cae24980a3f796c905ef582c
Date: 2026-04-16T08:28:19.366Z
Electron: 39.2.3
Chromium: 142.0.7444.175
Node.js: 22.21.1
V8: 14.2.231.21-electron.0
OS: Linux x64 6.17.0-23-generic
```

## Changes (14 files, +201 / -63)

### DOM Selector Updates
- Add `.text-ide-message-block-bot-color` selector to **all** extraction paths (`RESPONSE_TEXT`, `DUMP_ALL_TEXTS`, `PROCESS_LOGS`, `assistantDomExtractor`)
- Replace `.flex.flex-col.gap-y-3` selector (no longer present in AG 1.23.x)
- Add exclusion containers: `form`, `textarea`, user-role messages, and text-based filters for input placeholder text

### Stop Button Detection
- Fix: use `querySelectorAll` + visibility check (`offsetWidth`/`offsetHeight`/`getClientRects`) instead of `querySelector` to avoid false "not generating" states from stale/hidden elements
- Fix: `CLICK_STOP_BUTTON` now checks `getComputedStyle` (display/visibility/opacity) before clicking

### User Message Detection
- Refine: clone-and-strip button nodes before reading text content
- Fix: only strip undo label from trailing position (not globally), preserving legitimate content like "how do I undo the last commit?"

### Infrastructure
- Add configurable `cdpHost` (default `127.0.0.1`) to `AppConfig`, `ConfigLoader`, `CdpService`
- Expose `getUserMessageDetectorsForProject()` on `CdpConnectionPool` for echo prevention
- Update `docs/ANTIGRAVITY_DOM_SELECTORS.md` with current selector guidance
- Add `.mirror_state.json` and `tsconfig.tsbuildinfo` to `.gitignore`

### Tests
- Update handler test mocks with `cdpHost` property
- Update `assistantDomExtractor` tests for new selector behavior

## Test Results

```
Test Suites: 108 passed, 108 total
Tests:       1413 passed, 1413 total
```

## Version Correction

The original PR #150 title mentioned "Antigravity v0.3.0" which was incorrect — that is LazyGravity's own `package.json` version. The actual Antigravity version tested is **1.23.2**.

## Remaining PRs (to follow after this lands)
- PR 2: `/bind` Telegram command
- PR 3: Mirror state persistence
- PR 4: Live Telegram progress streaming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable CDP host support for flexible deployment scenarios.

* **Bug Fixes**
  * Improved detection of stop/cancel buttons and generation status.
  * Enhanced user message detection with additional deduplication safeguards.
  * Refined DOM content filtering to better distinguish assistant responses from other UI elements.

* **Documentation**
  * Updated selector verification data and exclusion rules for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->