### PR TITLE
fix(telegram): prevent mirror triple echo for Telegram-originated messages

### DIFF
--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1506,6 +1506,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                         accountPrefRepo,
                         channelPrefRepo,
                         antigravityAccounts: config.antigravityAccounts,
+                        activeMonitors,
                     }, interaction);
                     return;
                 }

--- a/src/bot/telegramJoinCommand.ts
+++ b/src/bot/telegramJoinCommand.ts
@@ -24,6 +24,9 @@ export interface TelegramJoinCommandDeps {
     readonly channelPrefRepo?: ChannelPreferenceRepository;
     readonly antigravityAccounts?: AntigravityAccountConfig[];
     readonly extractionMode?: import('../utils/config').ExtractionMode;
+    /** Primary active monitors from the main Telegram message handler (keyed by project name).
+     *  Used to skip passive mirror monitors when a primary monitor is already running. */
+    readonly activeMonitors?: Map<string, ResponseMonitor>;
 }
 
 const activeResponseMonitors = new Map<string, ResponseMonitor>();
@@ -189,13 +192,22 @@ async function routeMirroredMessage(
     startResponseMirror(deps, cdp, workspacePath, channel, chatTitle || 'Unknown');
 }
 
-function startResponseMirror(
+export function startResponseMirror(
     deps: TelegramJoinCommandDeps,
     cdp: CdpService,
     workspacePath: string,
     channel: any,
     chatTitle: string
 ): void {
+    // If the primary message handler already has an active monitor for this workspace,
+    // skip the passive mirror — the primary handler delivers the response itself, and
+    // running both would send the same AI response twice.
+    const projectName = deps.bridge.pool.extractProjectName(workspacePath);
+    if (deps.activeMonitors?.has(projectName)) {
+        logger.debug(`[TelegramMirror] Skipping passive monitor — primary monitor active for ${projectName}`);
+        return;
+    }
+
     const prev = activeResponseMonitors.get(workspacePath);
     if (prev?.isActive()) {
         prev.stop().catch(() => {});

--- a/src/bot/telegramMessageHandler.ts
+++ b/src/bot/telegramMessageHandler.ts
@@ -238,6 +238,13 @@ export function createTelegramMessageHandler(deps: TelegramMessageHandlerDeps) {
             const effectivePrompt = promptText || 'Please review the attached images and respond accordingly.';
             const baseline = await captureResponseMonitorBaseline(cdp);
 
+            // Register the echo hash BEFORE injecting (the Discord path registers it later):
+            // UserMessageDetector polls the DOM every ~2s, so registering only after
+            // injectMessage() resolves leaves a window where the injected prompt is detected
+            // as PC-side input and mirrored back to Telegram. If injection fails, the stale
+            // hash is harmless — it expires via its 60s TTL.
+            deps.bridge.pool.getUserMessageDetector?.(projectName, selectedAccount)?.addEchoHash(effectivePrompt);
+
             // Inject prompt (with or without images) into Antigravity
             logger.prompt(effectivePrompt);
             let injectResult;

--- a/tests/bot/telegramJoinCommand.test.ts
+++ b/tests/bot/telegramJoinCommand.test.ts
@@ -1,10 +1,19 @@
-import { handleMirror } from '../../src/bot/telegramJoinCommand';
+import { handleMirror, startResponseMirror } from '../../src/bot/telegramJoinCommand';
 import { ensureUserMessageDetector } from '../../src/services/cdpBridgeManager';
+import { ResponseMonitor } from '../../src/services/responseMonitor';
 
 jest.mock('../../src/services/cdpBridgeManager', () => ({
     ...jest.requireActual('../../src/services/cdpBridgeManager'),
     ensureUserMessageDetector: jest.fn(),
     getCurrentChatTitle: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('../../src/services/responseMonitor', () => ({
+    ResponseMonitor: jest.fn().mockImplementation(() => ({
+        startPassive: jest.fn().mockResolvedValue(undefined),
+        isActive: jest.fn().mockReturnValue(false),
+        stop: jest.fn().mockResolvedValue(undefined),
+    })),
 }));
 
 describe('telegramJoinCommand.handleMirror', () => {
@@ -58,5 +67,49 @@ describe('telegramJoinCommand.handleMirror', () => {
             expect.any(Function),
             'work1',
         );
+    });
+});
+
+describe('telegramJoinCommand.startResponseMirror', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    function createDeps(activeMonitors?: Map<string, any>) {
+        return {
+            bridge: {
+                pool: {
+                    extractProjectName: jest.fn().mockImplementation(
+                        (workspacePath: string) => workspacePath.split('/').pop(),
+                    ),
+                },
+            },
+            activeMonitors,
+        } as any;
+    }
+
+    it('skips the passive mirror when a primary monitor is active for the project', () => {
+        const activeMonitors = new Map([['project-a', {} as any]]);
+        const channel = { send: jest.fn() };
+
+        startResponseMirror(createDeps(activeMonitors), {} as any, '/ws/project-a', channel, 'Chat');
+
+        expect(ResponseMonitor).not.toHaveBeenCalled();
+    });
+
+    it('starts a passive mirror when no primary monitor is active', () => {
+        const channel = { send: jest.fn() };
+
+        startResponseMirror(createDeps(new Map()), {} as any, '/ws/project-b', channel, 'Chat');
+
+        expect(ResponseMonitor).toHaveBeenCalledTimes(1);
+    });
+
+    it('starts a passive mirror when activeMonitors is not provided (legacy callers)', () => {
+        const channel = { send: jest.fn() };
+
+        startResponseMirror(createDeps(undefined), {} as any, '/ws/project-c', channel, 'Chat');
+
+        expect(ResponseMonitor).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/bot/telegramMessageHandler.test.ts
+++ b/tests/bot/telegramMessageHandler.test.ts
@@ -215,6 +215,51 @@ describe('createTelegramMessageHandler', () => {
         expect(mockCdp.injectMessage).toHaveBeenCalledWith('test prompt');
     });
 
+    it('registers the echo hash with the effective prompt before injecting', async () => {
+        const callOrder: string[] = [];
+        const mockCdp = {
+            injectMessage: jest.fn().mockImplementation(async () => {
+                callOrder.push('injectMessage');
+                return { ok: true };
+            }),
+        };
+        const addEchoHash = jest.fn().mockImplementation(() => {
+            callOrder.push('addEchoHash');
+        });
+        const pool = {
+            ...createMockPool(mockCdp as any),
+            getUserMessageDetector: jest.fn().mockReturnValue({ addEchoHash }),
+        };
+        const bridge = createBridge(pool as any);
+        const binding = { chatId: 'chat-123', workspacePath: '/workspace/a' };
+        const telegramBindingRepo = createTelegramBindingRepo(binding);
+        const { message } = createMockMessage({ content: 'test prompt' });
+
+        const handler = createTelegramMessageHandler({ bridge, telegramBindingRepo });
+        await handler(message as any);
+
+        expect(pool.getUserMessageDetector).toHaveBeenCalledWith('test-project', 'default');
+        expect(addEchoHash).toHaveBeenCalledWith('test prompt');
+        expect(callOrder).toEqual(['addEchoHash', 'injectMessage']);
+    });
+
+    it('does not crash when the pool has no user message detector', async () => {
+        const mockCdp = createMockCdp();
+        const pool = {
+            ...createMockPool(mockCdp),
+            getUserMessageDetector: jest.fn().mockReturnValue(undefined),
+        };
+        const bridge = createBridge(pool as any);
+        const binding = { chatId: 'chat-123', workspacePath: '/workspace/a' };
+        const telegramBindingRepo = createTelegramBindingRepo(binding);
+        const { message } = createMockMessage({ content: 'test prompt' });
+
+        const handler = createTelegramMessageHandler({ bridge, telegramBindingRepo });
+        await handler(message as any);
+
+        expect(mockCdp.injectMessage).toHaveBeenCalledWith('test prompt');
+    });
+
     it('restores the saved account preference when reconnecting Telegram after restart', async () => {
         const mockCdp = createMockCdp();
         const pool = createMockPool(mockCdp);


### PR DESCRIPTION
## Summary

Salvages the mirror triple-echo fix from #158 (closed — the `/bind` half overlapped with the existing Telegram `/project` command), with the missing wiring added and the regression tests requested in the May 18 review on #158 included.

## Changes

- **`src/bot/telegramMessageHandler.ts`** — register the echo hash via `addEchoHash()` **before** injecting the prompt. `UserMessageDetector` polls the DOM every ~2s, so registering after `injectMessage()` resolves leaves a window where the injected prompt is detected as PC-side input and mirrored back to Telegram. The ordering rationale is documented inline (the Discord path registers at a different point — intentional asymmetry). On inject failure the stale hash simply expires via its 60s TTL.
- **`src/bot/telegramJoinCommand.ts`** — skip starting the passive mirror monitor when the primary message handler already has an active `ResponseMonitor` for the project (running both would deliver the same AI response twice).
- **`src/bot/index.ts`** — pass `activeMonitors` to `handleTelegramJoinSelect`. **This wiring was missing from the original PR**, which made the suppression half of the fix a silent no-op.
- **Tests** — regression coverage: echo hash registered with the effective prompt *before* injection; passive mirror suppressed when a primary monitor is active; legacy callers without `activeMonitors` unaffected; missing detector doesn't crash the flow.

## Test Results

```
Test Suites: 109 passed, 109 total
Tests:       1434 passed, 1434 total
```

Credit to @GTanger for the original investigation and fix (#158) — commits are co-authored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfW1KFVQk7tsmF9JRn7K5U

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Telegram response handling to avoid duplicate response delivery when a primary monitor is already active.
  * Enhanced prompt synchronization so echoed messages are tracked before injection, helping message detection stay accurate.
  * Kept Telegram message sending reliable even when message detection is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->