### PR TITLE
fix(chat-session): verify actual selected conversation in Past Conversations gate

### DIFF
--- a/src/services/chatSessionService.ts
+++ b/src/services/chatSessionService.ts
@@ -304,7 +304,7 @@ function buildActivateChatByTitleScript(title: string): string {
  * Build a script that opens Past Conversations and selects a conversation by title.
  * This path is required for older chats that are not visible in the current side panel.
  */
-function buildActivateViaPastConversationsScript(title: string): string {
+export function buildActivateViaPastConversationsScript(title: string): string {
     const safeTitle = JSON.stringify(title);
     return `(() => {
         const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -323,9 +323,9 @@ function buildActivateViaPastConversationsScript(title: string): string {
 
         const isVisible = (el) => !!el && el instanceof HTMLElement && el.offsetParent !== null;
         const asArray = (nodeList) => Array.from(nodeList || []);
-        const getLabelText = (el) => {
-            if (!el || !(el instanceof Element)) return '';
-            const parts = [
+        const getLabelParts = (el) => {
+            if (!el || !(el instanceof Element)) return [];
+            return [
                 el.textContent || '',
                 el.getAttribute('aria-label') || '',
                 el.getAttribute('title') || '',
@@ -333,7 +333,26 @@ function buildActivateViaPastConversationsScript(title: string): string {
                 el.getAttribute('data-tooltip-content') || '',
                 el.getAttribute('data-testid') || '',
             ];
-            return parts.filter(Boolean).join(' ');
+        };
+        const getLabelText = (el) => getLabelParts(el).filter(Boolean).join(' ');
+        // Verify the option that was actually selected really is the requested
+        // title. getLabelText concatenates several attributes, so a naive
+        // whole-string comparison can fail even for a correct pick (e.g. when
+        // textContent and aria-label duplicate the same value). Instead, check
+        // each label component individually for an exact (or loose-exact) match.
+        // If any component matches, report the requested title; otherwise report
+        // the actual visible text so the acceptance gate rejects a mere
+        // substring/loose selection.
+        const resolveMatchedTitle = (el) => {
+            const parts = getLabelParts(el);
+            for (const part of parts) {
+                if (!part) continue;
+                if (normalize(part) === wanted || (wantedLoose && normalizeLoose(part) === wantedLoose)) {
+                    return wantedRaw;
+                }
+            }
+            const visible = (parts[0] || '').trim();
+            return visible || null;
         };
         const getClickable = (el) => {
             if (!el || !(el instanceof Element)) return null;
@@ -508,22 +527,23 @@ function buildActivateViaPastConversationsScript(title: string): string {
                 await wait(260);
             }
 
-            let selected = clickByPatterns([wanted, wantedLoose], '[role="option"], li, button, [data-testid*="conversation"]');
-            if (selected) {
-                const selectedOption = pickBest(
-                    asArray(document.querySelectorAll('[role="option"], li, button, [data-testid*="conversation"]')),
-                    [wanted, wantedLoose],
-                );
-                const selectedClickable = getClickable(selectedOption);
-                if (selectedClickable) {
-                    selectedClickable.focus();
-                    pressEnter(selectedClickable);
-                }
-            }
-            if (!selected) {
+            // Resolve the exact option element, then click + focus + press Enter
+            // on that same element so the click target and the verification
+            // target can never drift apart. Mirror clickByPatterns' scoped
+            // selector -> broad fallback behaviour.
+            const optionSelector = '[role="option"], li, button, [data-testid*="conversation"]';
+            const scopedOptions = asArray(document.querySelectorAll(optionSelector));
+            const broadOptions = asArray(document.querySelectorAll('button, [role="button"], a, li, div, span'));
+            const optionSource = scopedOptions.length > 0 ? scopedOptions : broadOptions;
+            const selectedOption = pickBest(optionSource, [wanted, wantedLoose]);
+            const selectedClickable = getClickable(selectedOption);
+            if (!selectedClickable) {
                 return { ok: false, error: 'Conversation not found in Past Conversations' };
             }
-            return { ok: true, matchedTitle: wantedRaw };
+            selectedClickable.click();
+            selectedClickable.focus();
+            pressEnter(selectedClickable);
+            return { ok: true, matchedTitle: resolveMatchedTitle(selectedOption) };
         })();
     })()`;
 }

--- a/tests/services/chatSessionService.test.ts
+++ b/tests/services/chatSessionService.test.ts
@@ -1,4 +1,11 @@
-import { ChatSessionService } from '../../src/services/chatSessionService';
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+    ChatSessionService,
+    buildActivateViaPastConversationsScript,
+} from '../../src/services/chatSessionService';
 import { CdpService } from '../../src/services/cdpService';
 import { logger } from '../../src/utils/logger';
 
@@ -654,5 +661,97 @@ describe('ChatSessionService', () => {
             expect(sessions).toHaveLength(1);
             expect(sessions[0].title).toBe('Chat Session Only');
         });
+    });
+
+    describe('buildActivateViaPastConversationsScript() matchedTitle verification', () => {
+        // JSDOM performs no layout, so `offsetParent` is always null; the
+        // script's `isVisible` helper depends on it. Make attached elements
+        // report themselves as visible for the duration of these tests.
+        let originalOffsetParent: PropertyDescriptor | undefined;
+        beforeAll(() => {
+            originalOffsetParent = Object.getOwnPropertyDescriptor(
+                window.HTMLElement.prototype,
+                'offsetParent',
+            );
+            Object.defineProperty(window.HTMLElement.prototype, 'offsetParent', {
+                configurable: true,
+                get(this: HTMLElement) {
+                    return this.parentNode;
+                },
+            });
+        });
+        afterAll(() => {
+            if (originalOffsetParent) {
+                Object.defineProperty(
+                    window.HTMLElement.prototype,
+                    'offsetParent',
+                    originalOffsetParent,
+                );
+            }
+        });
+
+        /**
+         * Evaluate the Past Conversations activation script against a real DOM.
+         *
+         * The script is a browser-side IIFE that CDP would normally eval inside
+         * the Antigravity renderer. We run it in the JSDOM test environment so
+         * the acceptance gate's `matchedTitle` value reflects the element the
+         * script actually selected (Issue #187).
+         */
+        async function runPastConversationsScript(
+            bodyHtml: string,
+            title: string,
+        ): Promise<{ ok: boolean; matchedTitle?: string; error?: string }> {
+            document.body.innerHTML = bodyHtml;
+            const script = buildActivateViaPastConversationsScript(title);
+            const scriptEl = document.createElement('script');
+            scriptEl.textContent = `window.__pastConvResult = ${script};`;
+            document.body.appendChild(scriptEl);
+            return (window as any).__pastConvResult;
+        }
+
+        // A visible toggle so the script's "open Past Conversations" step
+        // succeeds immediately and proceeds to the selection phase.
+        const TOGGLE = '<div data-past-conversations-toggle></div>';
+
+        it('reports the actual visible text (not the requested title) when only a substring match exists', async () => {
+            const result = await runPastConversationsScript(
+                `${TOGGLE}<div role="option">Deploy v2</div>`,
+                'Deploy',
+            );
+
+            expect(result.ok).toBe(true);
+            // The script picked "Deploy v2" via substring match, so matchedTitle
+            // must be the real text - never a tautological echo of "Deploy".
+            expect(result.matchedTitle).toBe('Deploy v2');
+            expect(result.matchedTitle).not.toBe('Deploy');
+            // Acceptance gate condition (see activateSessionByTitle):
+            // matchedTitle.trim() === title.trim() must be false -> not accepted.
+            expect(result.matchedTitle?.trim() === 'Deploy'.trim()).toBe(false);
+        }, 15000);
+
+        it('reports the requested title when an exact-match option exists', async () => {
+            const result = await runPastConversationsScript(
+                `${TOGGLE}<div role="option">Deploy v2</div><div role="option">Deploy</div>`,
+                'Deploy',
+            );
+
+            expect(result.ok).toBe(true);
+            expect(result.matchedTitle).toBe('Deploy');
+            // Acceptance gate condition passes -> activation accepted.
+            expect(result.matchedTitle?.trim() === 'Deploy'.trim()).toBe(true);
+        }, 15000);
+
+        it('accepts an exact match carried on aria-label even when textContent differs', async () => {
+            const result = await runPastConversationsScript(
+                `${TOGGLE}<div role="option" aria-label="Deploy">Deploy · edited 2h ago</div>`,
+                'Deploy',
+            );
+
+            expect(result.ok).toBe(true);
+            // A single label component (aria-label) equals the requested title,
+            // so the join-based whole-string comparison trap is avoided.
+            expect(result.matchedTitle).toBe('Deploy');
+        }, 15000);
     });
 });


