### PR TITLE
ci: drop @semantic-release/git plugin to fix Release on protected main

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,20 +3,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md"
-      }
-    ],
     "@semantic-release/npm",
-    "@semantic-release/github",
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json", "package-lock.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ]
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Problem

The **Release** workflow (semantic-release) fails on every release-triggering merge to `main`. It first surfaced when **#177** landed:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - Required status check "build-and-test (20.x)" is expected.
 ! [remote rejected] HEAD -> main (protected branch hook declined)
  pluginName: '@semantic-release/git'
```

`@semantic-release/git` tries to commit `CHANGELOG.md` / `package.json` back to `main` and push directly, which the branch protection on `main` rejects. Because this happens in the `prepare` phase — **before** `@semantic-release/npm` publish and the GitHub release — **no release is actually published** for any `fix`/`feat`.

## Why it started recently

This is a regression from **#156**. The git plugin had previously been removed for exactly this reason:

- `bc30334` — *"fix: remove @semantic-release/git plugin for branch protection compatibility"*
- `#156` (`17c47a5`) — *"chore: automate CHANGELOG and version sync via semantic-release"* re-added `@semantic-release/git` (with `assets: [CHANGELOG.md, package.json, package-lock.json]`)

Between those two, releases worked (no push to `main`). Since #156, the first `fix:` merge (#177) hit the wall. Intervening merges were all dependabot `chore`s, which don't trigger a release, so the breakage stayed hidden.

## Fix

Remove `@semantic-release/git` (the push) and `@semantic-release/changelog` (its committed asset), restoring the `bc30334` configuration.

- ✅ `@semantic-release/npm` publish, `@semantic-release/github` releases, git tags and version resolution all keep working (tags are not under branch protection).
- ➖ Release notes live in **GitHub Releases** instead of a committed `CHANGELOG.md`. The existing `CHANGELOG.md` is left in place but no longer auto-updated.

If committing the changelog back into the repo is desired later, that requires a bypass-capable token (GitHub App / PAT) for the Release workflow rather than the default `GITHUB_TOKEN` — a larger change tracked separately.

## Validation

Merging this PR pushes to `main` and runs the Release workflow, which will pick up the already-merged-but-unreleased **#177** `fix:` and should now publish successfully (npm + GitHub release + tag), confirming the fix end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DeNwipWrjRhyLSjcrw4aVx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the release process so published updates now focus on package and GitHub release publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->