### PR TITLE
fix: check User-Agent for antigravity CDP identification in shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Just type in any bound channel:
 - `🔗 /join` — Join an existing Antigravity session (shows up to 20 recent sessions)
 - `🔗 /mirror` — Toggle PC→Discord message mirroring for the current session
 - `🛑 /stop` — Force-stop a running Antigravity task
+- `🛑 /shutdown` — shutdown the IDE while keep the active CDP project connections and session bindings
 - `📸 /screenshot` — Capture and send Antigravity's current screen
 - `🔧 /status` — Show bot connection status, current mode, and active project
 - `✅ /autoaccept [on|off|status]` — Toggle auto-approval of file edit dialogs

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Just type in any bound channel:
 - `🔗 /join` — Join an existing Antigravity session (shows up to 20 recent sessions)
 - `🔗 /mirror` — Toggle PC→Discord message mirroring for the current session
 - `🛑 /stop` — Force-stop a running Antigravity task
-- `🛑 /shutdown` — shutdown the IDE while keep the active CDP project connections and session bindings
+- `🛑 /shutdown` — Shut down the IDE while keeping the active CDP project connections and session bindings
 - `📸 /screenshot` — Capture and send Antigravity's current screen
 - `🔧 /status` — Show bot connection status, current mode, and active project
 - `✅ /autoaccept [on|off|status]` — Toggle auto-approval of file edit dialogs

--- a/src/services/antigravityLauncher.ts
+++ b/src/services/antigravityLauncher.ts
@@ -86,7 +86,8 @@ export function stopAntigravity(port: number = CDP_PORTS[0]): Promise<'stopped' 
 
         const version = await getCdpVersion(port);
         const browser = typeof version?.Browser === 'string' ? version.Browser.toLowerCase() : '';
-        if (!browser.includes('antigravity')) {
+        const userAgent = typeof version?.['User-Agent'] === 'string' ? version['User-Agent'].toLowerCase() : '';
+        if (!browser.includes('antigravity') && !userAgent.includes('antigravity')) {
             throw new Error(`Refusing to stop non-Antigravity CDP service on port ${port}.`);
         }
 

--- a/src/services/antigravityLauncher.ts
+++ b/src/services/antigravityLauncher.ts
@@ -31,6 +31,9 @@ export function checkPort(port: number): Promise<boolean> {
     });
 }
 