### PR DESCRIPTION
## Summary

Fixes #187 — the Past Conversations "Agent-header" acceptance gate was tautological: `buildActivateViaPastConversationsScript` returned the **requested** title as `matchedTitle`, so the gate `matchedTitle.trim() === title.trim()` was always true for any `ok` result, providing no post-selection verification.

## Changes

`src/services/chatSessionService.ts` (inside the CDP browser-side script):

- **`resolveMatchedTitle(el)`** — verifies the actually-selected option against the requested title **per label component** (textContent, aria-label, title, placeholder, data-tooltip-content, data-testid) instead of the joined string. If any component is an exact (or loose-exact) normalized match, it reports the requested title; otherwise it reports the option's real visible text so the acceptance gate rejects a mere substring selection. The per-component check avoids the trap where `getLabelText`'s join makes a whole-string comparison fail even for a correct pick (e.g. textContent and aria-label duplicating the same value).
- **Unified selection block** — the option element is resolved once (same scoped-selector → broad-fallback behavior as `clickByPatterns`), then click / focus / Enter / verification all operate on that single element, so the click target and the verification target can never drift apart.
- `getLabelText` behavior is unchanged (now composed from the new `getLabelParts`), so `pickBest` and the other helpers are unaffected. The acceptance gates themselves are untouched — they now just verify something real.

## Regression tests

`tests/services/chatSessionService.test.ts` — new jsdom-based tests that evaluate the actual script against a real DOM:

- requested `"Deploy"` with only `"Deploy v2"` present → `matchedTitle` is `"Deploy v2"` → **gate rejects** (this test fails against the pre-fix code)
- exact `"Deploy"` option present → accepted
- exact match carried on `aria-label` while textContent differs → accepted

## Test Results

```
Test Suites: 109 passed, 109 total
Tests:       1432 passed, 1432 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfW1KFVQk7tsmF9JRn7K5U

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved conversation activation matching so the selected chat can be identified more accurately from visible labels and related text.

* **Bug Fixes**
  * Selection now uses a more reliable matching and click flow, reducing the chance of opening the wrong conversation.
  * When a match is found, the result now reports the exact matched title instead of only the requested title.
  * Error messages are now more specific when a conversation option can’t be found or clicked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->