### PR TITLE
Fix message injection for current Antigravity IDE chat input

### DIFF
--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -62,7 +62,10 @@ export interface UiSyncResult {
 /** Antigravity UI DOM selector constants */
 const SELECTORS = {
     /** Chat input box: textbox excluding xterm */
-    CHAT_INPUT: 'div[role="textbox"]:not(.xterm-helper-textarea)',
+    CHAT_INPUT: [
+        'div[role="textbox"]:not(.xterm-helper-textarea)',
+        'div[role="combobox"][contenteditable="true"][aria-label="Message input"]',
+    ].join(', '),
     /** Submit button search target tag */
     SUBMIT_BUTTON_CONTAINER: 'button',
     /** Submit icon SVG class candidates */
@@ -1485,6 +1488,13 @@ export class CdpService extends EventEmitter {
         imageFilePaths?: string[],
     ): Promise<InjectResult> {
         logger.warn(`[CdpService] Initial message injection failed: ${firstError}. Retrying once after readiness check...`);
+
+        if (this.isTransientInjectError(firstError)) {
+            const target = await this.findWorkbenchTarget();
+            if (target?.webSocketDebuggerUrl) {
+                await this.openChatPanelViaKeyboard(target.webSocketDebuggerUrl);
+            }
+        }
 
         try {
             await this.reconnectOnDemand(INJECT_RETRY_READY_TIMEOUT_MS);

--- a/tests/services/cdpService.retryInject.test.ts
+++ b/tests/services/cdpService.retryInject.test.ts
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('CdpService injection recovery', () => {
+    it('supports the current Antigravity message input combobox', () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '../../src/services/cdpService.ts'),
+            'utf8',
+        );
+
+        expect(source).toContain(
+            'div[role="combobox"][contenteditable="true"][aria-label="Message input"]',
+        );
+    });
+
+    it('opens the chat panel before retrying a transient injection failure', () => {
+        const source = fs.readFileSync(
+            path.join(__dirname, '../../src/services/cdpService.ts'),
+            'utf8',
+        );
+        const retryStart = source.indexOf('private async retryInjectOnce');
+        const retryEnd = source.indexOf('private async clearInputField', retryStart);
+        const retrySource = source.slice(retryStart, retryEnd);
+
+        expect(retrySource).toContain('this.isTransientInjectError(firstError)');
+        expect(retrySource).toContain('await this.findWorkbenchTarget()');
+        expect(retrySource).toContain('await this.openChatPanelViaKeyboard(target.webSocketDebuggerUrl)');
+    });
+});


### PR DESCRIPTION
# Fix message injection for current Antigravity IDE chat input

## Summary

Update LazyGravity's Antigravity CDP integration to support the chat input DOM
used by the current Antigravity IDE and improve recovery when the Agent/chat
panel is closed.

The change:

- Adds the current Antigravity message editor selector:
  `div[role="combobox"][contenteditable="true"][aria-label="Message input"]`.
- Preserves support for the existing `div[role="textbox"]` selector.
- Opens the Agent/chat panel before retrying transient message-injection
  failures.
- Adds focused regression coverage for both behaviors.

## Problem

LazyGravity can successfully:

- connect to Antigravity IDE through CDP;
- discover the correct VS Code workbench page;
- bind a Discord channel to a workspace; and
- route a Discord prompt to that workspace.

However, message injection fails with:

```text
Message Injection Failed
Failed to send message: Chat input field not found
```

The existing selector only recognizes:

```css
div[role="textbox"]:not(.xterm-helper-textarea)
```

Live DOM inspection of the current Antigravity IDE shows that its visible chat
editor is now:

```html
<div
  role="combobox"
  contenteditable="true"
  aria-label="Message input"
>
```

As a result, LazyGravity connects to the workspace but cannot focus the editor,
insert prompt text, or send the message.

A related failure occurs when the Agent/chat panel is closed. LazyGravity
already contains `openChatPanelViaKeyboard()`, which opens the panel with
`Ctrl+L` or `Cmd+L`, but the injection retry path does not use it.

## Solution

### Support the current editor DOM

Expand `SELECTORS.CHAT_INPUT` into a selector list containing both the legacy
textbox and the current Antigravity combobox:

```ts
CHAT_INPUT: [
    'div[role="textbox"]:not(.xterm-helper-textarea)',
    'div[role="combobox"][contenteditable="true"][aria-label="Message input"]',
].join(', '),
```

This preserves backward compatibility while supporting the current IDE.

### Recover when the Agent panel is closed

Before retrying a transient injection failure, locate the workbench target and
reuse the existing keyboard-based panel opener:

```ts
if (this.isTransientInjectError(firstError)) {
    const target = await this.findWorkbenchTarget();
    if (target?.webSocketDebuggerUrl) {
        await this.openChatPanelViaKeyboard(target.webSocketDebuggerUrl);
    }
}
```

The existing reconnect, readiness wait, and single retry remain unchanged.

## Rationale

- **Backward compatible:** Retains the previous textbox selector.
- **Scoped:** Changes only input discovery and the existing transient retry
  path.
- **Reuses existing behavior:** Uses LazyGravity's existing workbench discovery
  and panel-opening methods.
- **Bounded:** Does not add unbounded retries or change queue semantics.
- **Evidence based:** The new selector was identified by inspecting the live
  Antigravity IDE workbench DOM through CDP.

## Testing

Automated validation:

```text
Test Suites: 109 passed, 109 total
Tests:       1415 passed, 1415 total
```

Build validation:

```bash
npm run build
```

End-to-end validation:

1. Started Antigravity IDE with CDP enabled.
2. Started LazyGravity using the locally built change.
3. Bound a Discord channel to the workspace.
4. Sent `list files` from Discord.
5. Confirmed Antigravity received and executed the prompt.
6. Confirmed Discord received the process log and final response.

Observed result:

```text
Prompt completed in 13s
Structured extraction completed
Final output delivered to Discord
```

## Files Changed

- `src/services/cdpService.ts`
- `tests/services/cdpService.retryInject.test.ts`

## Risk

Low. The selector expansion is additive, and panel opening occurs only after a
transient injection failure before the existing single retry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced chat panel integration with improved compatibility for different chat input implementations.

* **Bug Fixes**
  * Improved transient error handling and recovery when establishing chat connection, with automatic chat panel reopening during retry attempts.

* **Tests**
  * Added comprehensive test coverage for chat injection recovery mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->