+/**
+ * Waits for a specific port to respond within the given timeout.
+ */
 async function waitForPort(port: number, timeoutMs: number = 30000): Promise<boolean> {
     const deadline = Date.now() + timeoutMs;
     do {
@@ -40,6 +43,9 @@ async function waitForPort(port: number, timeoutMs: number = 30000): Promise<boo
     return false;
 }
 
+/**
+ * Ensures lifecycle operations (start/stop) are executed sequentially to prevent race conditions.
+ */
 function serializeLifecycle<T>(operation: () => Promise<T>): Promise<T> {
     const pending = lifecycleOperation
         ? lifecycleOperation.then(operation, operation)
@@ -51,6 +57,9 @@ function serializeLifecycle<T>(operation: () => Promise<T>): Promise<T> {
     return pending;
 }
 
+/**
+ * Starts the Antigravity IDE process with CDP enabled on the specified port.
+ */
 export function startAntigravity(port: number = CDP_PORTS[0]): Promise<'started' | 'already-running'> {
     return serializeLifecycle(async () => {
         if (await checkPort(port)) return 'already-running';
@@ -80,6 +89,9 @@ export function startAntigravity(port: number = CDP_PORTS[0]): Promise<'started'
     });
 }
 
+/**
+ * Gracefully stops the running Antigravity IDE CDP process on the specified port.
+ */
 export function stopAntigravity(port: number = CDP_PORTS[0]): Promise<'stopped' | 'already-stopped'> {
     return serializeLifecycle(async () => {
         if (!await checkPort(port)) return 'already-stopped';
@@ -116,6 +128,9 @@ export function stopAntigravity(port: number = CDP_PORTS[0]): Promise<'stopped' 
     });
 }
 
+/**
+ * Fetches the CDP /json/version payload to identify the connected browser target.
+ */
 function getCdpVersion(port: number): Promise<Record<string, unknown>> {
     return new Promise((resolve, reject) => {
         const req = http.get(`http://127.0.0.1:${port}/json/version`, (res) => {
@@ -137,6 +152,9 @@ function getCdpVersion(port: number): Promise<Record<string, unknown>> {
     });
 }
 
+/**
+ * Fetches the CDP /json/list payload to discover available debugging targets.
+ */
 function getCdpTargets(port: number): Promise<Record<string, unknown>[]> {
     return new Promise((resolve, reject) => {
         const req = http.get(`http://127.0.0.1:${port}/json/list`, (res) => {

--- a/src/services/antigravityLauncher.ts
+++ b/src/services/antigravityLauncher.ts
@@ -90,7 +90,7 @@ export function startAntigravity(port: number = CDP_PORTS[0]): Promise<'started'
 }
 
 /**
- * Gracefully stops the running Antigravity IDE CDP process on the specified port.
+ * Stops the running Antigravity IDE CDP process on the specified port (SIGTERM on POSIX, Stop-Process -Force on Windows).
  */
 export function stopAntigravity(port: number = CDP_PORTS[0]): Promise<'stopped' | 'already-stopped'> {
     return serializeLifecycle(async () => {

--- a/tests/services/antigravityLauncher.test.ts
+++ b/tests/services/antigravityLauncher.test.ts
@@ -235,6 +235,11 @@ describe('Antigravity lifecycle', () => {
                 ['-tiTCP:9222', '-sTCP:LISTEN'],
                 expect.any(Function),
             );
+            expect(execFile).toHaveBeenCalledWith(
+                'kill',
+                ['-TERM', '12345'],
+                expect.any(Function),
+            );
         }
     });
 });

--- a/tests/services/antigravityLauncher.test.ts
+++ b/tests/services/antigravityLauncher.test.ts
@@ -151,6 +151,19 @@ describe('Antigravity lifecycle', () => {
         }
     });
 
+    function mockStopExecFile() {
+        (execFile as unknown as jest.Mock).mockImplementation(
+            (file: string, _args: string[], optionsOrCallback: unknown, callback?: Function) => {
+                const cb = typeof optionsOrCallback === 'function' ? optionsOrCallback : callback;
+                if (file === 'lsof') {
+                    cb!(null, '12345\n');
+                } else {
+                    cb!();
+                }
+            }
+        );
+    }
+
     it('reports already stopped when the requested CDP port is unavailable', async () => {
         mockHttpErrorAlways();
 
@@ -162,16 +175,7 @@ describe('Antigravity lifecycle', () => {
     it('stops the process owning the requested CDP port', async () => {
         mockHttpSuccessOnce(9222);
         mockHttpSuccessOnce(9222, { Browser: 'Antigravity IDE' });
-        (execFile as unknown as jest.Mock).mockImplementation(
-            (file: string, _args: string[], optionsOrCallback: unknown, callback?: Function) => {
-                const cb = typeof optionsOrCallback === 'function' ? optionsOrCallback : callback;
-                if (file === 'lsof') {
-                    cb!(null, '12345\n');
-                } else {
-                    cb!();
-                }
-            }
-        );
+        mockStopExecFile();
 
         await expect(stopAntigravity(9222)).resolves.toBe('stopped');
 
@@ -207,39 +211,9 @@ describe('Antigravity lifecycle', () => {
 
     it('stops the process when only User-Agent contains Antigravity', async () => {
         mockHttpSuccessOnce(9222);
-        mockHttpSuccessOnce(9222, { Browser: 'Google Chrome', 'User-Agent': 'Mozilla/5.0 AntigravityIDE/1.0' });
-        (execFile as unknown as jest.Mock).mockImplementation(
-            (file: string, _args: string[], optionsOrCallback: unknown, callback?: Function) => {
-                const cb = typeof optionsOrCallback === 'function' ? optionsOrCallback : callback;
-                if (file === 'lsof') {
-                    cb!(null, '12345\n');
-                } else {
-                    cb!();
-                }
-            }
-        );
+        mockHttpSuccessOnce(9222, { Browser: 'Chrome/142.0.0.0', 'User-Agent': 'Mozilla/5.0 (...) Chrome/142.0.0.0 AntigravityIDE/2.0' });
+        mockStopExecFile();
 
         await expect(stopAntigravity(9222)).resolves.toBe('stopped');
-
-        const isWindows = process.platform === 'win32';
-        if (isWindows) {
-            expect(execFile).toHaveBeenCalledWith(
-                'powershell.exe',
-                expect.arrayContaining(['-Command', expect.stringContaining('LocalPort 9222')]),
-                expect.objectContaining({ windowsHide: true }),
-                expect.any(Function),
-            );
-        } else {
-            expect(execFile).toHaveBeenCalledWith(
-                'lsof',
-                ['-tiTCP:9222', '-sTCP:LISTEN'],
-                expect.any(Function),
-            );
-            expect(execFile).toHaveBeenCalledWith(
-                'kill',
-                ['-TERM', '12345'],
-                expect.any(Function),
-            );
-        }
     });
 });

--- a/tests/services/antigravityLauncher.test.ts
+++ b/tests/services/antigravityLauncher.test.ts
@@ -204,4 +204,37 @@ describe('Antigravity lifecycle', () => {
         await expect(stopAntigravity(9222)).rejects.toThrow('Refusing to stop non-Antigravity');
         expect(execFile).not.toHaveBeenCalled();
     });
+
+    it('stops the process when only User-Agent contains Antigravity', async () => {
+        mockHttpSuccessOnce(9222);
+        mockHttpSuccessOnce(9222, { Browser: 'Google Chrome', 'User-Agent': 'Mozilla/5.0 AntigravityIDE/1.0' });
+        (execFile as unknown as jest.Mock).mockImplementation(
+            (file: string, _args: string[], optionsOrCallback: unknown, callback?: Function) => {
+                const cb = typeof optionsOrCallback === 'function' ? optionsOrCallback : callback;
+                if (file === 'lsof') {
+                    cb!(null, '12345\n');
+                } else {
+                    cb!();
+                }
+            }
+        );
+
+        await expect(stopAntigravity(9222)).resolves.toBe('stopped');
+
+        const isWindows = process.platform === 'win32';
+        if (isWindows) {
+            expect(execFile).toHaveBeenCalledWith(
+                'powershell.exe',
+                expect.arrayContaining(['-Command', expect.stringContaining('LocalPort 9222')]),
+                expect.objectContaining({ windowsHide: true }),
+                expect.any(Function),
+            );
+        } else {
+            expect(execFile).toHaveBeenCalledWith(
+                'lsof',
+                ['-tiTCP:9222', '-sTCP:LISTEN'],
+                expect.any(Function),
+            );
+        }
+    });
 });


### PR DESCRIPTION
**Summary**
Fix CDP Detection for Antigravity Shutdown

**Description**
This pull request addresses an issue where the /shutdown command failed to stop the Antigravity IDE due to a mismatch in the Chrome DevTools Protocol (CDP) version check.

Previously, the shutdown logic only inspected the Browser property of the CDP version payload for the word "antigravity". However, the Antigravity IDE can report generic Chrome versions (e.g., Chrome/142.0.7444.175) in the Browser field, while appending its specific identifier (AntigravityIDE) to the User-Agent string. This caused the bot to incorrectly classify the IDE as a generic browser and refuse to stop the process.

This fix updates the shutdown validation logic to inspect both the Browser and User-Agent strings, ensuring the IDE is accurately detected.

**Changes Made**
Updated src/services/antigravityLauncher.ts to extract and validate the User-Agent field from the /json/version response during shutdown verification.

**Testing**
Triggered /shutdown locally with an active Antigravity IDE session.
Verified that the IDE process is correctly identified and gracefully terminated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Antigravity CDP service shutdown detection by checking both browser details and the User-Agent (case-insensitive), reducing incorrect stop failures.
* **New Features**
  * Added a new `🛑 /shutdown` slash command to shut down the IDE while keeping active CDP project connections and session bindings.
* **Tests**
  * Added coverage for shutdown behavior when the browser is non-Antigravity but the User-Agent indicates Antigravity.
* **Documentation**
  * Updated the README slash-command list to include `🛑 /shutdown`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->