### PR TITLE
Add Discord-controlled Antigravity IDE lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Double-click **`start_antigravity_mac.command`** in the repo root.
 #### Windows
 Double-click **`start_antigravity_win.bat`** in the repo root.
 
-- **If it doesn't launch**: the executable may not be in your PATH. Right-click the file, edit it, and replace `"Antigravity.exe"` with the full install path (e.g. `"%LOCALAPPDATA%\Programs\Antigravity\Antigravity.exe"`).
+- **If it doesn't launch**: verify that Antigravity IDE is installed at `"%LOCALAPPDATA%\Programs\Antigravity IDE\Antigravity IDE.exe"`. If it is installed elsewhere, right-click the file and update the executable path.
 
 #### Linux
 On Linux (especially when using AppImages), the `antigravity` command might not be globally available.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Double-click **`start_antigravity_mac.command`** in the repo root.
 Double-click **`start_antigravity_win.bat`** in the repo root.
 
 - **If it doesn't launch**: verify that Antigravity IDE is installed at `"%LOCALAPPDATA%\Programs\Antigravity IDE\Antigravity IDE.exe"`. If it is installed elsewhere, right-click the file and update the executable path.
+- **Upgrading to Antigravity 2.0?** The Windows executable was renamed to `Antigravity IDE.exe`. If you are still using the older `Antigravity.exe` installation, auto-launch will not find it. Please update Antigravity, or set the `ANTIGRAVITY_PATH` override in your `.env` file.
 
 #### Linux
 On Linux (especially when using AppImages), the `antigravity` command might not be globally available.

--- a/launch_dev.bat
+++ b/launch_dev.bat
@@ -14,7 +14,13 @@ if %errorlevel% equ 0 (
 echo [LazyLaunch] Found available CDP port: %AG_PORT%
 
 :: Path to Antigravity executable
-set "AG_PATH=%LOCALAPPDATA%\Programs\Antigravity IDE\Antigravity IDE.exe"
+if not defined AG_PATH (
+    if defined LOCALAPPDATA (
+        set "AG_PATH=%LOCALAPPDATA%\Programs\Antigravity IDE\Antigravity IDE.exe"
+    ) else (
+        set "AG_PATH=Antigravity IDE.exe"
+    )
+)
 
 if not exist "%AG_PATH%" (
     echo [ERROR] Antigravity executable not found at: %AG_PATH%

--- a/launch_dev.bat
+++ b/launch_dev.bat
@@ -14,7 +14,7 @@ if %errorlevel% equ 0 (
 echo [LazyLaunch] Found available CDP port: %AG_PORT%
 
 :: Path to Antigravity executable
-set "AG_PATH=%LOCALAPPDATA%\Programs\Antigravity\Antigravity.exe"
+set "AG_PATH=%LOCALAPPDATA%\Programs\Antigravity IDE\Antigravity IDE.exe"
 
 if not exist "%AG_PATH%" (
     echo [ERROR] Antigravity executable not found at: %AG_PATH%

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -54,7 +54,7 @@ import { isSessionSelectId } from '../ui/sessionPickerUi';
 import { CdpService } from '../services/cdpService';
 import { ChatSessionService } from '../services/chatSessionService';
 import { ResponseMonitor, RESPONSE_SELECTORS, captureResponseMonitorBaseline } from '../services/responseMonitor';
-import { ensureAntigravityRunning } from '../services/antigravityLauncher';
+import { ensureAntigravityRunning, startAntigravity, stopAntigravity } from '../services/antigravityLauncher';
 import { getAntigravityCdpHint } from '../utils/pathUtils';
 import { AutoAcceptService } from '../services/autoAcceptService';
 import { PromptDispatcher } from '../services/promptDispatcher';
@@ -1076,6 +1076,9 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             }
 
             await bridge.pool.getOrConnect(workspacePath, { name: selectedAccount });
+        },
+        async () => {
+            await startAntigravity();
         },
     );
     const chatHandler = new ChatCommandHandler(
@@ -2151,6 +2154,21 @@ export async function handleSlashInteraction(
                 }
             } catch (e: any) {
                 await interaction.editReply({ content: `❌ Error during stop processing: ${e.message}` });
+            }
+            break;
+        }
+
+        case 'shutdown': {
+            try {
+                bridge.pool.disconnectAll();
+                const result = await stopAntigravity();
+                await interaction.editReply({
+                    content: result === 'stopped'
+                        ? '✅ Antigravity IDE shut down. Use `/project list` to start it again.'
+                        : 'ℹ️ Antigravity IDE is already stopped. Use `/project list` to start it.',
+                });
+            } catch (e: any) {
+                await interaction.editReply({ content: `❌ Failed to shut down Antigravity IDE: ${e.message}` });
             }
             break;
         }

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1077,8 +1077,18 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
 
             await bridge.pool.getOrConnect(workspacePath, { name: selectedAccount });
         },
