### PR TITLE
Fix Windows multi-project session routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Double-click **`start_antigravity_mac.command`** in the repo root.
 #### Windows
 Double-click **`start_antigravity_win.bat`** in the repo root.
 
-- **If it doesn't launch**: the executable may not be in your PATH. Right-click the file, edit it, and replace `"Antigravity.exe"` with the full install path (e.g. `"%LOCALAPPDATA%\Programs\Antigravity\Antigravity.exe"`).
+- **If it doesn't launch**: verify that Antigravity IDE is installed at `"%LOCALAPPDATA%\Programs\Antigravity IDE\Antigravity IDE.exe"`. If it is installed elsewhere, right-click the file and update the executable path.
 
 #### Linux
 On Linux (especially when using AppImages), the `antigravity` command might not be globally available.

--- a/launch_dev.bat
+++ b/launch_dev.bat
@@ -14,7 +14,7 @@ if %errorlevel% equ 0 (
 echo [LazyLaunch] Found available CDP port: %AG_PORT%
 
 :: Path to Antigravity executable
-set "AG_PATH=%LOCALAPPDATA%\Programs\Antigravity\Antigravity.exe"
+set "AG_PATH=%LOCALAPPDATA%\Programs\Antigravity IDE\Antigravity IDE.exe"
 
 if not exist "%AG_PATH%" (
     echo [ERROR] Antigravity executable not found at: %AG_PATH%

--- a/src/services/chatSessionService.ts
+++ b/src/services/chatSessionService.ts
@@ -1,4 +1,5 @@
 import { CdpService } from './cdpService';
+import { logger } from '../utils/logger';
 
 /** Session list item from the side panel */
 export interface SessionListItem {
@@ -1015,6 +1016,10 @@ export class ChatSessionService {
         // The selection script only reports success after matching the wanted
         // title inside this workspace's conversation picker.
         if (usedPastConversations && after.title.trim() === 'Agent') {
+            logger.debug(
+                `[ChatSession] Accepting Agent-header bypass: ` +
+                `usedPastConversations=true observedTitle="${after.title}" targetTitle="${title}"`,
+            );
             await this.closePanelWithEscape(cdpService);
             return { ok: true };
         }
@@ -1041,6 +1046,10 @@ export class ChatSessionService {
                     return { ok: true };
                 }
                 if (afterPast.title.trim() === 'Agent') {
+                    logger.debug(
+                        `[ChatSession] Accepting Agent-header bypass: ` +
+                        `usedPastConversations=true observedTitle="${afterPast.title}" targetTitle="${title}"`,
+                    );
                     await this.closePanelWithEscape(cdpService);
                     return { ok: true };
                 }

--- a/src/services/chatSessionService.ts
+++ b/src/services/chatSessionService.ts
@@ -52,7 +52,14 @@ const GET_CHAT_TITLE_SCRIPT = `(() => {
     const header = panel.querySelector('div[class*="border-b"]');
     if (!header) return { title: '', hasActiveChat: false };
     const titleEl = header.querySelector('div[class*="text-ellipsis"]');
-    const title = titleEl ? (titleEl.textContent || '').trim() : '';
+    let title = titleEl ? (titleEl.textContent || '').trim() : '';
+    if (!title || title === 'Agent') {
+        const activeRow = Array.from(panel.querySelectorAll('div[class*="focusBackground"]'))
+            .find((el) => el instanceof HTMLElement && el.offsetParent !== null);
+        const activeTitle = activeRow?.querySelector('span.text-sm span, span.text-sm');
+        const activeText = activeTitle ? (activeTitle.textContent || '').trim() : '';
+        if (activeText) title = activeText;
+    }
     // "Agent" is the default empty chat title
     const hasActiveChat = title.length > 0 && title !== 'Agent';
     return { title: title || '(Untitled)', hasActiveChat };
@@ -72,7 +79,14 @@ const GET_SESSION_VIEW_STATE_SCRIPT = `(() => {
     }
     const header = panel.querySelector('div[class*="border-b"]');
     const titleEl = header?.querySelector('div[class*="text-ellipsis"]');
-    const title = titleEl ? (titleEl.textContent || '').trim() : '';
+    let title = titleEl ? (titleEl.textContent || '').trim() : '';
+    if (!title || title === 'Agent') {
+        const activeRow = Array.from(panel.querySelectorAll('div[class*="focusBackground"]'))
+            .find((el) => el instanceof HTMLElement && el.offsetParent !== null);
+        const activeTitle = activeRow?.querySelector('span.text-sm span, span.text-sm');
+        const activeText = activeTitle ? (activeTitle.textContent || '').trim() : '';
+        if (activeText) title = activeText;
+    }
     const hasActiveChat = title.length > 0 && title !== 'Agent';
 
     const bodyCandidates = Array.from(panel.querySelectorAll(
@@ -494,6 +508,17 @@ function buildActivateViaPastConversationsScript(title: string): string {
             }
 
             let selected = clickByPatterns([wanted, wantedLoose], '[role="option"], li, button, [data-testid*="conversation"]');
+            if (selected) {
+                const selectedOption = pickBest(
+                    asArray(document.querySelectorAll('[role="option"], li, button, [data-testid*="conversation"]')),
+                    [wanted, wantedLoose],
+                );
+                const selectedClickable = getClickable(selectedOption);
+                if (selectedClickable) {
+                    selectedClickable.focus();
+                    pressEnter(selectedClickable);
+                }
+            }
             if (!selected && input) {
                 pressEnter(input);
                 await wait(220);
@@ -985,6 +1010,15 @@ export class ChatSessionService {
             return { ok: true };
         }
 
+        // Current Antigravity builds keep the header at the generic "Agent"
+        // label even after an exact Past Conversations option is selected.
+        // The selection script only reports success after matching the wanted
+        // title inside this workspace's conversation picker.
+        if (usedPastConversations && after.title.trim() === 'Agent') {
+            await this.closePanelWithEscape(cdpService);
+            return { ok: true };
+        }
+
         if (!warmupConsumed && allowVisibilityWarmupMs > 0 && after.title.trim() === 'Agent') {
             warmupConsumed = true;
             startedAt = Date.now();
@@ -1003,6 +1037,10 @@ export class ChatSessionService {
                 await new Promise((resolve) => setTimeout(resolve, 500));
                 const afterPast = await this.getCurrentSessionInfo(cdpService);
                 if (afterPast.title.trim() === title.trim()) {
+                    await this.closePanelWithEscape(cdpService);
+                    return { ok: true };
+                }
+                if (afterPast.title.trim() === 'Agent') {
                     await this.closePanelWithEscape(cdpService);
                     return { ok: true };
                 }

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -19,9 +19,9 @@ export function getAntigravityCliPath(): string {
     if (process.platform === 'win32') {
         const localAppData = process.env.LOCALAPPDATA;
         if (localAppData) {
-            return `${localAppData}\\Programs\\Antigravity\\Antigravity.exe`;
+            return `${localAppData}\\Programs\\Antigravity IDE\\Antigravity IDE.exe`;
         }
-        return 'Antigravity.exe'; // Fallback if LOCALAPPDATA is undefined
+        return 'Antigravity IDE.exe'; // Fallback if LOCALAPPDATA is undefined
     }
 
     // Default for Linux or any unknown OS, assuming 'antigravity' is in the system PATH
@@ -50,7 +50,7 @@ export function getAntigravityCdpHint(port: number = 9222): string {
         case 'darwin':
             return `open -a ${APP_NAME} --args --remote-debugging-port=${port}`;
         case 'win32':
-            return `${APP_NAME}.exe --remote-debugging-port=${port}`;
+            return `${APP_NAME} IDE.exe --remote-debugging-port=${port}`;
         default:
             return `${APP_NAME.toLowerCase()} --remote-debugging-port=${port}`;
     }

--- a/start_antigravity_win.bat
+++ b/start_antigravity_win.bat
@@ -22,7 +22,7 @@ exit /b 1
 
 :found
 echo [INFO] Starting Antigravity on port %SELECTED_PORT%...
-start "" "Antigravity.exe" --remote-debugging-port=%SELECTED_PORT%
+start "" "%LOCALAPPDATA%\Programs\Antigravity IDE\Antigravity IDE.exe" --remote-debugging-port=%SELECTED_PORT%
 echo [OK] Launch complete! CDP port: %SELECTED_PORT%
 timeout /t 2 >nul
 exit /b 0

--- a/tests/services/cdpService.workspace.test.ts
+++ b/tests/services/cdpService.workspace.test.ts
@@ -128,12 +128,12 @@ describe('CdpService - Cross-Platform Workspace Launching', () => {
             await service.discoverAndConnectForWorkspace(workspacePath);
 
             expect(mockRunCommand).toHaveBeenCalledWith(
-                'C:\\Users\\TestUser\\AppData\\Local\\Programs\\Antigravity\\Antigravity.exe',
+                'C:\\Users\\TestUser\\AppData\\Local\\Programs\\Antigravity IDE\\Antigravity IDE.exe',
                 ['--remote-debugging-port=9999', '--new-window', workspacePath]
             );
         });
 
-        it('should fallback to Antigravity.exe if LOCALAPPDATA is missing on Windows', async () => {
+        it('should fallback to Antigravity IDE.exe if LOCALAPPDATA is missing on Windows', async () => {
             setPlatform('win32');
             delete process.env.LOCALAPPDATA;
 
@@ -151,7 +151,36 @@ describe('CdpService - Cross-Platform Workspace Launching', () => {
             await service.discoverAndConnectForWorkspace(workspacePath);
 
             expect(mockRunCommand).toHaveBeenCalledWith(
-                'Antigravity.exe',
+                'Antigravity IDE.exe',
+                ['--remote-debugging-port=9999', '--new-window', workspacePath]
+            );
+        });
+
+        it('should honor ANTIGRAVITY_PATH when opening another Windows workspace', async () => {
+            setPlatform('win32');
+            process.env.ANTIGRAVITY_PATH = 'C:\\Custom\\Antigravity IDE.exe';
+
+            mockGetJson
+                .mockResolvedValueOnce([{
+                    id: 'existing-id',
+                    type: 'page',
+                    title: 'ExistingProject - Antigravity IDE',
+                    webSocketDebuggerUrl: 'ws://existing',
+                    url: 'file:///workbench'
+                }])
+                .mockResolvedValue([{
+                    id: 'new-id',
+                    type: 'page',
+                    title: 'MyProject - Antigravity IDE',
+                    webSocketDebuggerUrl: 'ws://new',
+                    url: 'file:///workbench'
+                }]);
+
+            const workspacePath = 'C:\\Source\\MyProject';
+            await service.discoverAndConnectForWorkspace(workspacePath);
+
+            expect(mockRunCommand).toHaveBeenCalledWith(
+                'C:\\Custom\\Antigravity IDE.exe',
                 ['--remote-debugging-port=9999', '--new-window', workspacePath]
             );
         });

--- a/tests/services/chatSessionService.test.ts
+++ b/tests/services/chatSessionService.test.ts
@@ -1,5 +1,6 @@
 import { ChatSessionService } from '../../src/services/chatSessionService';
 import { CdpService } from '../../src/services/cdpService';
+import { logger } from '../../src/utils/logger';
 
 jest.mock('../../src/services/cdpService');
 const MockedCdpService = CdpService as jest.MockedClass<typeof CdpService>;
@@ -225,6 +226,7 @@ describe('ChatSessionService', () => {
         });
 
         it('accepts an exact Past Conversations selection when the header remains Agent', async () => {
+            const debugSpy = jest.spyOn(logger, 'debug');
             mockCdpService.call.mockImplementation(async (method: string, params: any) => {
                 const expression = String(params?.expression || '');
                 if (method !== 'Runtime.evaluate') return {};
@@ -243,6 +245,11 @@ describe('ChatSessionService', () => {
             const result = await service.activateSessionByTitle(mockCdpService, 'target-session');
 
             expect(result).toEqual({ ok: true });
+            expect(debugSpy).toHaveBeenCalledWith(
+                expect.stringContaining(
+                    'usedPastConversations=true observedTitle="Agent" targetTitle="target-session"',
+                ),
+            );
         });
 
         it('retries activation while UI is still loading and eventually succeeds', async () => {

--- a/tests/services/chatSessionService.test.ts
+++ b/tests/services/chatSessionService.test.ts
@@ -128,6 +128,18 @@ describe('ChatSessionService', () => {
             expect(info.hasActiveChat).toBe(false);
         });
 
+        it('checks the highlighted conversation row when the header is the generic Agent label', async () => {
+            mockCdpService.call.mockResolvedValue({
+                result: { value: { title: 'Listing Repository Files', hasActiveChat: true } }
+            });
+
+            const info = await service.getCurrentSessionInfo(mockCdpService);
+            const expression = String(mockCdpService.call.mock.calls[0][1]?.expression || '');
+
+            expect(expression).toContain('focusBackground');
+            expect(info).toEqual({ title: 'Listing Repository Files', hasActiveChat: true });
+        });
+
         it('returns fallback values when a CDP call throws an exception', async () => {
             mockCdpService.call.mockRejectedValue(new Error('CDPエラー'));
 
@@ -210,6 +222,27 @@ describe('ChatSessionService', () => {
                 (c) => c.method === 'Input.dispatchKeyEvent' && c.params?.key === 'Escape',
             );
             expect(escapeCall).toBeDefined();
+        });
+
+        it('accepts an exact Past Conversations selection when the header remains Agent', async () => {
+            mockCdpService.call.mockImplementation(async (method: string, params: any) => {
+                const expression = String(params?.expression || '');
+                if (method !== 'Runtime.evaluate') return {};
+                if (expression.includes('const header = panel.querySelector')) {
+                    return { result: { value: { title: 'Agent', hasActiveChat: false } } };
+                }
+                if (expression.includes('Chat title not found in side panel')) {
+                    return { result: { value: { ok: false, error: 'not found' } } };
+                }
+                if (expression.includes('Past Conversations button not found')) {
+                    return { result: { value: { ok: true } } };
+                }
+                return { result: { value: null } };
+            });
+
+            const result = await service.activateSessionByTitle(mockCdpService, 'target-session');
+
+            expect(result).toEqual({ ok: true });
         });
 
         it('retries activation while UI is still loading and eventually succeeds', async () => {

--- a/tests/utils/pathUtils.test.ts
+++ b/tests/utils/pathUtils.test.ts
@@ -58,7 +58,7 @@ describe('pathUtils', () => {
         it('returns exe hint on Windows', () => {
             withPlatform('win32', () => {
                 expect(getAntigravityCdpHint(9222)).toBe(
-                    'Antigravity.exe --remote-debugging-port=9222',
+                    'Antigravity IDE.exe --remote-debugging-port=9222',
                 );
             });
         });


### PR DESCRIPTION
# Fix Windows multi-project workspace and session routing

## Summary

Fix LazyGravity's Windows multi-project flow so additional Discord-bound
projects open as separate workbench targets on the existing CDP endpoint and
saved conversations can be activated in current Antigravity IDE builds.

The change:

- Opens additional Windows workspaces with `Antigravity IDE.exe`, matching the
  application that exposes the controllable workbench.
- Preserves `ANTIGRAVITY_PATH` as the explicit executable override.
- Reads the highlighted conversation title when available if the header remains
  the generic `Agent` label.
- Improves Past Conversations selection by focusing the exact matched option
  and dispatching Enter after the DOM click.
- Accepts an exact project-scoped Past Conversations selection when the current
  Antigravity build keeps the header at `Agent`.

## Problem

The first Discord project works, but creating or messaging a channel for a
second project fails to establish a usable session.

Live logs showed LazyGravity launching:

```text
C:\Users\...\Programs\Antigravity\Antigravity.exe
  --remote-debugging-port=9222 --new-window C:\...\second-project
```

The active CDP endpoint belongs to:

```text
C:\Users\...\Programs\Antigravity IDE\Antigravity IDE.exe
```

The separate `Antigravity.exe` application does not add a workbench target to
that endpoint, so LazyGravity times out looking for the second project.

After correcting the executable, both projects connect, but saved-session
routing still fails:

```text
Activated chat did not match target title
(expected="Listing Workspace Files", actual="Agent")
```

Live CDP DOM inspection showed:

- distinct workbench targets for both projects;
- the requested saved conversation present in each project's Past
  Conversations picker;
- Past Conversations options rendered as `[role="option"]`;
- the Antigravity header remaining `Agent` after exact conversation selection;
  and
- Electron sometimes ignoring a synthetic DOM click unless the option is also
  focused and selected with Enter.

## Solution

### Use the controllable Windows application

Resolve the default Windows executable to:

```text
%LOCALAPPDATA%\Programs\Antigravity IDE\Antigravity IDE.exe
```

This opens additional projects as separate workbench targets on the same CDP
port. `ANTIGRAVITY_PATH` remains the highest-precedence override.

### Handle current saved-conversation behavior

When the header is generic, current-session inspection attempts to read the
highlighted conversation row.

For Past Conversations activation, the exact matching option is clicked,
focused, and sent an Enter key event. If that exact selection succeeds inside
the already selected project workbench but Antigravity still reports the
generic `Agent` header, routing proceeds.

This does not permit arbitrary title mismatches: the relaxed verification only
applies after an exact title match in the correct project's Past Conversations
picker.

## Testing

Automated validation:

```text
Test Suites: 108 passed, 108 total
Tests:       1416 passed, 1416 total
```

Build validation:

```bash
npm run build
```

Live validation:

1. Started `Antigravity IDE.exe` with CDP on port `9222`.
2. Opened `ai-cli` and `antigravity-bot` as separate windows.
3. Confirmed `/json/list` exposed distinct workbench targets for both projects.
4. Connected both Discord project channels.
5. Reproduced and inspected saved-session activation through live CDP.
6. Confirmed prompts route successfully after applying the fix.

## Files Changed

- `src/services/chatSessionService.ts`
- `src/utils/pathUtils.ts`
- `tests/services/cdpService.workspace.test.ts`
- `tests/services/chatSessionService.test.ts`
- `tests/utils/pathUtils.test.ts`

## Risk

Moderate and scoped to Windows workspace launching and saved-session
activation. Existing explicit executable overrides are preserved. Generic
`Agent` verification is accepted only after an exact conversation-title match
inside the correct project workbench.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat title detection by deriving the title from the active conversation when the header is missing or generic.
  * Improved “Past Conversations” activation to reliably re-select, focus, and confirm the best matching item.
  * Fixed session activation behavior for generic “Agent” headers, including the Past Conversations flow.
  * Updated Windows launch handling to use **Antigravity IDE.exe** (including focus/Cascade session evaluation behavior).
* **Documentation**
  * Refreshed Windows troubleshooting to reference the **%LOCALAPPDATA%\Programs\Antigravity IDE\Antigravity IDE.exe** location.
* **Tests**
  * Updated and expanded test coverage for the new chat/session behaviors and Windows executable/path expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->