-        async () => {
-            await startAntigravity();
+        async ({ channelId, userId }) => {
+            const accountName = resolveScopedAccountName({
+                channelId,
+                userId,
+                sessionAccountName: chatSessionRepo.findByChannelId(channelId)?.activeAccountName ?? null,
+                parentChannelId: null,
+                selectedAccountByChannel: bridge.selectedAccountByChannel,
+                channelPrefRepo,
+                accountPrefRepo,
+                accounts: config.antigravityAccounts,
+            });
+            await startAntigravity(accountPorts[accountName] ?? 9222);
         },
     );
     const chatHandler = new ChatCommandHandler(
@@ -2161,9 +2171,11 @@ export async function handleSlashInteraction(
         case 'shutdown': {
             try {
                 bridge.pool.disconnectAll();
-                const result = await stopAntigravity();
+                const ports = [...new Set(antigravityAccounts.map((account) => account.cdpPort))];
+                const results = await Promise.all(ports.map((port) => stopAntigravity(port)));
+                const stopped = results.some((result) => result === 'stopped');
                 await interaction.editReply({
-                    content: result === 'stopped'
+                    content: stopped
                         ? '✅ Antigravity IDE shut down. Use `/project list` to start it again.'
                         : 'ℹ️ Antigravity IDE is already stopped. Use `/project list` to start it.',
                 });

--- a/src/commands/registerSlashCommands.ts
+++ b/src/commands/registerSlashCommands.ts
@@ -1,6 +1,7 @@
 import { logger } from '../utils/logger';
 import {
     SlashCommandBuilder,
+    PermissionFlagsBits,
     REST,
     Routes,
 } from 'discord.js';
@@ -73,7 +74,8 @@ const stopCommand = new SlashCommandBuilder()
 /** /shutdown command definition */
 const shutdownCommand = new SlashCommandBuilder()
     .setName('shutdown')
-    .setDescription(t('Shut down Antigravity IDE'));
+    .setDescription(t('Shut down Antigravity IDE'))
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator);
 
 /** /screenshot command definition */
 const screenshotCommand = new SlashCommandBuilder()

--- a/src/commands/registerSlashCommands.ts
+++ b/src/commands/registerSlashCommands.ts
@@ -70,6 +70,11 @@ const stopCommand = new SlashCommandBuilder()
     .setName('stop')
     .setDescription(t('Interrupt active LLM generation'));
 
+/** /shutdown command definition */
+const shutdownCommand = new SlashCommandBuilder()
+    .setName('shutdown')
+    .setDescription(t('Shut down Antigravity IDE'));
+
 /** /screenshot command definition */
 const screenshotCommand = new SlashCommandBuilder()
     .setName('screenshot')
@@ -219,6 +224,7 @@ export const slashCommands = [
     modelCommand,
     templateCommand,
     stopCommand,
+    shutdownCommand,
     screenshotCommand,
     statusCommand,
     autoAcceptCommand,

--- a/src/commands/workspaceCommandHandler.ts
+++ b/src/commands/workspaceCommandHandler.ts
@@ -33,7 +33,7 @@ export class WorkspaceCommandHandler {
         sourceChannelId: string,
         userId: string,
     ) => Promise<void>;
-    private readonly ensureIdeRunning?: () => Promise<void>;
+    private readonly ensureIdeRunning?: (scope: { channelId: string; userId: string }) => Promise<void>;
 
     private processingWorkspaces: Set<string> = new Set();
 
@@ -82,7 +82,7 @@ export class WorkspaceCommandHandler {
             sourceChannelId: string,
             userId: string,
         ) => Promise<void>,
-        ensureIdeRunning?: () => Promise<void>,
+        ensureIdeRunning?: (scope: { channelId: string; userId: string }) => Promise<void>,
     ) {
         this.bindingRepo = bindingRepo;
         this.chatSessionRepo = chatSessionRepo;
@@ -96,7 +96,10 @@ export class WorkspaceCommandHandler {
      * /project list -- Display project list via select menu
      */
     public async handleShow(interaction: ChatInputCommandInteraction): Promise<void> {
-        await this.ensureIdeRunning?.();
+        await this.ensureIdeRunning?.({
+            channelId: interaction.channelId,
+            userId: interaction.user.id,
+        });
         const workspaces = this.workspaceService.scanWorkspaces();
         const { embeds, components } = buildProjectListUI(workspaces, 0);
 

--- a/src/commands/workspaceCommandHandler.ts
+++ b/src/commands/workspaceCommandHandler.ts
@@ -33,6 +33,7 @@ export class WorkspaceCommandHandler {
         sourceChannelId: string,
         userId: string,
     ) => Promise<void>;
+    private readonly ensureIdeRunning?: () => Promise<void>;
 
     private processingWorkspaces: Set<string> = new Set();
 
@@ -81,18 +82,21 @@ export class WorkspaceCommandHandler {
             sourceChannelId: string,
             userId: string,
         ) => Promise<void>,
+        ensureIdeRunning?: () => Promise<void>,
     ) {
         this.bindingRepo = bindingRepo;
         this.chatSessionRepo = chatSessionRepo;
         this.workspaceService = workspaceService;
         this.channelManager = channelManager;
         this.onSessionChannelCreated = onSessionChannelCreated;
+        this.ensureIdeRunning = ensureIdeRunning;
     }
 
     /**
      * /project list -- Display project list via select menu
      */
     public async handleShow(interaction: ChatInputCommandInteraction): Promise<void> {
+        await this.ensureIdeRunning?.();
         const workspaces = this.workspaceService.scanWorkspaces();
         const { embeds, components } = buildProjectListUI(workspaces, 0);
 

--- a/src/services/antigravityLauncher.ts
+++ b/src/services/antigravityLauncher.ts
@@ -61,6 +61,16 @@ export function startAntigravity(port: number = CDP_PORTS[0]): Promise<'started'
             stdio: 'ignore',
             windowsHide: true,
         });
+
+        const spawnError = await new Promise<Error | null>((resolve) => {
+            child.on('error', resolve);
+            setTimeout(() => resolve(null), 100);
+        });
+
+        if (spawnError) {
+            throw spawnError;
+        }
+
         child.unref();
 
         if (!await waitForPort(port)) {
@@ -74,11 +84,9 @@ export function stopAntigravity(port: number = CDP_PORTS[0]): Promise<'stopped' 
     return serializeLifecycle(async () => {
         if (!await checkPort(port)) return 'already-stopped';
 
-        const targets = await getCdpTargets(port);
-        const identifiesAntigravity = targets.some((target) =>
-            JSON.stringify(target).toLowerCase().includes('antigravity'),
-        );
-        if (!identifiesAntigravity) {
+        const version = await getCdpVersion(port);
+        const browser = typeof version?.Browser === 'string' ? version.Browser.toLowerCase() : '';
+        if (!browser.includes('antigravity')) {
             throw new Error(`Refusing to stop non-Antigravity CDP service on port ${port}.`);
         }
 
@@ -104,6 +112,27 @@ export function stopAntigravity(port: number = CDP_PORTS[0]): Promise<'stopped' 
             });
         });
         return 'stopped';
+    });
+}
+
+function getCdpVersion(port: number): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+        const req = http.get(`http://127.0.0.1:${port}/json/version`, (res) => {
+            let data = '';
+            res.on('data', (chunk) => (data += chunk));
+            res.on('end', () => {
+                try {
+                    resolve(JSON.parse(data));
+                } catch (error) {
+                    reject(error);
+                }
+            });
+        });
+        req.on('error', reject);
+        req.setTimeout(2000, () => {
+            req.destroy();
+            reject(new Error(`Timed out reading CDP version from port ${port}.`));
+        });
     });
 }
 

--- a/src/services/antigravityLauncher.ts
+++ b/src/services/antigravityLauncher.ts
@@ -2,11 +2,14 @@ import { logger } from '../utils/logger';
 import { CDP_PORTS } from '../utils/cdpPorts';
 import { getAntigravityCdpHint } from '../utils/pathUtils';
 import * as http from 'http';
+import { execFile, spawn } from 'child_process';
+
+let lifecycleOperation: Promise<unknown> | null = null;
 
 /**
  * Check if CDP responds on the specified port.
  */
-function checkPort(port: number): Promise<boolean> {
+export function checkPort(port: number): Promise<boolean> {
     return new Promise((resolve) => {
         const req = http.get(`http://127.0.0.1:${port}/json/list`, (res) => {
             let data = '';
@@ -25,6 +28,65 @@ function checkPort(port: number): Promise<boolean> {
             req.destroy();
             resolve(false);
         });
+    });
+}
+
+async function waitForPort(port: number, timeoutMs: number = 30000): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    do {
+        if (await checkPort(port)) return true;
+        await new Promise((resolve) => setTimeout(resolve, 500));
+    } while (Date.now() < deadline);
+    return false;
+}
+
+function serializeLifecycle<T>(operation: () => Promise<T>): Promise<T> {
+    if (lifecycleOperation) {
+        return lifecycleOperation.then(operation, operation);
+    }
+    const pending = operation();
+    lifecycleOperation = pending;
+    pending.finally(() => {
+        if (lifecycleOperation === pending) lifecycleOperation = null;
+    }).catch(() => {});
+    return pending;
+}
+
+export function startAntigravity(port: number = CDP_PORTS[0]): Promise<'started' | 'already-running'> {
+    return serializeLifecycle(async () => {
+        if (await checkPort(port)) return 'already-running';
+
+        const executable = process.env.ANTIGRAVITY_PATH || 'Antigravity IDE.exe';
+        const child = spawn(executable, [`--remote-debugging-port=${port}`], {
+            detached: true,
+            stdio: 'ignore',
+            windowsHide: true,
+        });
+        child.unref();
+
+        if (!await waitForPort(port)) {
+            throw new Error(`Antigravity did not become ready on CDP port ${port}.`);
+        }
+        return 'started';
+    });
+}
+
+export function stopAntigravity(port: number = CDP_PORTS[0]): Promise<'stopped' | 'already-stopped'> {
+    return serializeLifecycle(async () => {
+        if (!await checkPort(port)) return 'already-stopped';
+
+        await new Promise<void>((resolve, reject) => {
+            const command = [
+                `$ownerPid=(Get-NetTCPConnection -State Listen -LocalPort ${port} -ErrorAction SilentlyContinue`,
+                '| Select-Object -First 1 -ExpandProperty OwningProcess);',
+                'if ($ownerPid) { Stop-Process -Id $ownerPid -Force }',
+            ].join(' ');
+            execFile('powershell.exe', ['-NoProfile', '-Command', command], { windowsHide: true }, (error) => {
+                if (error) reject(error);
+                else resolve();
+            });
+        });
+        return 'stopped';
     });
 }
 

--- a/src/services/antigravityLauncher.ts
+++ b/src/services/antigravityLauncher.ts
@@ -1,6 +1,6 @@
 import { logger } from '../utils/logger';
 import { CDP_PORTS } from '../utils/cdpPorts';
-import { getAntigravityCdpHint } from '../utils/pathUtils';
+import { getAntigravityCdpHint, getAntigravityCliPath } from '../utils/pathUtils';
 import * as http from 'http';
 import { execFile, spawn } from 'child_process';
 
@@ -41,10 +41,9 @@ async function waitForPort(port: number, timeoutMs: number = 30000): Promise<boo
 }
 
 function serializeLifecycle<T>(operation: () => Promise<T>): Promise<T> {
-    if (lifecycleOperation) {
-        return lifecycleOperation.then(operation, operation);
-    }
-    const pending = operation();
+    const pending = lifecycleOperation
+        ? lifecycleOperation.then(operation, operation)
+        : operation();
     lifecycleOperation = pending;
     pending.finally(() => {
         if (lifecycleOperation === pending) lifecycleOperation = null;
@@ -56,7 +55,7 @@ export function startAntigravity(port: number = CDP_PORTS[0]): Promise<'started'
     return serializeLifecycle(async () => {
         if (await checkPort(port)) return 'already-running';
 
-        const executable = process.env.ANTIGRAVITY_PATH || 'Antigravity IDE.exe';
+        const executable = process.env.ANTIGRAVITY_PATH || getAntigravityCliPath();
         const child = spawn(executable, [`--remote-debugging-port=${port}`], {
             detached: true,
             stdio: 'ignore',
@@ -75,18 +74,59 @@ export function stopAntigravity(port: number = CDP_PORTS[0]): Promise<'stopped' 
     return serializeLifecycle(async () => {
         if (!await checkPort(port)) return 'already-stopped';
 
+        const targets = await getCdpTargets(port);
+        const identifiesAntigravity = targets.some((target) =>
+            JSON.stringify(target).toLowerCase().includes('antigravity'),
+        );
+        if (!identifiesAntigravity) {
+            throw new Error(`Refusing to stop non-Antigravity CDP service on port ${port}.`);
+        }
+
         await new Promise<void>((resolve, reject) => {
-            const command = [
-                `$ownerPid=(Get-NetTCPConnection -State Listen -LocalPort ${port} -ErrorAction SilentlyContinue`,
-                '| Select-Object -First 1 -ExpandProperty OwningProcess);',
-                'if ($ownerPid) { Stop-Process -Id $ownerPid -Force }',
-            ].join(' ');
-            execFile('powershell.exe', ['-NoProfile', '-Command', command], { windowsHide: true }, (error) => {
-                if (error) reject(error);
-                else resolve();
+            if (process.platform === 'win32') {
+                const command = [
+                    `$ownerPid=(Get-NetTCPConnection -State Listen -LocalPort ${port} -ErrorAction SilentlyContinue`,
+                    '| Select-Object -First 1 -ExpandProperty OwningProcess);',
+                    'if ($ownerPid) { Stop-Process -Id $ownerPid -Force }',
+                ].join(' ');
+                execFile('powershell.exe', ['-NoProfile', '-Command', command], { windowsHide: true }, (error) => {
+                    if (error) reject(error);
+                    else resolve();
+                });
+                return;
+            }
+
+            execFile('lsof', ['-tiTCP:' + port, '-sTCP:LISTEN'], (lookupError, stdout) => {
+                if (lookupError) return reject(lookupError);
+                const pid = String(stdout).trim().split(/\s+/)[0];
+                if (!/^\d+$/.test(pid)) return reject(new Error(`No listener PID found for CDP port ${port}.`));
+                execFile('kill', ['-TERM', pid], (killError) => killError ? reject(killError) : resolve());
             });
         });
         return 'stopped';
+    });
+}
+
+function getCdpTargets(port: number): Promise<Record<string, unknown>[]> {
+    return new Promise((resolve, reject) => {
+        const req = http.get(`http://127.0.0.1:${port}/json/list`, (res) => {
+            let data = '';
+            res.on('data', (chunk) => (data += chunk));
+            res.on('end', () => {
+                try {
+                    const parsed = JSON.parse(data);
+                    if (!Array.isArray(parsed)) throw new Error('CDP target list is not an array');
+                    resolve(parsed);
+                } catch (error) {
+                    reject(error);
+                }
+            });
+        });
+        req.on('error', reject);
+        req.setTimeout(2000, () => {
+            req.destroy();
+            reject(new Error(`Timed out reading CDP metadata from port ${port}.`));
+        });
     });
 }
 

--- a/src/services/chatSessionService.ts
+++ b/src/services/chatSessionService.ts
@@ -1,4 +1,5 @@
 import { CdpService } from './cdpService';
+import { logger } from '../utils/logger';
 
 /** Session list item from the side panel */
 export interface SessionListItem {
@@ -1015,6 +1016,10 @@ export class ChatSessionService {
         // The selection script only reports success after matching the wanted
         // title inside this workspace's conversation picker.
         if (usedPastConversations && after.title.trim() === 'Agent') {
+            logger.debug(
+                `[ChatSession] Accepting Agent-header bypass: ` +
+                `usedPastConversations=true observedTitle="${after.title}" targetTitle="${title}"`,
+            );
             await this.closePanelWithEscape(cdpService);
             return { ok: true };
         }
@@ -1041,6 +1046,10 @@ export class ChatSessionService {
                     return { ok: true };
                 }
                 if (afterPast.title.trim() === 'Agent') {
+                    logger.debug(
+                        `[ChatSession] Accepting Agent-header bypass: ` +
+                        `usedPastConversations=true observedTitle="${afterPast.title}" targetTitle="${title}"`,
+                    );
                     await this.closePanelWithEscape(cdpService);
                     return { ok: true };
                 }

--- a/src/services/chatSessionService.ts
+++ b/src/services/chatSessionService.ts
@@ -52,7 +52,14 @@ const GET_CHAT_TITLE_SCRIPT = `(() => {
     const header = panel.querySelector('div[class*="border-b"]');
     if (!header) return { title: '', hasActiveChat: false };
     const titleEl = header.querySelector('div[class*="text-ellipsis"]');
-    const title = titleEl ? (titleEl.textContent || '').trim() : '';
+    let title = titleEl ? (titleEl.textContent || '').trim() : '';
+    if (!title || title === 'Agent') {
+        const activeRow = Array.from(panel.querySelectorAll('div[class*="focusBackground"]'))
+            .find((el) => el instanceof HTMLElement && el.offsetParent !== null);
+        const activeTitle = activeRow?.querySelector('span.text-sm span, span.text-sm');
+        const activeText = activeTitle ? (activeTitle.textContent || '').trim() : '';
+        if (activeText) title = activeText;
+    }
     // "Agent" is the default empty chat title
     const hasActiveChat = title.length > 0 && title !== 'Agent';
     return { title: title || '(Untitled)', hasActiveChat };
@@ -72,7 +79,14 @@ const GET_SESSION_VIEW_STATE_SCRIPT = `(() => {
     }
     const header = panel.querySelector('div[class*="border-b"]');
     const titleEl = header?.querySelector('div[class*="text-ellipsis"]');
-    const title = titleEl ? (titleEl.textContent || '').trim() : '';
+    let title = titleEl ? (titleEl.textContent || '').trim() : '';
+    if (!title || title === 'Agent') {
+        const activeRow = Array.from(panel.querySelectorAll('div[class*="focusBackground"]'))
+            .find((el) => el instanceof HTMLElement && el.offsetParent !== null);
+        const activeTitle = activeRow?.querySelector('span.text-sm span, span.text-sm');
+        const activeText = activeTitle ? (activeTitle.textContent || '').trim() : '';
+        if (activeText) title = activeText;
+    }
     const hasActiveChat = title.length > 0 && title !== 'Agent';
 
     const bodyCandidates = Array.from(panel.querySelectorAll(
@@ -494,6 +508,17 @@ function buildActivateViaPastConversationsScript(title: string): string {
             }
 
             let selected = clickByPatterns([wanted, wantedLoose], '[role="option"], li, button, [data-testid*="conversation"]');
+            if (selected) {
+                const selectedOption = pickBest(
+                    asArray(document.querySelectorAll('[role="option"], li, button, [data-testid*="conversation"]')),
+                    [wanted, wantedLoose],
+                );
+                const selectedClickable = getClickable(selectedOption);
+                if (selectedClickable) {
+                    selectedClickable.focus();
+                    pressEnter(selectedClickable);
+                }
+            }
             if (!selected && input) {
                 pressEnter(input);
                 await wait(220);
@@ -985,6 +1010,15 @@ export class ChatSessionService {
             return { ok: true };
         }
 
+        // Current Antigravity builds keep the header at the generic "Agent"
+        // label even after an exact Past Conversations option is selected.
+        // The selection script only reports success after matching the wanted
+        // title inside this workspace's conversation picker.
+        if (usedPastConversations && after.title.trim() === 'Agent') {
+            await this.closePanelWithEscape(cdpService);
+            return { ok: true };
+        }
+
         if (!warmupConsumed && allowVisibilityWarmupMs > 0 && after.title.trim() === 'Agent') {
             warmupConsumed = true;
             startedAt = Date.now();
@@ -1003,6 +1037,10 @@ export class ChatSessionService {
                 await new Promise((resolve) => setTimeout(resolve, 500));
                 const afterPast = await this.getCurrentSessionInfo(cdpService);
                 if (afterPast.title.trim() === title.trim()) {
+                    await this.closePanelWithEscape(cdpService);
+                    return { ok: true };
+                }
+                if (afterPast.title.trim() === 'Agent') {
                     await this.closePanelWithEscape(cdpService);
                     return { ok: true };
                 }

--- a/src/services/chatSessionService.ts
+++ b/src/services/chatSessionService.ts
@@ -520,15 +520,10 @@ function buildActivateViaPastConversationsScript(title: string): string {
                     pressEnter(selectedClickable);
                 }
             }
-            if (!selected && input) {
-                pressEnter(input);
-                await wait(220);
-                selected = true;
-            }
             if (!selected) {
                 return { ok: false, error: 'Conversation not found in Past Conversations' };
             }
-            return { ok: true };
+            return { ok: true, matchedTitle: wantedRaw };
         })();
     })()`;
 }
@@ -964,7 +959,7 @@ export class ChatSessionService {
 
         let usedPastConversations = false;
         let directResult: { ok: boolean; error?: string } = { ok: false, error: 'not attempted' };
-        let pastResult: { ok: boolean; error?: string } | null = null;
+        let pastResult: { ok: boolean; error?: string; matchedTitle?: string } | null = null;
         let clicked = false;
         let startedAt = Date.now();
         let attempts = 0;
@@ -1015,7 +1010,11 @@ export class ChatSessionService {
         // label even after an exact Past Conversations option is selected.
         // The selection script only reports success after matching the wanted
         // title inside this workspace's conversation picker.
-        if (usedPastConversations && after.title.trim() === 'Agent') {
+        if (
+            usedPastConversations &&
+            after.title.trim() === 'Agent' &&
+            pastResult?.matchedTitle?.trim() === title.trim()
+        ) {
             logger.debug(
                 `[ChatSession] Accepting Agent-header bypass: ` +
                 `usedPastConversations=true observedTitle="${after.title}" targetTitle="${title}"`,
@@ -1045,7 +1044,10 @@ export class ChatSessionService {
                     await this.closePanelWithEscape(cdpService);
                     return { ok: true };
                 }
-                if (afterPast.title.trim() === 'Agent') {
+                if (
+                    afterPast.title.trim() === 'Agent' &&
+                    viaPast.matchedTitle?.trim() === title.trim()
+                ) {
                     logger.debug(
                         `[ChatSession] Accepting Agent-header bypass: ` +
                         `usedPastConversations=true observedTitle="${afterPast.title}" targetTitle="${title}"`,
@@ -1082,7 +1084,7 @@ export class ChatSessionService {
     private async tryActivateByPastConversations(
         cdpService: CdpService,
         title: string,
-    ): Promise<{ ok: boolean; error?: string }> {
+    ): Promise<{ ok: boolean; error?: string; matchedTitle?: string }> {
         return this.tryActivateWithScript(cdpService, buildActivateViaPastConversationsScript(title), true);
     }
 
@@ -1090,7 +1092,7 @@ export class ChatSessionService {
         cdpService: CdpService,
         script: string,
         awaitPromise: boolean,
-    ): Promise<{ ok: boolean; error?: string }> {
+    ): Promise<{ ok: boolean; error?: string; matchedTitle?: string }> {
         const contexts = cdpService.getContexts();
         let lastError = 'Activation script returned no match';
         for (const ctx of contexts) {
@@ -1103,7 +1105,12 @@ export class ChatSessionService {
                 });
                 const value = result?.result?.value;
                 if (value?.ok) {
-                    return { ok: true };
+                    return {
+                        ok: true,
+                        ...(typeof value.matchedTitle === 'string'
+                            ? { matchedTitle: value.matchedTitle }
+                            : {}),
+                    };
                 }
                 if (value?.error && typeof value.error === 'string') {
                     lastError = value.error;

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -19,9 +19,9 @@ export function getAntigravityCliPath(): string {
     if (process.platform === 'win32') {
         const localAppData = process.env.LOCALAPPDATA;
         if (localAppData) {
-            return `${localAppData}\\Programs\\Antigravity\\Antigravity.exe`;
+            return `${localAppData}\\Programs\\Antigravity IDE\\Antigravity IDE.exe`;
         }
-        return 'Antigravity.exe'; // Fallback if LOCALAPPDATA is undefined
+        return 'Antigravity IDE.exe'; // Fallback if LOCALAPPDATA is undefined
     }
 
     // Default for Linux or any unknown OS, assuming 'antigravity' is in the system PATH
@@ -50,7 +50,7 @@ export function getAntigravityCdpHint(port: number = 9222): string {
         case 'darwin':
             return `open -a ${APP_NAME} --args --remote-debugging-port=${port}`;
         case 'win32':
-            return `${APP_NAME}.exe --remote-debugging-port=${port}`;
+            return `${APP_NAME} IDE.exe --remote-debugging-port=${port}`;
         default:
             return `${APP_NAME.toLowerCase()} --remote-debugging-port=${port}`;
     }

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -50,7 +50,7 @@ export function getAntigravityCdpHint(port: number = 9222): string {
         case 'darwin':
             return `open -a ${APP_NAME} --args --remote-debugging-port=${port}`;
         case 'win32':
-            return `${APP_NAME} IDE.exe --remote-debugging-port=${port}`;
+            return `"${APP_NAME} IDE.exe" --remote-debugging-port=${port}`;
         default:
             return `${APP_NAME.toLowerCase()} --remote-debugging-port=${port}`;
     }

--- a/start_antigravity_win.bat
+++ b/start_antigravity_win.bat
@@ -22,7 +22,12 @@ exit /b 1
 
 :found
 echo [INFO] Starting Antigravity on port %SELECTED_PORT%...
-start "" "%LOCALAPPDATA%\Programs\Antigravity IDE\Antigravity IDE.exe" --remote-debugging-port=%SELECTED_PORT%
+if defined LOCALAPPDATA (
+    set "AG_EXE=%LOCALAPPDATA%\Programs\Antigravity IDE\Antigravity IDE.exe"
+) else (
+    set "AG_EXE=Antigravity IDE.exe"
+)
+start "" "%AG_EXE%" --remote-debugging-port=%SELECTED_PORT%
 echo [OK] Launch complete! CDP port: %SELECTED_PORT%
 timeout /t 2 >nul
 exit /b 0

--- a/start_antigravity_win.bat
+++ b/start_antigravity_win.bat
@@ -22,7 +22,7 @@ exit /b 1
 
 :found
 echo [INFO] Starting Antigravity on port %SELECTED_PORT%...
-start "" "Antigravity.exe" --remote-debugging-port=%SELECTED_PORT%
+start "" "%LOCALAPPDATA%\Programs\Antigravity IDE\Antigravity IDE.exe" --remote-debugging-port=%SELECTED_PORT%
 echo [OK] Launch complete! CDP port: %SELECTED_PORT%
 timeout /t 2 >nul
 exit /b 0

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -28,6 +28,7 @@ jest.mock('discord.js', () => {
             const builder: any = {};
             builder.setName = jest.fn().mockReturnValue(builder);
             builder.setDescription = jest.fn().mockReturnValue(builder);
+            builder.setDefaultMemberPermissions = jest.fn().mockReturnValue(builder);
             builder.addStringOption = jest.fn().mockImplementation((fn) => {
                 const option: any = {};
                 option.setName = jest.fn().mockReturnValue(option);
@@ -74,6 +75,7 @@ jest.mock('discord.js', () => {
             applicationCommands: jest.fn().mockReturnValue('/commands'),
             applicationGuildCommands: jest.fn().mockReturnValue('/guild-commands'),
         },
+        PermissionFlagsBits: { Administrator: 8n },
         // Additional mocks used in wiring
         AttachmentBuilder: jest.fn(),
         ButtonBuilder: jest.fn().mockImplementation(() => ({

--- a/tests/commands/registerSlashCommands.test.ts
+++ b/tests/commands/registerSlashCommands.test.ts
@@ -13,6 +13,11 @@ jest.mock('discord.js', () => {
             return this;
         }
 
+        setDefaultMemberPermissions(permissions: bigint) {
+            this.data.default_member_permissions = permissions.toString();
+            return this;
+        }
+
         addStringOption(fn: (option: any) => void) {
             const option = {
                 setName: jest.fn().mockReturnThis(),
@@ -69,6 +74,7 @@ jest.mock('discord.js', () => {
             applicationCommands: jest.fn().mockReturnValue('/global-commands'),
             applicationGuildCommands: jest.fn().mockReturnValue('/guild-commands'),
         },
+        PermissionFlagsBits: { Administrator: 8n },
     };
 });
 
@@ -96,6 +102,11 @@ describe('registerSlashCommands', () => {
         const names = slashCommands.map((cmd) => cmd.toJSON().name);
         expect(names).toContain('stop');
         expect(names).toContain('shutdown');
+    });
+
+    it('restricts shutdown visibility to administrators by default', () => {
+        const shutdown = slashCommands.find((cmd) => cmd.toJSON().name === 'shutdown');
+        expect(shutdown?.toJSON().default_member_permissions).toBe('8');
     });
 
     beforeEach(() => {

--- a/tests/commands/registerSlashCommands.test.ts
+++ b/tests/commands/registerSlashCommands.test.ts
@@ -92,6 +92,12 @@ describe('registerSlashCommands', () => {
         expect(names).toContain('output');
     });
 
+    it('registers both stop and shutdown commands', () => {
+        const names = slashCommands.map((cmd) => cmd.toJSON().name);
+        expect(names).toContain('stop');
+        expect(names).toContain('shutdown');
+    });
+
     beforeEach(() => {
         jest.clearAllMocks();
     });

--- a/tests/commands/workspaceCommandHandler.test.ts
+++ b/tests/commands/workspaceCommandHandler.test.ts
@@ -43,6 +43,7 @@ describe('WorkspaceCommandHandler', () => {
     }> = {}) => ({
         channelId: overrides.channelId ?? 'ch-1',
         guildId: overrides.guildId ?? 'guild-1',
+        user: { id: 'user-1' },
         editReply: jest.fn().mockResolvedValue(undefined),
     });
 
@@ -82,7 +83,7 @@ describe('WorkspaceCommandHandler', () => {
 
             await handler.handleShow(interaction as any);
 
-            expect(ensureIdeRunning).toHaveBeenCalledTimes(1);
+            expect(ensureIdeRunning).toHaveBeenCalledWith({ channelId: 'ch-1', userId: 'user-1' });
             expect(ensureIdeRunning.mock.invocationCallOrder[0])
                 .toBeLessThan(interaction.editReply.mock.invocationCallOrder[0]);
         });

--- a/tests/commands/workspaceCommandHandler.test.ts
+++ b/tests/commands/workspaceCommandHandler.test.ts
@@ -67,6 +67,41 @@ describe('WorkspaceCommandHandler', () => {
             const call = interaction.editReply.mock.calls[0][0];
             expect(call.components).toHaveLength(0);
         });
+
+        it('ensures Antigravity is running before displaying projects', async () => {
+            const ensureIdeRunning = jest.fn().mockResolvedValue(undefined);
+            handler = new WorkspaceCommandHandler(
+                bindingRepo,
+                chatSessionRepo,
+                service,
+                channelManager,
+                undefined,
+                ensureIdeRunning,
+            );
+            const interaction = mockInteraction();
+
+            await handler.handleShow(interaction as any);
+
+            expect(ensureIdeRunning).toHaveBeenCalledTimes(1);
+            expect(ensureIdeRunning.mock.invocationCallOrder[0])
+                .toBeLessThan(interaction.editReply.mock.invocationCallOrder[0]);
+        });
+
+        it('does not display projects when Antigravity startup fails', async () => {
+            const ensureIdeRunning = jest.fn().mockRejectedValue(new Error('startup failed'));
+            handler = new WorkspaceCommandHandler(
+                bindingRepo,
+                chatSessionRepo,
+                service,
+                channelManager,
+                undefined,
+                ensureIdeRunning,
+            );
+            const interaction = mockInteraction();
+
+            await expect(handler.handleShow(interaction as any)).rejects.toThrow('startup failed');
+            expect(interaction.editReply).not.toHaveBeenCalled();
+        });
     });
 
     describe('handleSelectMenu', () => {

--- a/tests/services/antigravityLauncher.test.ts
+++ b/tests/services/antigravityLauncher.test.ts
@@ -17,9 +17,9 @@ import {
 } from '../../src/services/antigravityLauncher';
 import { logger } from '../../src/utils/logger';
 
-function mockHttpSuccessOnce(port: number, targets: unknown[] = []): void {
+function mockHttpSuccessOnce(port: number, payload: unknown = []): void {
     (http.get as unknown as jest.Mock).mockImplementationOnce((url: string, cb: (res: EventEmitter) => void) => {
-        expect(url).toBe(`http://127.0.0.1:${port}/json/list`);
+        expect(url).toMatch(new RegExp(`http://127\\.0\\.0\\.1:${port}/json/(list|version)`));
 
         const req = new EventEmitter() as EventEmitter & {
             setTimeout: (ms: number, handler: () => void) => void;
@@ -31,7 +31,7 @@ function mockHttpSuccessOnce(port: number, targets: unknown[] = []): void {
         const res = new EventEmitter();
         cb(res);
         process.nextTick(() => {
-            res.emit('data', JSON.stringify(targets));
+            res.emit('data', JSON.stringify(payload));
             res.emit('end');
         });
 
@@ -41,7 +41,7 @@ function mockHttpSuccessOnce(port: number, targets: unknown[] = []): void {
 
 function mockHttpErrorOnce(port: number): void {
     (http.get as unknown as jest.Mock).mockImplementationOnce((url: string) => {
-        expect(url).toBe(`http://127.0.0.1:${port}/json/list`);
+        expect(url).toMatch(new RegExp(`http://127\\.0\\.0\\.1:${port}/json/(list|version)`));
         const req = new EventEmitter() as EventEmitter & {
             setTimeout: (ms: number, handler: () => void) => void;
             destroy: jest.Mock;
@@ -55,7 +55,7 @@ function mockHttpErrorOnce(port: number): void {
 
 function mockHttpErrorAlways(): void {
     (http.get as unknown as jest.Mock).mockImplementation((url: string, _cb: (res: EventEmitter) => void) => {
-        expect(url).toMatch(/http:\/\/127\.0\.0\.1:\d+\/json\/list/);
+        expect(url).toMatch(/http:\/\/127\.0\.0\.1:\d+\/json\/(list|version)/);
 
         const req = new EventEmitter() as EventEmitter & {
             setTimeout: (ms: number, handler: () => void) => void;
@@ -133,7 +133,7 @@ describe('Antigravity lifecycle', () => {
         process.env.LOCALAPPDATA = 'C:\\Users\\test\\AppData\\Local';
         mockHttpErrorOnce(9222);
         mockHttpSuccessOnce(9222);
-        (spawn as unknown as jest.Mock).mockReturnValue({ unref: jest.fn() });
+        (spawn as unknown as jest.Mock).mockReturnValue({ unref: jest.fn(), on: jest.fn() });
 
         try {
             await expect(startAntigravity(9222)).resolves.toBe('started');
@@ -160,7 +160,7 @@ describe('Antigravity lifecycle', () => {
 
     it('stops the process owning the requested CDP port', async () => {
         mockHttpSuccessOnce(9222);
-        mockHttpSuccessOnce(9222, [{ title: 'project - Antigravity' }]);
+        mockHttpSuccessOnce(9222, { Browser: 'Antigravity IDE' });
         (execFile as unknown as jest.Mock).mockImplementation(
             (_file: string, _args: string[], _options: unknown, callback: (error?: Error) => void) => callback(),
         );
@@ -177,7 +177,7 @@ describe('Antigravity lifecycle', () => {
 
     it('refuses to stop a non-Antigravity CDP listener', async () => {
         mockHttpSuccessOnce(9222);
-        mockHttpSuccessOnce(9222, [{ title: 'Google Chrome' }]);
+        mockHttpSuccessOnce(9222, { Browser: 'Google Chrome' });
 
         await expect(stopAntigravity(9222)).rejects.toThrow('Refusing to stop non-Antigravity');
         expect(execFile).not.toHaveBeenCalled();

--- a/tests/services/antigravityLauncher.test.ts
+++ b/tests/services/antigravityLauncher.test.ts
@@ -17,7 +17,7 @@ import {
 } from '../../src/services/antigravityLauncher';
 import { logger } from '../../src/utils/logger';
 
-function mockHttpSuccessOnce(port: number): void {
+function mockHttpSuccessOnce(port: number, targets: unknown[] = []): void {
     (http.get as unknown as jest.Mock).mockImplementationOnce((url: string, cb: (res: EventEmitter) => void) => {
         expect(url).toBe(`http://127.0.0.1:${port}/json/list`);
 
@@ -31,10 +31,24 @@ function mockHttpSuccessOnce(port: number): void {
         const res = new EventEmitter();
         cb(res);
         process.nextTick(() => {
-            res.emit('data', '[]');
+            res.emit('data', JSON.stringify(targets));
             res.emit('end');
         });
 
+        return req;
+    });
+}
+
+function mockHttpErrorOnce(port: number): void {
+    (http.get as unknown as jest.Mock).mockImplementationOnce((url: string) => {
+        expect(url).toBe(`http://127.0.0.1:${port}/json/list`);
+        const req = new EventEmitter() as EventEmitter & {
+            setTimeout: (ms: number, handler: () => void) => void;
+            destroy: jest.Mock;
+        };
+        req.setTimeout = () => {};
+        req.destroy = jest.fn();
+        process.nextTick(() => req.emit('error', new Error('connect failed')));
         return req;
     });
 }
@@ -112,6 +126,30 @@ describe('Antigravity lifecycle', () => {
         expect(spawn).not.toHaveBeenCalled();
     });
 
+    it('launches with the platform resolver when no path override is configured', async () => {
+        const originalPath = process.env.ANTIGRAVITY_PATH;
+        const originalLocalAppData = process.env.LOCALAPPDATA;
+        delete process.env.ANTIGRAVITY_PATH;
+        process.env.LOCALAPPDATA = 'C:\\Users\\test\\AppData\\Local';
+        mockHttpErrorOnce(9222);
+        mockHttpSuccessOnce(9222);
+        (spawn as unknown as jest.Mock).mockReturnValue({ unref: jest.fn() });
+
+        try {
+            await expect(startAntigravity(9222)).resolves.toBe('started');
+            expect(spawn).toHaveBeenCalledWith(
+                'C:\\Users\\test\\AppData\\Local\\Programs\\Antigravity IDE\\Antigravity IDE.exe',
+                ['--remote-debugging-port=9222'],
+                expect.objectContaining({ detached: true }),
+            );
+        } finally {
+            if (originalPath === undefined) delete process.env.ANTIGRAVITY_PATH;
+            else process.env.ANTIGRAVITY_PATH = originalPath;
+            if (originalLocalAppData === undefined) delete process.env.LOCALAPPDATA;
+            else process.env.LOCALAPPDATA = originalLocalAppData;
+        }
+    });
+
     it('reports already stopped when the requested CDP port is unavailable', async () => {
         mockHttpErrorAlways();
 
@@ -122,6 +160,7 @@ describe('Antigravity lifecycle', () => {
 
     it('stops the process owning the requested CDP port', async () => {
         mockHttpSuccessOnce(9222);
+        mockHttpSuccessOnce(9222, [{ title: 'project - Antigravity' }]);
         (execFile as unknown as jest.Mock).mockImplementation(
             (_file: string, _args: string[], _options: unknown, callback: (error?: Error) => void) => callback(),
         );
@@ -134,5 +173,13 @@ describe('Antigravity lifecycle', () => {
             expect.objectContaining({ windowsHide: true }),
             expect.any(Function),
         );
+    });
+
+    it('refuses to stop a non-Antigravity CDP listener', async () => {
+        mockHttpSuccessOnce(9222);
+        mockHttpSuccessOnce(9222, [{ title: 'Google Chrome' }]);
+
+        await expect(stopAntigravity(9222)).rejects.toThrow('Refusing to stop non-Antigravity');
+        expect(execFile).not.toHaveBeenCalled();
     });
 });

--- a/tests/services/antigravityLauncher.test.ts
+++ b/tests/services/antigravityLauncher.test.ts
@@ -163,17 +163,38 @@ describe('Antigravity lifecycle', () => {
         mockHttpSuccessOnce(9222);
         mockHttpSuccessOnce(9222, { Browser: 'Antigravity IDE' });
         (execFile as unknown as jest.Mock).mockImplementation(
-            (_file: string, _args: string[], _options: unknown, callback: (error?: Error) => void) => callback(),
+            (file: string, _args: string[], optionsOrCallback: unknown, callback?: Function) => {
+                const cb = typeof optionsOrCallback === 'function' ? optionsOrCallback : callback;
+                if (file === 'lsof') {
+                    cb!(null, '12345\n');
+                } else {
+                    cb!();
+                }
+            }
         );
 
         await expect(stopAntigravity(9222)).resolves.toBe('stopped');
 
-        expect(execFile).toHaveBeenCalledWith(
-            'powershell.exe',
-            expect.arrayContaining(['-Command', expect.stringContaining('LocalPort 9222')]),
-            expect.objectContaining({ windowsHide: true }),
-            expect.any(Function),
-        );
+        const isWindows = process.platform === 'win32';
+        if (isWindows) {
+            expect(execFile).toHaveBeenCalledWith(
+                'powershell.exe',
+                expect.arrayContaining(['-Command', expect.stringContaining('LocalPort 9222')]),
+                expect.objectContaining({ windowsHide: true }),
+                expect.any(Function),
+            );
+        } else {
+            expect(execFile).toHaveBeenCalledWith(
+                'lsof',
+                ['-tiTCP:9222', '-sTCP:LISTEN'],
+                expect.any(Function),
+            );
+            expect(execFile).toHaveBeenCalledWith(
+                'kill',
+                ['-TERM', '12345'],
+                expect.any(Function),
+            );
+        }
     });
 
     it('refuses to stop a non-Antigravity CDP listener', async () => {

--- a/tests/services/antigravityLauncher.test.ts
+++ b/tests/services/antigravityLauncher.test.ts
@@ -3,9 +3,18 @@ import { EventEmitter } from 'events';
 jest.mock('http', () => ({
     get: jest.fn(),
 }));
+jest.mock('child_process', () => ({
+    execFile: jest.fn(),
+    spawn: jest.fn(),
+}));
 
 import * as http from 'http';
-import { ensureAntigravityRunning } from '../../src/services/antigravityLauncher';
+import { execFile, spawn } from 'child_process';
+import {
+    ensureAntigravityRunning,
+    startAntigravity,
+    stopAntigravity,
+} from '../../src/services/antigravityLauncher';
 import { logger } from '../../src/utils/logger';
 
 function mockHttpSuccessOnce(port: number): void {
@@ -86,6 +95,44 @@ describe('ensureAntigravityRunning', () => {
         expect(consoleWarnSpy).toHaveBeenCalledWith(
             expect.stringContaining('\x1b[33m[WARN]\x1b[0m'),
             expect.stringContaining('  Antigravity CDP ports are not responding')
+        );
+    });
+});
+
+describe('Antigravity lifecycle', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('does not launch when the requested CDP port is already running', async () => {
+        mockHttpSuccessOnce(9222);
+
+        await expect(startAntigravity(9222)).resolves.toBe('already-running');
+
+        expect(spawn).not.toHaveBeenCalled();
+    });
+
+    it('reports already stopped when the requested CDP port is unavailable', async () => {
+        mockHttpErrorAlways();
+
+        await expect(stopAntigravity(9222)).resolves.toBe('already-stopped');
+
+        expect(execFile).not.toHaveBeenCalled();
+    });
+
+    it('stops the process owning the requested CDP port', async () => {
+        mockHttpSuccessOnce(9222);
+        (execFile as unknown as jest.Mock).mockImplementation(
+            (_file: string, _args: string[], _options: unknown, callback: (error?: Error) => void) => callback(),
+        );
+
+        await expect(stopAntigravity(9222)).resolves.toBe('stopped');
+
+        expect(execFile).toHaveBeenCalledWith(
+            'powershell.exe',
+            expect.arrayContaining(['-Command', expect.stringContaining('LocalPort 9222')]),
+            expect.objectContaining({ windowsHide: true }),
+            expect.any(Function),
         );
     });
 });

--- a/tests/services/antigravityLauncher.test.ts
+++ b/tests/services/antigravityLauncher.test.ts
@@ -7,6 +7,10 @@ jest.mock('child_process', () => ({
     execFile: jest.fn(),
     spawn: jest.fn(),
 }));
+jest.mock('../../src/utils/pathUtils', () => ({
+    ...jest.requireActual('../../src/utils/pathUtils'),
+    getAntigravityCliPath: jest.fn(() => '/mock/antigravity'),
+}));
 
 import * as http from 'http';
 import { execFile, spawn } from 'child_process';
@@ -128,9 +132,8 @@ describe('Antigravity lifecycle', () => {
 
     it('launches with the platform resolver when no path override is configured', async () => {
         const originalPath = process.env.ANTIGRAVITY_PATH;
-        const originalLocalAppData = process.env.LOCALAPPDATA;
         delete process.env.ANTIGRAVITY_PATH;
-        process.env.LOCALAPPDATA = 'C:\\Users\\test\\AppData\\Local';
+
         mockHttpErrorOnce(9222);
         mockHttpSuccessOnce(9222);
         (spawn as unknown as jest.Mock).mockReturnValue({ unref: jest.fn(), on: jest.fn() });
@@ -138,15 +141,13 @@ describe('Antigravity lifecycle', () => {
         try {
             await expect(startAntigravity(9222)).resolves.toBe('started');
             expect(spawn).toHaveBeenCalledWith(
-                'C:\\Users\\test\\AppData\\Local\\Programs\\Antigravity IDE\\Antigravity IDE.exe',
+                '/mock/antigravity',
                 ['--remote-debugging-port=9222'],
                 expect.objectContaining({ detached: true }),
             );
         } finally {
             if (originalPath === undefined) delete process.env.ANTIGRAVITY_PATH;
             else process.env.ANTIGRAVITY_PATH = originalPath;
-            if (originalLocalAppData === undefined) delete process.env.LOCALAPPDATA;
-            else process.env.LOCALAPPDATA = originalLocalAppData;
         }
     });
 

--- a/tests/services/cdpService.retryInject.test.ts
+++ b/tests/services/cdpService.retryInject.test.ts
@@ -1,29 +1,42 @@
-import fs from 'fs';
-import path from 'path';
+import { CdpService } from '../../src/services/cdpService';
 
 describe('CdpService injection recovery', () => {
-    it('supports the current Antigravity message input combobox', () => {
-        const source = fs.readFileSync(
-            path.join(__dirname, '../../src/services/cdpService.ts'),
-            'utf8',
-        );
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
 
-        expect(source).toContain(
-            'div[role="combobox"][contenteditable="true"][aria-label="Message input"]',
-        );
+    it('opens the chat panel and retries injection after a transient failure', async () => {
+        const service = new CdpService() as any;
+        jest.spyOn(service, 'isTransientInjectError').mockReturnValue(true);
+        const findTarget = jest.spyOn(service, 'findWorkbenchTarget').mockResolvedValue({
+            webSocketDebuggerUrl: 'ws://workbench',
+        });
+        const openPanel = jest.spyOn(service, 'openChatPanelViaKeyboard').mockResolvedValue(undefined);
+        jest.spyOn(service, 'reconnectOnDemand').mockResolvedValue(undefined);
+        jest.spyOn(service, 'waitForChatInputReady').mockResolvedValue({ ok: true, contextId: 7 });
+        const inject = jest.spyOn(service, 'injectMessageCore').mockResolvedValue({ ok: true, method: 'enter' });
+
+        const pending = service.retryInjectOnce('hello', 'WebSocket disconnected');
+        await jest.runAllTimersAsync();
+
+        await expect(pending).resolves.toEqual({ ok: true, method: 'enter' });
+        expect(findTarget).toHaveBeenCalledTimes(1);
+        expect(openPanel).toHaveBeenCalledWith('ws://workbench');
+        expect(inject).toHaveBeenCalledWith('hello', undefined);
     });
 
-    it('opens the chat panel before retrying a transient injection failure', () => {
-        const source = fs.readFileSync(
-            path.join(__dirname, '../../src/services/cdpService.ts'),
-            'utf8',
-        );
-        const retryStart = source.indexOf('private async retryInjectOnce');
-        const retryEnd = source.indexOf('private async clearInputField', retryStart);
-        const retrySource = source.slice(retryStart, retryEnd);
+    it('returns the readiness error without retrying injection when input stays unavailable', async () => {
+        const service = new CdpService() as any;
+        jest.spyOn(service, 'isTransientInjectError').mockReturnValue(false);
+        const findTarget = jest.spyOn(service, 'findWorkbenchTarget');
+        jest.spyOn(service, 'reconnectOnDemand').mockRejectedValue(new Error('offline'));
+        jest.spyOn(service, 'waitForChatInputReady').mockResolvedValue({ ok: false, error: 'input unavailable' });
+        const inject = jest.spyOn(service, 'injectMessageCore');
 
-        expect(retrySource).toContain('this.isTransientInjectError(firstError)');
-        expect(retrySource).toContain('await this.findWorkbenchTarget()');
-        expect(retrySource).toContain('await this.openChatPanelViaKeyboard(target.webSocketDebuggerUrl)');
+        const pending = service.retryInjectOnce('hello', 'input missing');
+        await jest.runAllTimersAsync();
+
+        await expect(pending).resolves.toEqual({ ok: false, error: 'input unavailable' });
+        expect(findTarget).not.toHaveBeenCalled();
+        expect(inject).not.toHaveBeenCalled();
     });
 });

--- a/tests/services/cdpService.workspace.test.ts
+++ b/tests/services/cdpService.workspace.test.ts
@@ -128,12 +128,12 @@ describe('CdpService - Cross-Platform Workspace Launching', () => {
             await service.discoverAndConnectForWorkspace(workspacePath);
 
             expect(mockRunCommand).toHaveBeenCalledWith(
-                'C:\\Users\\TestUser\\AppData\\Local\\Programs\\Antigravity\\Antigravity.exe',
+                'C:\\Users\\TestUser\\AppData\\Local\\Programs\\Antigravity IDE\\Antigravity IDE.exe',
                 ['--remote-debugging-port=9999', '--new-window', workspacePath]
             );
         });
 
-        it('should fallback to Antigravity.exe if LOCALAPPDATA is missing on Windows', async () => {
+        it('should fallback to Antigravity IDE.exe if LOCALAPPDATA is missing on Windows', async () => {
             setPlatform('win32');
             delete process.env.LOCALAPPDATA;
 
@@ -151,7 +151,36 @@ describe('CdpService - Cross-Platform Workspace Launching', () => {
             await service.discoverAndConnectForWorkspace(workspacePath);
 
             expect(mockRunCommand).toHaveBeenCalledWith(
-                'Antigravity.exe',
+                'Antigravity IDE.exe',
+                ['--remote-debugging-port=9999', '--new-window', workspacePath]
+            );
+        });
+
+        it('should honor ANTIGRAVITY_PATH when opening another Windows workspace', async () => {
+            setPlatform('win32');
+            process.env.ANTIGRAVITY_PATH = 'C:\\Custom\\Antigravity IDE.exe';
+
+            mockGetJson
+                .mockResolvedValueOnce([{
+                    id: 'existing-id',
+                    type: 'page',
+                    title: 'ExistingProject - Antigravity IDE',
+                    webSocketDebuggerUrl: 'ws://existing',
+                    url: 'file:///workbench'
+                }])
+                .mockResolvedValue([{
+                    id: 'new-id',
+                    type: 'page',
+                    title: 'MyProject - Antigravity IDE',
+                    webSocketDebuggerUrl: 'ws://new',
+                    url: 'file:///workbench'
+                }]);
+
+            const workspacePath = 'C:\\Source\\MyProject';
+            await service.discoverAndConnectForWorkspace(workspacePath);
+
+            expect(mockRunCommand).toHaveBeenCalledWith(
+                'C:\\Custom\\Antigravity IDE.exe',
                 ['--remote-debugging-port=9999', '--new-window', workspacePath]
             );
         });

--- a/tests/services/chatSessionService.test.ts
+++ b/tests/services/chatSessionService.test.ts
@@ -1,5 +1,6 @@
 import { ChatSessionService } from '../../src/services/chatSessionService';
 import { CdpService } from '../../src/services/cdpService';
+import { logger } from '../../src/utils/logger';
 
 jest.mock('../../src/services/cdpService');
 const MockedCdpService = CdpService as jest.MockedClass<typeof CdpService>;
@@ -225,6 +226,7 @@ describe('ChatSessionService', () => {
         });
 
         it('accepts an exact Past Conversations selection when the header remains Agent', async () => {
+            const debugSpy = jest.spyOn(logger, 'debug');
             mockCdpService.call.mockImplementation(async (method: string, params: any) => {
                 const expression = String(params?.expression || '');
                 if (method !== 'Runtime.evaluate') return {};
@@ -243,6 +245,11 @@ describe('ChatSessionService', () => {
             const result = await service.activateSessionByTitle(mockCdpService, 'target-session');
 
             expect(result).toEqual({ ok: true });
+            expect(debugSpy).toHaveBeenCalledWith(
+                expect.stringContaining(
+                    'usedPastConversations=true observedTitle="Agent" targetTitle="target-session"',
+                ),
+            );
         });
 
         it('retries activation while UI is still loading and eventually succeeds', async () => {

--- a/tests/services/chatSessionService.test.ts
+++ b/tests/services/chatSessionService.test.ts
@@ -211,7 +211,7 @@ describe('ChatSessionService', () => {
                 }
 
                 if (expression.includes('Past Conversations button not found')) {
-                    return { result: { value: { ok: true } } };
+                    return { result: { value: { ok: true, matchedTitle: 'target-session' } } };
                 }
 
                 return { result: { value: null } };
@@ -237,7 +237,7 @@ describe('ChatSessionService', () => {
                     return { result: { value: { ok: false, error: 'not found' } } };
                 }
                 if (expression.includes('Past Conversations button not found')) {
-                    return { result: { value: { ok: true } } };
+                    return { result: { value: { ok: true, matchedTitle: 'target-session' } } };
                 }
                 return { result: { value: null } };
             });
@@ -250,6 +250,28 @@ describe('ChatSessionService', () => {
                     'usedPastConversations=true observedTitle="Agent" targetTitle="target-session"',
                 ),
             );
+        });
+
+        it('rejects an Agent header when Past Conversations provides no deterministic match', async () => {
+            mockCdpService.call.mockImplementation(async (method: string, params: any) => {
+                const expression = String(params?.expression || '');
+                if (method !== 'Runtime.evaluate') return {};
+                if (expression.includes('const header = panel.querySelector')) {
+                    return { result: { value: { title: 'Agent', hasActiveChat: false } } };
+                }
+                if (expression.includes('Chat title not found in side panel')) {
+                    return { result: { value: { ok: false, error: 'not found' } } };
+                }
+                if (expression.includes('Past Conversations button not found')) {
+                    return { result: { value: { ok: true } } };
+                }
+                return { result: { value: null } };
+            });
+
+            const result = await service.activateSessionByTitle(mockCdpService, 'target-session');
+
+            expect(result.ok).toBe(false);
+            expect(result.error).toContain('did not match target title');
         });
 
         it('retries activation while UI is still loading and eventually succeeds', async () => {

--- a/tests/services/chatSessionService.test.ts
+++ b/tests/services/chatSessionService.test.ts
@@ -128,6 +128,18 @@ describe('ChatSessionService', () => {
             expect(info.hasActiveChat).toBe(false);
         });
 
+        it('checks the highlighted conversation row when the header is the generic Agent label', async () => {
+            mockCdpService.call.mockResolvedValue({
+                result: { value: { title: 'Listing Repository Files', hasActiveChat: true } }
+            });
+
+            const info = await service.getCurrentSessionInfo(mockCdpService);
+            const expression = String(mockCdpService.call.mock.calls[0][1]?.expression || '');
+
+            expect(expression).toContain('focusBackground');
+            expect(info).toEqual({ title: 'Listing Repository Files', hasActiveChat: true });
+        });
+
         it('returns fallback values when a CDP call throws an exception', async () => {
             mockCdpService.call.mockRejectedValue(new Error('CDPエラー'));
 
@@ -210,6 +222,27 @@ describe('ChatSessionService', () => {
                 (c) => c.method === 'Input.dispatchKeyEvent' && c.params?.key === 'Escape',
             );
             expect(escapeCall).toBeDefined();
+        });
+
+        it('accepts an exact Past Conversations selection when the header remains Agent', async () => {
+            mockCdpService.call.mockImplementation(async (method: string, params: any) => {
+                const expression = String(params?.expression || '');
+                if (method !== 'Runtime.evaluate') return {};
+                if (expression.includes('const header = panel.querySelector')) {
+                    return { result: { value: { title: 'Agent', hasActiveChat: false } } };
+                }
+                if (expression.includes('Chat title not found in side panel')) {
+                    return { result: { value: { ok: false, error: 'not found' } } };
+                }
+                if (expression.includes('Past Conversations button not found')) {
+                    return { result: { value: { ok: true } } };
+                }
+                return { result: { value: null } };
+            });
+
+            const result = await service.activateSessionByTitle(mockCdpService, 'target-session');
+
+            expect(result).toEqual({ ok: true });
         });
 
         it('retries activation while UI is still loading and eventually succeeds', async () => {

--- a/tests/utils/pathUtils.test.ts
+++ b/tests/utils/pathUtils.test.ts
@@ -58,7 +58,7 @@ describe('pathUtils', () => {
         it('returns exe hint on Windows', () => {
             withPlatform('win32', () => {
                 expect(getAntigravityCdpHint(9222)).toBe(
-                    'Antigravity.exe --remote-debugging-port=9222',
+                    'Antigravity IDE.exe --remote-debugging-port=9222',
                 );
             });
         });

--- a/tests/utils/pathUtils.test.ts
+++ b/tests/utils/pathUtils.test.ts
@@ -58,7 +58,7 @@ describe('pathUtils', () => {
         it('returns exe hint on Windows', () => {
             withPlatform('win32', () => {
                 expect(getAntigravityCdpHint(9222)).toBe(
-                    'Antigravity IDE.exe --remote-debugging-port=9222',
+                    '"Antigravity IDE.exe" --remote-debugging-port=9222',
                 );
             });
         });


### PR DESCRIPTION
## Dependencies

This PR is based on and requires the pending current Antigravity chat-input and Windows multi-project session-routing changes.

## Problem

Remote operators cannot shut down the Antigravity IDE while keeping LazyGravity online to restart it later. The existing /stop command must remain available for interrupting active LLM generation.

## Solution

- Add /shutdown to stop only the Antigravity IDE process owning the configured CDP port.
- Keep LazyGravity online and preserve /stop generation-interruption behavior.
- Disconnect stale project CDP connections during IDE shutdown.
- Start Antigravity lazily from /project list when CDP is unavailable.
- Preserve project and session bindings across IDE restarts.

## Validation

- npm test: 109 suites and 1,424 tests passed.
- npm run build passed.
- Added command-registration, launcher lifecycle, and project-list startup coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `/shutdown` command for administrators to stop the app’s connected services.
* **Bug Fixes**
  * Improved session selection so the correct chat session is recognized more reliably.
  * Made project listing wait for the IDE to be ready before loading workspaces.
  * Updated Windows launch and path handling to use the newer Antigravity IDE executable name.
* **Documentation**
  * Refreshed Windows troubleshooting guidance in the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->