### PR TITLE
feat: Planning Mode & Interactive Approval Workflows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lazy-gravity",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lazy-gravity",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@inquirer/select": "^5.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lazy-gravity",
-  "version": "0.9.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lazy-gravity",
-      "version": "0.9.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@inquirer/select": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lazy-gravity",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Control Antigravity from anywhere — a local, secure bot (Discord + Telegram) that lets you remotely operate Antigravity on your home PC from your smartphone.",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lazy-gravity",
-  "version": "0.9.0",
+  "version": "0.8.1",
   "description": "Control Antigravity from anywhere — a local, secure bot (Discord + Telegram) that lets you remotely operate Antigravity on your home PC from your smartphone.",
   "main": "dist/index.js",
   "bin": {

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -13,6 +13,8 @@ import {
 } from 'discord.js';
 import Database from 'better-sqlite3';
 import fs from 'fs';
+import { execFile } from 'child_process';
+import path from 'path';
 
 import { wrapDiscordChannel } from '../platform/discord/wrappers';
 import type { PlatformType } from '../platform/types';
@@ -55,7 +57,8 @@ import { CdpService } from '../services/cdpService';
 import { ChatSessionService } from '../services/chatSessionService';
 import { ResponseMonitor, RESPONSE_SELECTORS, captureResponseMonitorBaseline } from '../services/responseMonitor';
 import { ensureAntigravityRunning, startAntigravity, stopAntigravity } from '../services/antigravityLauncher';
-import { getAntigravityCdpHint } from '../utils/pathUtils';
+import { getAntigravityCdpHint, getAntigravityCliPath } from '../utils/pathUtils';
+import { fileOpenCache } from '../utils/fileOpenCache';
 import { AutoAcceptService } from '../services/autoAcceptService';
 import { PromptDispatcher } from '../services/promptDispatcher';
 import {
@@ -65,17 +68,21 @@ import {
     ensureErrorPopupDetector,
     ensurePlanningDetector,
     ensureRunCommandDetector,
+    ensureQuestionDetector,
     getCurrentCdp,
     initCdpBridge,
     parseApprovalCustomId,
     parseErrorPopupCustomId,
     parsePlanningCustomId,
+    buildFileChangeCustomId,
+    parseFileChangeCustomId,
     parseRunCommandCustomId,
     registerApprovalSessionChannel,
     registerApprovalWorkspaceChannel,
 } from '../services/cdpBridgeManager';
 import { buildModeModelLines, fitForSingleEmbedDescription, splitForEmbedDescription } from '../utils/streamMessageFormatter';
 import { formatForDiscord, splitOutputAndLogs } from '../utils/discordFormatter';
+import { renderDiscordResponse } from '../platform/discord/discordResponseRenderer';
 import { ProcessLogBuffer } from '../utils/processLogBuffer';
 import {
     buildPromptWithAttachmentUrls,
@@ -113,8 +120,11 @@ import { createPlanningButtonAction } from '../handlers/planningButtonAction';
 import { createErrorPopupButtonAction } from '../handlers/errorPopupButtonAction';
 import { createRunCommandButtonAction } from '../handlers/runCommandButtonAction';
 import { createModelButtonAction } from '../handlers/modelButtonAction';
-import { createAutoAcceptButtonAction } from '../handlers/autoAcceptButtonAction';
+import { createQuestionSelectAction } from '../handlers/questionSelectAction';
 import { createTemplateButtonAction } from '../handlers/templateButtonAction';
+import { createFileChangeButtonAction } from '../handlers/fileChangeButtonAction';
+import { createAutoAcceptButtonAction } from '../handlers/autoAcceptButtonAction';
+import { createGenericActionButtonAction } from '../handlers/genericActionButtonAction';
 import { createModeSelectAction } from '../handlers/modeSelectAction';
 import { createAccountSelectAction } from '../handlers/accountSelectAction';
 import { selectTelegramStartupChatId } from './telegramStartupTarget';
@@ -187,8 +197,10 @@ export function createSerialTaskQueueForTest(queueName: string, traceId: string)
     };
 }
 
+// Shared fileOpenCache is imported from utils/fileOpenCache
+
 /**
- * Send a Discord message (prompt) to Antigravity, wait for the response, and relay it back to Discord
+ * Send a user's prompt to Antigravity and monitor generation.
  *
  * Message strategy:
  *   - Send new messages per phase instead of editing, to preserve history
@@ -212,6 +224,7 @@ async function sendPromptToAntigravity(
         onFullCompletion?: () => void;
         extractionMode?: ExtractionMode;
         responseTimeoutMs?: number;
+        resumeOnly?: boolean;
     }
 
 ): Promise<void> {
@@ -464,6 +477,7 @@ async function sendPromptToAntigravity(
             source?: string;
             expectedVersion?: number;
             skipWhenFinalized?: boolean;
+            components?: any[]; // using any[] to avoid missing type imports like ActionRowBuilder
         },
     ): Promise<void> => enqueueResponse(async () => {
         if (opts?.skipWhenFinalized && isFinalized) return;
@@ -480,16 +494,21 @@ async function sendPromptToAntigravity(
             lastLiveResponseKey = renderKey;
 
             for (let i = 0; i < plainChunks.length; i++) {
+                const messageOpts: any = { content: plainChunks[i] };
+                if (i === plainChunks.length - 1 && opts?.components?.length) {
+                    messageOpts.components = opts.components;
+                }
+                
                 if (!liveResponseMessages[i]) {
-                    liveResponseMessages[i] = await channel.send({ content: plainChunks[i] }).catch((error: unknown) => {
+                    liveResponseMessages[i] = await channel.send(messageOpts).catch((error: unknown) => {
                         logDeliveryError('liveResponse/plain/send', error);
                         return null;
                     });
                     continue;
                 }
-                await liveResponseMessages[i].edit({ content: plainChunks[i] }).catch(async (error: unknown) => {
+                await liveResponseMessages[i].edit(messageOpts).catch(async (error: unknown) => {
                     logDeliveryError('liveResponse/plain/edit', error);
-                    liveResponseMessages[i] = await channel.send({ content: plainChunks[i] }).catch((sendError: unknown) => {
+                    liveResponseMessages[i] = await channel.send(messageOpts).catch((sendError: unknown) => {
                         logDeliveryError('liveResponse/plain/resend', sendError);
                         return null;
                     });
@@ -519,16 +538,24 @@ async function sendPromptToAntigravity(
                 .setTimestamp();
 
             if (!liveResponseMessages[i]) {
-                liveResponseMessages[i] = await channel.send({ embeds: [embed] }).catch((error: unknown) => {
+                const messageOpts: any = { embeds: [embed] };
+                if (i === descriptions.length - 1 && opts?.components?.length) {
+                    messageOpts.components = opts.components;
+                }
+                liveResponseMessages[i] = await channel.send(messageOpts).catch((error: unknown) => {
                     logDeliveryError('liveResponse/embed/send', error);
                     return null;
                 });
                 continue;
             }
 
-            await liveResponseMessages[i].edit({ embeds: [embed] }).catch(async (error: unknown) => {
+            const messageOpts: any = { embeds: [embed] };
+            if (i === descriptions.length - 1 && opts?.components?.length) {
+                messageOpts.components = opts.components;
+            }
+            await liveResponseMessages[i].edit(messageOpts).catch(async (error: unknown) => {
                 logDeliveryError('liveResponse/embed/edit', error);
-                liveResponseMessages[i] = await channel.send({ embeds: [embed] }).catch((sendError: unknown) => {
+                liveResponseMessages[i] = await channel.send(messageOpts).catch((sendError: unknown) => {
                     logDeliveryError('liveResponse/embed/resend', sendError);
                     return null;
                 });
@@ -635,23 +662,25 @@ async function sendPromptToAntigravity(
 
         logger.prompt(prompt);
 
-        let injectResult;
-        if (inboundImages.length > 0) {
-            injectResult = await cdp.injectMessageWithImageFiles(
-                prompt,
-                inboundImages.map((image) => image.localPath),
-            );
-
-            if (!injectResult.ok) {
-                await sendEmbed(
-                    t('🖼️ Attached image fallback'),
-                    t('Failed to attach image directly, resending via URL reference.'),
-                    PHASE_COLORS.thinking,
+        let injectResult: any = { ok: true };
+        if (!options?.resumeOnly) {
+            if (inboundImages.length > 0) {
+                injectResult = await cdp.injectMessageWithImageFiles(
+                    prompt,
+                    inboundImages.map((image) => image.localPath),
                 );
-                injectResult = await cdp.injectMessage(buildPromptWithAttachmentUrls(prompt, inboundImages));
+
+                if (!injectResult.ok) {
+                    await sendEmbed(
+                        t('🖼️ Attached image fallback'),
+                        t('Failed to attach image directly, resending via URL reference.'),
+                        PHASE_COLORS.thinking,
+                    );
+                    injectResult = await cdp.injectMessage(buildPromptWithAttachmentUrls(prompt, inboundImages));
+                }
+            } else {
+                injectResult = await cdp.injectMessage(prompt);
             }
-        } else {
-            injectResult = await cdp.injectMessage(prompt);
         }
 
         if (!injectResult.ok) {
@@ -719,7 +748,7 @@ async function sendPromptToAntigravity(
                 }
             },
 
-            onComplete: async (finalText) => {
+            onComplete: async (finalText, citedFiles, fileChanges) => {
                 isFinalized = true;
 
                 try {
@@ -826,29 +855,9 @@ async function sendPromptToAntigravity(
 
                     liveResponseUpdateVersion += 1;
                     const responseVersion = liveResponseUpdateVersion;
-                    if (finalOutputText && finalOutputText.trim().length > 0) {
-                        await upsertLiveResponseEmbeds(
-                            `${PHASE_ICONS.complete} Final Output`,
-                            finalOutputText,
-                            PHASE_COLORS.complete,
-                            t(`⏱️ Time: ${elapsed}s | Complete`),
-                            {
-                                source: 'complete',
-                                expectedVersion: responseVersion,
-                            },
-                        );
-                    } else {
-                        await upsertLiveResponseEmbeds(
-                            `${PHASE_ICONS.complete} Complete`,
-                            t('Failed to extract response. Use `/screenshot` to verify.'),
-                            PHASE_COLORS.complete,
-                            t(`⏱️ Time: ${elapsed}s | Complete`),
-                            {
-                                source: 'complete',
-                                expectedVersion: responseVersion,
-                            },
-                        );
-                    }
+                    
+                    const components: any[] = [];
+                    if (!citedFiles) citedFiles = [];
 
                     if (options && message.guild) {
                         try {
@@ -871,7 +880,12 @@ async function sendPromptToAntigravity(
 
                                 // Persist conversation_id for artifact picker resolution
                                 if (options.artifactService) {
-                                    const convId = options.artifactService.findConversationByTitle(sessionInfo.title);
+                                    const session = options.chatSessionRepo.findByChannelId(message.channelId);
+                                    let workspaceDirName: string | undefined;
+                                    if (session && session.workspacePath) {
+                                        workspaceDirName = bridge.pool.extractProjectName(session.workspacePath);
+                                    }
+                                    const convId = options.artifactService.findConversationByTitle(sessionInfo.title, workspaceDirName);
                                     if (convId) {
                                         options.chatSessionRepo.setConversationId(message.channelId, convId);
                                     }
@@ -880,6 +894,123 @@ async function sendPromptToAntigravity(
                         } catch (e) {
                             logger.error('[Rename] Failed to get title from Antigravity and rename:', e);
                         }
+                    }
+
+                    if (citedFiles && citedFiles.length > 0) {
+                        // Strip trailing punctuation and deduplicate
+                        let uniqueFiles = Array.from(new Set(citedFiles.map(f => {
+                            let clean = f.trim();
+                            while (clean.match(/[.,;:!?]$/)) {
+                                clean = clean.slice(0, -1);
+                            }
+                            return clean;
+                        })));
+                        // Filter out obviously bad paths
+                        uniqueFiles = uniqueFiles.filter(f => f.length > 0 && f !== 'unknown');
+                        
+                        const row = new ActionRowBuilder();
+                        // Max 5 buttons per row in Discord
+                        for (let i = 0; i < Math.min(uniqueFiles.length, 5); i++) {
+                            let fileUrl = uniqueFiles[i];
+                            
+                            if (!fileUrl.startsWith('file:///') && !path.isAbsolute(fileUrl)) {
+                                const wsPath = cdp.getCurrentWorkspacePath();
+                                if (wsPath) {
+                                    fileUrl = `file:///${path.resolve(wsPath, fileUrl).replace(/\\/g, '/')}`;
+                                }
+                            }
+                            
+                            // Verify the file actually exists
+                            const fsPath = fileUrl.replace(/^file:\/\/\//, '');
+                            if (!fs.existsSync(fsPath)) {
+                                continue;
+                            }
+
+                            let displayName = fileUrl;
+                            if (displayName.startsWith('file:///')) {
+                                const parts = displayName.split('/');
+                                displayName = parts[parts.length - 1];
+                            }
+                            const hashId = Math.random().toString(36).substring(2, 10);
+                            fileOpenCache.set(hashId, fileUrl);
+                            
+                            row.addComponents(
+                                new ButtonBuilder()
+                                    .setCustomId(`file_open:${hashId}`)
+                                    .setLabel(`Open ${displayName.substring(0, 20)}`)
+                                    .setStyle(ButtonStyle.Primary)
+                            );
+                        }
+                        if (row.components.length > 0) {
+                            components.push(row);
+                        }
+                    }
+
+                    if (fileChanges && fileChanges.length > 0) {
+                        // The extracted text is the toolbar title, e.g. "1 File With Changes"
+                        const widgetTitle = fileChanges[fileChanges.length - 1] || 'Files With Changes';
+                        const fileChangesRow = new ActionRowBuilder().addComponents(
+                            new ButtonBuilder()
+                                .setCustomId(buildFileChangeCustomId('reject', cdp.getCurrentWorkspaceName() || 'unknown', message.channelId))
+                                .setLabel(`Reject all (${widgetTitle})`)
+                                .setStyle(ButtonStyle.Danger),
+                            new ButtonBuilder()
+                                .setCustomId(buildFileChangeCustomId('accept', cdp.getCurrentWorkspaceName() || 'unknown', message.channelId))
+                                .setLabel('Accept all')
+                                .setStyle(ButtonStyle.Success)
+                        );
+                        components.push(fileChangesRow);
+                    }
+
+                    const classified = monitor.getLastClassified();
+                    if (options?.extractionMode === 'structured' && classified && outputFormat !== 'plain') {
+                        const messageOptions = renderDiscordResponse(classified);
+                        for (const msg of liveResponseMessages) {
+                            if (msg) await msg.delete().catch(() => {});
+                        }
+                        liveResponseMessages.length = 0;
+                        
+                        if (components.length > 0) {
+                            if (!messageOptions.components) messageOptions.components = [];
+                            messageOptions.components = [...(messageOptions.components || []), ...components];
+                        }
+
+                        if (messageOptions.embeds && messageOptions.embeds.length > 0) {
+                            const lastEmbed = messageOptions.embeds[messageOptions.embeds.length - 1];
+                            if (lastEmbed && typeof (lastEmbed as any).setFooter === 'function') {
+                                (lastEmbed as any).setFooter({ text: t(`⏱️ Time: ${elapsed}s | Complete`) });
+                            }
+                        }
+                        
+                        if (channel) {
+                            await channel.send(messageOptions).catch((error: unknown) => {
+                                logDeliveryError('renderDiscordResponse/send', error);
+                            });
+                        }
+                    } else if (finalOutputText && finalOutputText.trim().length > 0) {
+                        await upsertLiveResponseEmbeds(
+                            `${PHASE_ICONS.complete} Final Output`,
+                            finalOutputText,
+                            PHASE_COLORS.complete,
+                            t(`⏱️ Time: ${elapsed}s | Complete`),
+                            {
+                                source: 'complete',
+                                expectedVersion: responseVersion,
+                                components: components.length > 0 ? components : undefined,
+                            },
+                        );
+                    } else {
+                        await upsertLiveResponseEmbeds(
+                            `${PHASE_ICONS.complete} Complete`,
+                            t('Failed to extract response. Use `/screenshot` to verify.'),
+                            PHASE_COLORS.complete,
+                            t(`⏱️ Time: ${elapsed}s | Complete`),
+                            {
+                                source: 'complete',
+                                expectedVersion: responseVersion,
+                                components: components.length > 0 ? components : undefined,
+                            },
+                        );
                     }
 
                     await sendGeneratedImages(finalOutputText || '');
@@ -1210,6 +1341,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         } catch (error) {
             logger.warn('Failed to send startup dashboard embed:', error);
         }
+
     });
 
     // [Discord Interactions API] Slash command interaction handler
@@ -1223,6 +1355,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         wsHandler,
         chatHandler,
         client,
+        promptDispatcher,
         sendModeUI,
         sendModelsUI,
         sendAutoAcceptUI,
@@ -1230,6 +1363,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         parseApprovalCustomId,
         parseErrorPopupCustomId,
         parsePlanningCustomId,
+        parseFileChangeCustomId,
         parseRunCommandCustomId,
         joinHandler,
         userPrefRepo,
@@ -1254,6 +1388,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             accountPrefRepoArg,
             channelPrefRepoArg,
             antigravityAccountsArg,
+            chatSessionRepoArg,
         ) => handleSlashInteraction(
             interaction,
             handler,
@@ -1273,7 +1408,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             accountPrefRepoArg,
             channelPrefRepoArg,
             antigravityAccountsArg,
-            chatSessionRepo,
+            chatSessionRepoArg,
             artifactService,
         ),
         handleTemplateUse: async (interaction, templateId) => {
@@ -1322,6 +1457,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                     ensureErrorPopupDetector(bridge, cdp, projectName, selectedAccount);
                     ensurePlanningDetector(bridge, cdp, projectName, selectedAccount);
                     ensureRunCommandDetector(bridge, cdp, projectName, selectedAccount);
+                    ensureQuestionDetector(bridge, cdp, projectName, selectedAccount);
                 } catch (e: any) {
                     await interaction.followUp({
                         content: `Failed to connect to workspace: ${e.message}`,
@@ -1488,10 +1624,12 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                         : binding.workspacePath;
                 },
             });
+            const questionSelectAction = createQuestionSelectAction({ bridge, wsHandler });
             const telegramSelectHandler = createPlatformSelectHandler({
                 actions: [
                     modeSelectAction,
                     accountSelectAction,
+                    questionSelectAction,
                 ],
             });
             // Composite handler that routes to the right handler
@@ -1510,7 +1648,11 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                     }, interaction);
                     return;
                 }
-                if (interaction.customId === 'mode_select' || interaction.customId === 'account_select') {
+                if (
+                    interaction.customId === 'mode_select' ||
+                    interaction.customId === 'account_select' ||
+                    interaction.customId.startsWith('question_select_action')
+                ) {
                     await telegramSelectHandler(interaction);
                     return;
                 }
@@ -1526,10 +1668,10 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
 
             const telegramButtonHandler = createPlatformButtonHandler({
                 actions: [
-                    createApprovalButtonAction({ bridge }),
-                    createPlanningButtonAction({ bridge }),
-                    createErrorPopupButtonAction({ bridge }),
-                    createRunCommandButtonAction({ bridge }),
+                    createApprovalButtonAction({ bridge, wsHandler }),
+                    createPlanningButtonAction({ bridge, wsHandler }),
+                    createErrorPopupButtonAction({ bridge, wsHandler }),
+                    createRunCommandButtonAction({ bridge, wsHandler }),
                     createModelButtonAction({
                         bridge,
                         fetchQuota: () => bridge.quota.fetchQuota(),
@@ -1574,6 +1716,8 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
                     }),
                     createAutoAcceptButtonAction({ autoAcceptService: bridge.autoAccept }),
                     createTemplateButtonAction({ bridge, templateRepo }),
+                    createFileChangeButtonAction({ bridge, wsHandler }),
+                    createGenericActionButtonAction({ bridge }),
                 ],
             });
 
@@ -2289,6 +2433,58 @@ export async function handleSlashInteraction(
                 : `\`\`\`\n${formatted.slice(0, MAX_CONTENT)}\n\`\`\`\n(truncated — showing ${MAX_CONTENT} chars of ${formatted.length})`;
 
             await interaction.editReply({ content: codeBlock });
+            break;
+        }
+
+        case 'open': {
+            const filepath = interaction.options.getString('filepath', true);
+            let resolvedPath = filepath;
+            if (filepath.startsWith('file:///')) {
+                // Windows fix: remove leading slash if it's file:///C:/...
+                let rawPath = filepath.replace('file:///', '');
+                if (process.platform === 'win32' && rawPath.startsWith('/')) {
+                    rawPath = rawPath.substring(1);
+                }
+                resolvedPath = path.resolve(rawPath);
+            } else if (!path.isAbsolute(filepath)) {
+                // Try resolving as an artifact first
+                if (chatSessionRepo && artifactService) {
+                    const session = chatSessionRepo.findByChannelId(interaction.channelId);
+                    if (session && session.conversationId) {
+                        const possibleArtifact = artifactService.getArtifactPath(session.conversationId, filepath);
+                        if (fs.existsSync(possibleArtifact)) {
+                            resolvedPath = possibleArtifact;
+                        }
+                    }
+                }
+                
+                // If still not absolute (meaning artifact not found), try workspace
+                if (!path.isAbsolute(resolvedPath)) {
+                    // Try to resolve against workspace
+                    const cdp = await ensureChannelCdp();
+                    if (cdp) {
+                        const wsPath = cdp.getCurrentWorkspacePath();
+                        if (wsPath) {
+                            resolvedPath = path.join(wsPath, filepath);
+                        }
+                    } else {
+                        resolvedPath = path.resolve(filepath);
+                    }
+                }
+            }
+
+            try {
+                execFile(getAntigravityCliPath(), [resolvedPath], (error) => {
+                    if (error) {
+                        logger.error(`Failed to open file via CLI: ${error.message}`);
+                        interaction.editReply({ content: `❌ Error opening file via CLI: ${error.message}` }).catch(() => {});
+                    } else {
+                        interaction.editReply({ content: `✅ Opened file: **${resolvedPath}**` }).catch(() => {});
+                    }
+                });
+            } catch (e: any) {
+                await interaction.editReply({ content: `❌ Error opening file: ${e.message}` });
+            }
             break;
         }
 

--- a/src/bot/telegramMessageHandler.ts
+++ b/src/bot/telegramMessageHandler.ts
@@ -12,7 +12,7 @@
 import type { PlatformMessage, PlatformChannel, PlatformSentMessage } from '../platform/types';
 import type { TelegramBindingRepository } from '../database/telegramBindingRepository';
 import type { WorkspaceService } from '../services/workspaceService';
-import { CdpBridge, registerApprovalWorkspaceChannel, ensureApprovalDetector, ensureErrorPopupDetector, ensurePlanningDetector, ensureRunCommandDetector } from '../services/cdpBridgeManager';
+import { CdpBridge, registerApprovalWorkspaceChannel, ensureApprovalDetector, ensureErrorPopupDetector, ensurePlanningDetector, ensureRunCommandDetector, ensureQuestionDetector } from '../services/cdpBridgeManager';
 import { CdpService } from '../services/cdpService';
 import { ResponseMonitor, captureResponseMonitorBaseline } from '../services/responseMonitor';
 import { ProcessLogBuffer } from '../utils/processLogBuffer';
@@ -209,6 +209,7 @@ export function createTelegramMessageHandler(deps: TelegramMessageHandlerDeps) {
             ensureErrorPopupDetector(deps.bridge, cdp, projectName, selectedAccount);
             ensurePlanningDetector(deps.bridge, cdp, projectName, selectedAccount);
             ensureRunCommandDetector(deps.bridge, cdp, projectName, selectedAccount);
+            ensureQuestionDetector(deps.bridge, cdp, projectName, selectedAccount);
 
             // Acknowledge receipt
             await message.react('\u{1F440}').catch(() => {});

--- a/src/events/interactionCreateHandler.ts
+++ b/src/events/interactionCreateHandler.ts
@@ -1,6 +1,5 @@
 import {
     ActionRowBuilder,
-    ButtonBuilder,
     ButtonInteraction,
     ChatInputCommandInteraction,
     EmbedBuilder,
@@ -9,9 +8,14 @@ import {
     MessageFlags,
 } from 'discord.js';
 
+import { execFile } from 'child_process';
+import path from 'path';
+import fs from 'fs';
 import { t } from '../utils/i18n';
 import { logger } from '../utils/logger';
 import { disableAllButtons } from '../utils/discordButtonUtils';
+import { getAntigravityCliPath } from '../utils/pathUtils';
+import { fileOpenCache } from '../utils/fileOpenCache';
 import { TEMPLATE_BTN_PREFIX, parseTemplateButtonId } from '../ui/templateUi';
 import {
     AUTOACCEPT_BTN_OFF,
@@ -23,6 +27,10 @@ import {
     OUTPUT_BTN_PLAIN,
     sendOutputUI,
 } from '../ui/outputUi';
+import { QUESTION_SELECT_ACTION_PREFIX, QUESTION_SKIP_ACTION_PREFIX } from '../services/notificationSender';
+import { createQuestionSelectAction } from '../handlers/questionSelectAction';
+import { createQuestionSkipAction } from '../handlers/questionSkipAction';
+import { wrapDiscordButton, wrapDiscordSelect } from '../platform/discord/wrappers';
 import { AccountPreferenceRepository } from '../database/accountPreferenceRepository';
 import { ChannelPreferenceRepository } from '../database/channelPreferenceRepository';
 import { UserPreferenceRepository, OutputFormat } from '../database/userPreferenceRepository';
@@ -42,12 +50,15 @@ import { CdpService } from '../services/cdpService';
 import { MODE_DISPLAY_NAMES, ModeService } from '../services/modeService';
 import { ModelService } from '../services/modelService';
 import { AutoAcceptService } from '../services/autoAcceptService';
+import { buildClickScript } from '../services/approvalDetector';
+import { RunCommandDetector } from '../services/runCommandDetector';
 import { ChatSessionService } from '../services/chatSessionService';
 import { JoinCommandHandler } from '../commands/joinCommandHandler';
 import { isSessionSelectId } from '../ui/sessionPickerUi';
 import { ARTIFACT_SELECT_ID, ARTIFACT_THREAD_BTN, ARTIFACT_INLINE_BTN, buildArtifactPickerUI, sendArtifactPickerUI } from '../ui/artifactsUi';
 import { ArtifactService } from '../services/artifactService';
 import { ArtifactThreadRepository } from '../database/artifactThreadRepository';
+import { ScheduleService } from '../services/scheduleService';
 import type { AntigravityAccountConfig } from '../utils/configLoader';
 import { inferParentScopeChannelId, listAccountNames, resolveScopedAccountName } from '../utils/accountUtils';
 import { ACCOUNT_SELECT_ID, sendAccountUI } from '../ui/accountUi';
@@ -74,7 +85,8 @@ export interface InteractionCreateHandlerDeps {
     handleScreenshot?: (...args: any[]) => Promise<void>;
     getCurrentCdp: (bridge: CdpBridge) => CdpService | null;
     parseApprovalCustomId: (customId: string) => { action: 'approve' | 'always_allow' | 'deny'; projectName: string | null; channelId: string | null } | null;
-    parsePlanningCustomId: (customId: string) => { action: 'open' | 'proceed'; projectName: string | null; channelId: string | null } | null;
+    parsePlanningCustomId: (customId: string) => { action: 'open' | 'proceed' | 'reject'; projectName: string | null; channelId: string | null } | null;
+    parseFileChangeCustomId: (customId: string) => { action: 'accept' | 'reject'; projectName: string | null; channelId: string | null } | null;
     parseErrorPopupCustomId: (customId: string) => { action: 'dismiss' | 'copy_debug' | 'retry'; projectName: string | null; channelId: string | null } | null;
     parseRunCommandCustomId: (customId: string) => { action: 'run' | 'reject'; projectName: string | null; channelId: string | null } | null;
     handleSlashInteraction: (
@@ -92,6 +104,7 @@ export interface InteractionCreateHandlerDeps {
         channelPrefRepo?: ChannelPreferenceRepository,
         antigravityAccounts?: AntigravityAccountConfig[],
         chatSessionRepo?: ChatSessionRepository,
+        scheduleService?: ScheduleService,
     ) => Promise<void>;
     handleTemplateUse?: (interaction: ButtonInteraction, templateId: number) => Promise<void>;
     joinHandler?: JoinCommandHandler;
@@ -103,6 +116,8 @@ export interface InteractionCreateHandlerDeps {
     chatSessionRepo?: ChatSessionRepository;
     chatSessionService?: ChatSessionService;
     artifactService?: ArtifactService;
+    scheduleService?: ScheduleService;
+    promptDispatcher?: import('../services/promptDispatcher').PromptDispatcher;
 }
 
 export function createInteractionCreateHandler(deps: InteractionCreateHandlerDeps) {
@@ -127,23 +142,21 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
             accountPrefRepo: deps.accountPrefRepo,
             accounts: deps.antigravityAccounts,
         });
+    const resolveProjectFromChannel = (channelId: string): string | null => {
+        const workspacePath = deps.wsHandler.getWorkspaceForChannel(channelId);
+        return workspacePath ? deps.bridge.pool.extractProjectName(workspacePath) : null;
+    };
     const getChannelCdp = (channelId: string, userId: string): CdpService | null =>
         (() => {
-            const workspacePath = deps.wsHandler.getWorkspaceForChannel(channelId);
-            if (workspacePath) {
-                const projectName = deps.bridge.pool.extractProjectName(workspacePath);
+            const projectName = resolveProjectFromChannel(channelId);
+            if (projectName) {
                 return deps.bridge.pool.getConnected(
                     projectName,
                     resolveSelectedAccount(channelId, userId),
                 );
             }
 
-            return deps.bridge.lastActiveWorkspace
-                ? deps.bridge.pool.getConnected(
-                    deps.bridge.lastActiveWorkspace,
-                    resolveSelectedAccount(channelId, userId),
-                )
-                : null;
+            return null;
         })();
     const ensureBoundSessionActive = async (
         channelId: string,
@@ -233,6 +246,25 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
             }
 
             try {
+                if (interaction.customId.startsWith('action_btn_')) {
+                    const actionName = interaction.customId.replace('action_btn_', '').replace(/_/g, ' ');
+                    const formattedName = actionName.charAt(0).toUpperCase() + actionName.slice(1);
+                    
+                    const cdp = await deps.getCurrentCdp(deps.bridge);
+
+                    if (!cdp) {
+                        await interaction.reply({ content: 'Not connected to CDP.', flags: MessageFlags.Ephemeral });
+                        return;
+                    }
+                    
+                    await interaction.deferUpdate();
+                    const result = await cdp.injectMessage(formattedName);
+                    if (!result.ok) {
+                        await interaction.followUp({ content: `Failed to execute action: ${result.error}`, flags: MessageFlags.Ephemeral });
+                    }
+                    return;
+                }
+
                 const approvalAction = deps.parseApprovalCustomId(interaction.customId);
                 if (approvalAction) {
                     if (approvalAction.channelId && approvalAction.channelId !== interaction.channelId) {
@@ -243,7 +275,7 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                         return;
                     }
 
-                    const projectName = approvalAction.projectName ?? deps.bridge.lastActiveWorkspace;
+                    const projectName = approvalAction.projectName ?? resolveProjectFromChannel(interaction.channelId);
                     const detector = projectName
                         ? deps.bridge.pool.getApprovalDetector(
                             projectName,
@@ -320,7 +352,7 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                         return;
                     }
 
-                    const planWorkspaceDirName = planningAction.projectName ?? deps.bridge.lastActiveWorkspace;
+                    const planWorkspaceDirName = planningAction.projectName ?? resolveProjectFromChannel(interaction.channelId);
                     const planDetector = planWorkspaceDirName
                         ? deps.bridge.pool.getPlanningDetector(
                             planWorkspaceDirName,
@@ -397,6 +429,12 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                                     flags: MessageFlags.Ephemeral,
                                 }).catch(logger.error);
                             }
+                        } else if (planningAction.action === 'reject') {
+                            await interaction.reply({
+                                content: t('Rejection of a plan is not allowed.'),
+                                flags: MessageFlags.Ephemeral,
+                            }).catch(logger.error);
+                            return;
                         } else {
                             // Proceed action
                             const clicked = await planDetector.clickProceedButton();
@@ -429,6 +467,26 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                                     throw interactionError;
                                 }
                             }
+                            
+                            if (clicked && deps.promptDispatcher && interaction.channelId && interaction.message) {
+                                const cdp = getChannelCdp(interaction.channelId, interaction.user.id);
+                                if (cdp) {
+                                    // Use 'as any' to bypass the type difference between Interaction's Message and Discord.js Message if needed
+                                    deps.promptDispatcher.resume({
+                                        message: interaction.message as any,
+                                        prompt: '',
+                                        cdp,
+                                        options: {
+                                            chatSessionService: deps.chatSessionService!,
+                                            chatSessionRepo: deps.chatSessionRepo!,
+                                            channelManager: {} as any, // Only used for some channel mapping which we don't strictly need here
+                                            titleGenerator: {} as any,
+                                            userPrefRepo: deps.userPrefRepo,
+                                            artifactService: deps.artifactService,
+                                        }
+                                    }).catch(e => logger.error('[Planning] Failed to resume monitoring:', e));
+                                }
+                            }
                         }
                     } catch (planError: any) {
                         if (planError?.code === 10062 || planError?.code === 40060) {
@@ -447,6 +505,90 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                     return;
                 }
 
+                // File Change handling
+                const fileChangeAction = deps.parseFileChangeCustomId(interaction.customId);
+                if (fileChangeAction) {
+                    if (fileChangeAction.channelId && fileChangeAction.channelId !== interaction.channelId) {
+                        await interaction.reply({
+                            content: t('This file change action is linked to a different session channel.'),
+                            flags: MessageFlags.Ephemeral,
+                        }).catch(logger.error);
+                        return;
+                    }
+                    const projectName = fileChangeAction.projectName ?? resolveProjectFromChannel(interaction.channelId);
+                    const cdp = projectName ? deps.bridge.pool.getConnected(projectName, resolveSelectedAccount(interaction.channelId, interaction.user.id, getParentChannelId(interaction))) : null;
+
+                    if (!cdp) {
+                        await interaction.reply({ content: t('Workspace CDP connection not found.'), flags: MessageFlags.Ephemeral }).catch(logger.error);
+                        return;
+                    }
+
+                    try {
+                        await interaction.deferUpdate();
+                        
+                        let clicked = false;
+                        if (fileChangeAction.action === 'accept') {
+                            const script = buildClickScript('Accept all');
+                            const contextId = cdp.getPrimaryContextId();
+                            const callParams: Record<string, unknown> = {
+                                expression: script,
+                                returnByValue: true,
+                            };
+                            if (contextId !== null) callParams.contextId = contextId;
+                            const res = await cdp.call('Runtime.evaluate', callParams);
+                            clicked = res?.result?.value?.ok === true;
+                        } else {
+                            const script = buildClickScript('Reject all');
+                            const contextId = cdp.getPrimaryContextId();
+                            const callParams: Record<string, unknown> = {
+                                expression: script,
+                                returnByValue: true,
+                            };
+                            if (contextId !== null) callParams.contextId = contextId;
+                            const res = await cdp.call('Runtime.evaluate', callParams);
+                            clicked = res?.result?.value?.ok === true;
+                        }
+                        
+                        const originalEmbed = interaction.message.embeds[0];
+                        const updatedEmbed = originalEmbed
+                            ? EmbedBuilder.from(originalEmbed)
+                            : new EmbedBuilder().setTitle('File Changes');
+                        
+                        const actionLabel = fileChangeAction.action === 'accept' ? 'Accept All' : 'Reject All';
+                        const historyText = `${actionLabel} by <@${interaction.user.id}> (${new Date().toLocaleString('ja-JP')})`;
+                        
+                        updatedEmbed
+                            .setColor(clicked ? (fileChangeAction.action === 'accept' ? 0x2ECC71 : 0xE74C3C) : 0x95A5A6)
+                            .addFields({ name: 'Action History', value: historyText, inline: false })
+                            .setTimestamp();
+                        
+                        await interaction.editReply({
+                            embeds: [updatedEmbed],
+                            components: disableAllButtons(interaction.message.components),
+                        });
+                        
+                        if (clicked && deps.promptDispatcher && interaction.channelId && interaction.message) {
+                            // Resume monitoring, treating the completion of file changes as a need to poll again
+                            deps.promptDispatcher.resume({
+                                message: interaction.message as any,
+                                prompt: '',
+                                cdp,
+                                options: {
+                                    chatSessionService: deps.chatSessionService!,
+                                    chatSessionRepo: deps.chatSessionRepo!,
+                                    channelManager: {} as any,
+                                    titleGenerator: {} as any,
+                                    userPrefRepo: deps.userPrefRepo,
+                                    artifactService: deps.artifactService,
+                                }
+                            }).catch(e => logger.error('[FileChange] Failed to resume monitoring:', e));
+                        }
+                    } catch (err: any) {
+                        logger.error('[FileChange] action error:', err);
+                    }
+                    return;
+                }
+
                 const errorPopupAction = deps.parseErrorPopupCustomId(interaction.customId);
                 if (errorPopupAction) {
                     if (errorPopupAction.channelId && errorPopupAction.channelId !== interaction.channelId) {
@@ -457,7 +599,7 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                         return;
                     }
 
-                    const errorWorkspaceDirName = errorPopupAction.projectName ?? deps.bridge.lastActiveWorkspace;
+                    const errorWorkspaceDirName = errorPopupAction.projectName ?? resolveProjectFromChannel(interaction.channelId);
                     const errorDetector = errorWorkspaceDirName
                         ? deps.bridge.pool.getErrorPopupDetector(
                             errorWorkspaceDirName,
@@ -614,7 +756,7 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                         return;
                     }
 
-                    const runCmdWorkspace = runCommandAction.projectName ?? deps.bridge.lastActiveWorkspace;
+                    const runCmdWorkspace = runCommandAction.projectName ?? resolveProjectFromChannel(interaction.channelId);
                     const runCmdDetector = runCmdWorkspace
                         ? deps.bridge.pool.getRunCommandDetector(
                             runCmdWorkspace,
@@ -876,6 +1018,65 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                     }, true, passedConvId);
                     return;
                 }
+
+                if (interaction.customId.startsWith('file_open:')) {
+                    await interaction.deferUpdate().catch(() => {});
+                    const hashId = interaction.customId.replace('file_open:', '');
+                    const fileUrl = fileOpenCache.get(hashId);
+                    if (!fileUrl) {
+                        await interaction.followUp({
+                            content: t('File URL not found in cache or expired.'),
+                            flags: MessageFlags.Ephemeral
+                        }).catch(logger.error);
+                        return;
+                    }
+
+                    let resolvedPath = fileUrl;
+                    if (fileUrl.startsWith('file:///')) {
+                        let rawPath = fileUrl.replace('file:///', '');
+                        if (process.platform === 'win32' && rawPath.startsWith('/')) {
+                            rawPath = rawPath.substring(1);
+                        }
+                        resolvedPath = path.resolve(rawPath);
+                    }
+
+                    try {
+                        const fileContent = fs.readFileSync(resolvedPath, 'utf8');
+                        const MAX_DESC_LEN = 4096;
+                        const truncated = fileContent.length > MAX_DESC_LEN
+                            ? fileContent.substring(0, MAX_DESC_LEN - 15) + '\n\n(truncated)'
+                            : fileContent;
+                        
+                        const embed = new EmbedBuilder()
+                            .setTitle(`Opened: ${path.basename(resolvedPath)}`)
+                            .setDescription(truncated)
+                            .setColor(0x3498DB)
+                            .setTimestamp();
+
+                        execFile(getAntigravityCliPath(), [resolvedPath], async (error) => {
+                            if (error) {
+                                logger.error(`Failed to open file via CLI: ${error.message}`);
+                                await interaction.followUp({
+                                    content: `❌ Error opening file via CLI: ${error.message}`,
+                                    flags: MessageFlags.Ephemeral
+                                }).catch(() => {});
+                            } else {
+                                await interaction.followUp({
+                                    content: `✅ Opened file in IDE: **${path.basename(resolvedPath)}**`,
+                                    embeds: [embed],
+                                    flags: MessageFlags.Ephemeral
+                                }).catch(() => {});
+                            }
+                        });
+                    } catch (e: any) {
+                        await interaction.followUp({
+                            content: `❌ Error opening file: ${e.message}`,
+                            flags: MessageFlags.Ephemeral
+                        }).catch(logger.error);
+                    }
+                    return;
+                }
+
             } catch (error) {
                 logger.error('Error during button interaction handling:', error);
 
@@ -1072,9 +1273,13 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
 
                 // Resolve the selected artifact by rescanning and matching the encoded value
                 const channelId = (interaction as any).channelId as string;
-                const sessionTitle = deps.chatSessionRepo?.findByChannelId(channelId)?.displayName?.trim() ?? '';
-                let conversationId = sessionTitle ? artifactService.findConversationByTitle(sessionTitle) : null;
-                if (!conversationId) conversationId = artifactService.getLatestConversationWithArtifacts();
+                const session = deps.chatSessionRepo?.findByChannelId(channelId);
+                const sessionTitle = session?.displayName?.trim() ?? '';
+                let workspaceDirName: string | undefined;
+                if (session && session.workspacePath) {
+                    workspaceDirName = path.basename(session.workspacePath);
+                }
+                const conversationId = session?.conversationId || (sessionTitle ? artifactService.findConversationByTitle(sessionTitle, workspaceDirName) : null);
 
                 if (!conversationId) {
                     await interaction.editReply({ content: '📂 No artifacts found.', components: [], allowedMentions: { parse: [] } }).catch(logger.error);
@@ -1191,6 +1396,38 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
             return;
         }
 
+        if (interaction.isStringSelectMenu() && interaction.customId.startsWith(QUESTION_SELECT_ACTION_PREFIX)) {
+            try {
+                const action = createQuestionSelectAction({ bridge: deps.bridge, wsHandler: deps.wsHandler });
+                const wrapped = wrapDiscordSelect(interaction as any);
+                await action.execute(wrapped, interaction.values);
+            } catch (err: unknown) {
+                logger.error('[QuestionSelectAction] Error executing action:', err);
+                if (!interaction.replied && !interaction.deferred) {
+                    await interaction.reply({ content: 'An error occurred.', ephemeral: true }).catch(logger.error);
+                } else {
+                    await interaction.followUp({ content: 'An error occurred.', ephemeral: true }).catch(logger.error);
+                }
+            }
+            return;
+        }
+
+        if (interaction.isButton() && interaction.customId.startsWith(QUESTION_SKIP_ACTION_PREFIX)) {
+            try {
+                const action = createQuestionSkipAction({ bridge: deps.bridge, wsHandler: deps.wsHandler });
+                const wrapped = wrapDiscordButton(interaction as any);
+                await action.execute(wrapped, {});
+            } catch (err: unknown) {
+                logger.error('[QuestionSkipAction] Error executing action:', err);
+                if (!interaction.replied && !interaction.deferred) {
+                    await interaction.reply({ content: 'An error occurred.', ephemeral: true }).catch(logger.error);
+                } else {
+                    await interaction.followUp({ content: 'An error occurred.', ephemeral: true }).catch(logger.error);
+                }
+            }
+            return;
+        }
+
         if (interaction.isStringSelectMenu() && isProjectSelectId(interaction.customId)) {
             if (!deps.config.allowedUserIds.includes(interaction.user.id)) {
                 await interaction.reply({ content: t('You do not have permission.'), flags: MessageFlags.Ephemeral }).catch(logger.error);
@@ -1253,6 +1490,7 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                 deps.channelPrefRepo,
                 deps.antigravityAccounts,
                 deps.chatSessionRepo,
+                deps.scheduleService,
             );
         } catch (error) {
             logger.error(

--- a/src/events/messageCreateHandler.ts
+++ b/src/events/messageCreateHandler.ts
@@ -322,19 +322,26 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
                 }
             }
 
-            // Fetch and append text attachments
-            for (const textAtt of textAttachments) {
-                try {
-                    const res = await fetch(textAtt.url);
-                    if (res.ok) {
-                        const content = await res.text();
-                        promptText += `\n\n[Attached File: ${textAtt.name}]\n\`\`\`\n${content}\n\`\`\``;
-                    } else {
-                        logger.warn(`[MessageCreate] Non-ok status fetching text attachment ${textAtt.name}: ${res.status}`);
+            // Fetch and append text attachments in parallel with a small concurrency cap
+            const CONCURRENCY_LIMIT = 3;
+            for (let i = 0; i < textAttachments.length; i += CONCURRENCY_LIMIT) {
+                const chunk = textAttachments.slice(i, i + CONCURRENCY_LIMIT);
+                const results = await Promise.all(chunk.map(async (textAtt) => {
+                    try {
+                        const res = await fetch(textAtt.url);
+                        if (res.ok) {
+                            const content = await res.text();
+                            return `\n\n[Attached File: ${textAtt.name}]\n\`\`\`\n${content}\n\`\`\``;
+                        } else {
+                            logger.warn(`[MessageCreate] Non-ok status fetching text attachment ${textAtt.name}: ${res.status}`);
+                            return '';
+                        }
+                    } catch (e) {
+                        logger.warn(`[MessageCreate] Failed to fetch text attachment ${textAtt.name}:`, e);
+                        return '';
                     }
-                } catch (e) {
-                    logger.warn(`[MessageCreate] Failed to fetch text attachment ${textAtt.name}:`, e);
-                }
+                }));
+                promptText += results.join('');
             }
 
             const inboundImages = await downloadInboundImageAttachments(message);

--- a/src/events/messageCreateHandler.ts
+++ b/src/events/messageCreateHandler.ts
@@ -16,6 +16,7 @@ import {
     ensureErrorPopupDetector as ensureErrorPopupDetectorFn,
     ensurePlanningDetector as ensurePlanningDetectorFn,
     ensureRunCommandDetector as ensureRunCommandDetectorFn,
+    ensureQuestionDetector as ensureQuestionDetectorFn,
     getCurrentCdp as getCurrentCdpFn,
     registerApprovalSessionChannel as registerApprovalSessionChannelFn,
     registerApprovalWorkspaceChannel as registerApprovalWorkspaceChannelFn,
@@ -72,6 +73,7 @@ export interface MessageCreateHandlerDeps {
     ensureErrorPopupDetector?: (bridge: CdpBridge, cdp: CdpService, projectName: string) => void;
     ensurePlanningDetector?: (bridge: CdpBridge, cdp: CdpService, projectName: string) => void;
     ensureRunCommandDetector?: (bridge: CdpBridge, cdp: CdpService, projectName: string) => void;
+    ensureQuestionDetector?: (bridge: CdpBridge, cdp: CdpService, projectName: string) => void;
     registerApprovalWorkspaceChannel?: (bridge: CdpBridge, projectName: string, channel: PlatformChannel) => void;
     registerApprovalSessionChannel?: (bridge: CdpBridge, projectName: string, sessionTitle: string, channel: PlatformChannel) => void;
     downloadInboundImageAttachments?: (message: Message) => Promise<InboundImageAttachment[]>;
@@ -89,6 +91,7 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
     const ensureErrorPopupDetector = deps.ensureErrorPopupDetector ?? ensureErrorPopupDetectorFn;
     const ensurePlanningDetector = deps.ensurePlanningDetector ?? ensurePlanningDetectorFn;
     const ensureRunCommandDetector = deps.ensureRunCommandDetector ?? ensureRunCommandDetectorFn;
+    const ensureQuestionDetector = deps.ensureQuestionDetector ?? ensureQuestionDetectorFn;
     const registerApprovalWorkspaceChannel = deps.registerApprovalWorkspaceChannel ?? registerApprovalWorkspaceChannelFn;
     const registerApprovalSessionChannel = deps.registerApprovalSessionChannel ?? registerApprovalSessionChannelFn;
     const downloadInboundImageAttachments = deps.downloadInboundImageAttachments ?? downloadInboundImageAttachmentsFn;
@@ -290,10 +293,50 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
             return;
         }
 
-        const hasImageAttachments = Array.from(message.attachments.values())
-            .some((attachment) => isImageAttachment(attachment.contentType, attachment.name));
-        if (message.content.trim() || hasImageAttachments) {
-            const promptText = message.content.trim() || 'Please review the attached images and respond accordingly.';
+        const allAttachments = Array.from(message.attachments.values());
+        const hasImageAttachments = allAttachments.some((attachment) => isImageAttachment(attachment.contentType, attachment.name));
+        
+        const MAX_TEXT_ATTACHMENT_SIZE = 50 * 1024; // 50KB
+        const textAttachments = allAttachments.filter((a) => {
+            if (isImageAttachment(a.contentType, a.name)) return false;
+            if (a.size > MAX_TEXT_ATTACHMENT_SIZE) return false;
+            const isTextType = a.contentType?.startsWith('text/') || a.contentType?.startsWith('application/json') || a.contentType?.startsWith('application/javascript');
+            const hasTextExt = a.name?.match(/\.(txt|md|js|ts|py|json|html|css|csv|log|sh|yml|yaml|xml)$/i);
+            return isTextType || hasTextExt;
+        });
+
+        if (message.content.trim() || hasImageAttachments || textAttachments.length > 0) {
+            let promptText = message.content.trim() || 'Please review the attached content and respond accordingly.';
+
+            // Prepend reply context if replying to a message
+            if (message.reference && message.reference.messageId) {
+                try {
+                    const repliedTo = await message.channel.messages.fetch(message.reference.messageId);
+                    if (repliedTo) {
+                        const cleanContent = (repliedTo.content || '(Attachment/Embed)').trim();
+                        const truncated = cleanContent.length > 500 ? cleanContent.substring(0, 500) + '...' : cleanContent;
+                        promptText = `[Replying to context: "${truncated}"]\n\n${promptText}`;
+                    }
+                } catch (e) {
+                    logger.warn('[MessageCreate] Failed to fetch replied-to message context:', e);
+                }
+            }
+
+            // Fetch and append text attachments
+            for (const textAtt of textAttachments) {
+                try {
+                    const res = await fetch(textAtt.url);
+                    if (res.ok) {
+                        const content = await res.text();
+                        promptText += `\n\n[Attached File: ${textAtt.name}]\n\`\`\`\n${content}\n\`\`\``;
+                    } else {
+                        logger.warn(`[MessageCreate] Non-ok status fetching text attachment ${textAtt.name}: ${res.status}`);
+                    }
+                } catch (e) {
+                    logger.warn(`[MessageCreate] Failed to fetch text attachment ${textAtt.name}:`, e);
+                }
+            }
+
             const inboundImages = await downloadInboundImageAttachments(message);
 
             if (hasImageAttachments && inboundImages.length === 0) {
@@ -372,6 +415,7 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
                             ensureErrorPopupDetector(deps.bridge, cdp, projectName, selectedAccount);
                             ensurePlanningDetector(deps.bridge, cdp, projectName, selectedAccount);
                             ensureRunCommandDetector(deps.bridge, cdp, projectName, selectedAccount);
+                            ensureQuestionDetector(deps.bridge, cdp, projectName, selectedAccount);
 
                             let session = deps.chatSessionRepo.findByChannelId(message.channelId);
                             const staleSessionAccount = session?.isRenamed

--- a/src/handlers/__tests__/fileChangeButtonAction.test.ts
+++ b/src/handlers/__tests__/fileChangeButtonAction.test.ts
@@ -1,0 +1,105 @@
+import { createFileChangeButtonAction } from '../fileChangeButtonAction';
+
+describe('fileChangeButtonAction', () => {
+    let mockInteraction: any;
+    let mockCdp: any;
+    let mockBridge: any;
+    let mockWsHandler: any;
+
+    beforeEach(() => {
+        mockInteraction = {
+            deferUpdate: jest.fn().mockResolvedValue(undefined),
+            reply: jest.fn().mockResolvedValue(undefined),
+            update: jest.fn().mockResolvedValue(undefined),
+            followUp: jest.fn().mockResolvedValue(undefined),
+        };
+
+        mockCdp = {
+            isConnected: jest.fn().mockReturnValue(true),
+            call: jest.fn(),
+        };
+
+        mockBridge = {
+            lastActiveWorkspace: 'test_project',
+            pool: {
+                getConnected: jest.fn().mockReturnValue(mockCdp),
+                extractProjectName: jest.fn().mockReturnValue('test_project'),
+            },
+        };
+
+        mockWsHandler = {
+            getWorkspaceForChannel: jest.fn().mockReturnValue('test_project'),
+        };
+    });
+
+    it('matches valid legacy custom IDs', () => {
+        const action = createFileChangeButtonAction({ bridge: mockBridge, wsHandler: mockWsHandler });
+        expect(action.match('ide_file_accept_all')).toEqual({ action: 'accept', projectName: '', channelId: '' });
+        expect(action.match('ide_file_reject_all')).toEqual({ action: 'reject', projectName: '', channelId: '' });
+        expect(action.match('unknown_button')).toBeNull();
+    });
+
+    it('matches valid custom IDs with project and channel', () => {
+        const action = createFileChangeButtonAction({ bridge: mockBridge, wsHandler: mockWsHandler });
+        expect(action.match('file_change_accept:proj:chan1')).toEqual({ action: 'accept', projectName: 'proj', channelId: 'chan1' });
+        expect(action.match('file_change_reject:proj:chan2')).toEqual({ action: 'reject', projectName: 'proj', channelId: 'chan2' });
+    });
+
+    it('fails if linked to a different session channel', async () => {
+        mockInteraction.channel = { id: 'channel_123' };
+        const action = createFileChangeButtonAction({ bridge: mockBridge, wsHandler: mockWsHandler });
+        
+        await action.execute(mockInteraction, { action: 'accept', channelId: 'channel_456' });
+        
+        expect(mockInteraction.reply).toHaveBeenCalledWith({ text: 'This file change action is linked to a different session channel.' });
+    });
+
+    it('fails if not connected to IDE', async () => {
+        mockInteraction.channel = { id: 'channel_123' };
+        mockCdp.isConnected.mockReturnValue(false);
+        const action = createFileChangeButtonAction({ bridge: mockBridge, wsHandler: mockWsHandler });
+        
+        await action.execute(mockInteraction, { action: 'accept', channelId: 'channel_123' });
+        
+        expect(mockInteraction.reply).toHaveBeenCalledWith({ text: 'Not connected to IDE.' });
+    });
+
+    it('successfully accepts changes when button is found', async () => {
+        mockInteraction.channel = { id: 'channel_123' };
+        mockCdp.call.mockResolvedValue({ result: { value: true } });
+        const action = createFileChangeButtonAction({ bridge: mockBridge, wsHandler: mockWsHandler });
+        
+        await action.execute(mockInteraction, { action: 'accept' });
+        
+        expect(mockCdp.call).toHaveBeenCalled();
+        expect(mockInteraction.update).toHaveBeenCalledWith({
+            text: '✅ Accepted file changes.',
+            components: [],
+        });
+    });
+
+    it('successfully rejects changes when button is found', async () => {
+        mockInteraction.channel = { id: 'channel_123' };
+        mockCdp.call.mockResolvedValue({ result: { value: true } });
+        const action = createFileChangeButtonAction({ bridge: mockBridge, wsHandler: mockWsHandler });
+        
+        await action.execute(mockInteraction, { action: 'reject' });
+        
+        expect(mockInteraction.update).toHaveBeenCalledWith({
+            text: '❌ Rejected file changes.',
+            components: [],
+        });
+    });
+
+    it('sends followup if button is not found', async () => {
+        mockInteraction.channel = { id: 'channel_123' };
+        mockCdp.call.mockResolvedValue({ result: { value: false } });
+        const action = createFileChangeButtonAction({ bridge: mockBridge, wsHandler: mockWsHandler });
+        
+        await action.execute(mockInteraction, { action: 'accept' });
+        
+        expect(mockInteraction.followUp).toHaveBeenCalledWith({
+            text: expect.stringContaining('Could not find the "Accept all" button'),
+        });
+    });
+});

--- a/src/handlers/approvalButtonAction.ts
+++ b/src/handlers/approvalButtonAction.ts
@@ -9,10 +9,12 @@ import type { PlatformButtonInteraction } from '../platform/types';
 import type { ButtonAction } from './buttonHandler';
 import type { CdpBridge } from '../services/cdpBridgeManager';
 import { parseApprovalCustomId } from '../services/cdpBridgeManager';
+import type { WorkspaceCommandHandler } from '../commands/workspaceCommandHandler';
 import { logger } from '../utils/logger';
 
 export interface ApprovalButtonActionDeps {
     readonly bridge: CdpBridge;
+    readonly wsHandler: WorkspaceCommandHandler;
 }
 
 export function createApprovalButtonAction(
@@ -46,7 +48,11 @@ export function createApprovalButtonAction(
                 return;
             }
 
-            const projectName = params.projectName || deps.bridge.lastActiveWorkspace;
+            let projectName: string | undefined = params.projectName;
+            if (!projectName) {
+                const workspacePath = deps.wsHandler.getWorkspaceForChannel(interaction.channel.id);
+                projectName = workspacePath ? deps.bridge.pool.extractProjectName(workspacePath) : undefined;
+            }
             logger.debug(`[ApprovalAction] action=${action} project=${projectName ?? 'null'} channel=${interaction.channel.id}`);
 
             const detector = projectName

--- a/src/handlers/errorPopupButtonAction.ts
+++ b/src/handlers/errorPopupButtonAction.ts
@@ -9,10 +9,12 @@ import type { PlatformButtonInteraction } from '../platform/types';
 import type { ButtonAction } from './buttonHandler';
 import type { CdpBridge } from '../services/cdpBridgeManager';
 import { parseErrorPopupCustomId } from '../services/cdpBridgeManager';
+import type { WorkspaceCommandHandler } from '../commands/workspaceCommandHandler';
 import { logger } from '../utils/logger';
 
 export interface ErrorPopupButtonActionDeps {
     readonly bridge: CdpBridge;
+    readonly wsHandler: WorkspaceCommandHandler;
 }
 
 const MAX_DEBUG_CONTENT = 4096;
@@ -44,7 +46,11 @@ export function createErrorPopupButtonAction(
                 return;
             }
 
-            const projectName = params.projectName || deps.bridge.lastActiveWorkspace;
+            let projectName: string | undefined = params.projectName;
+            if (!projectName) {
+                const workspacePath = deps.wsHandler.getWorkspaceForChannel(interaction.channel.id);
+                projectName = workspacePath ? deps.bridge.pool.extractProjectName(workspacePath) : undefined;
+            }
             const detector = projectName
                 ? deps.bridge.pool.getErrorPopupDetector(projectName)
                 : undefined;

--- a/src/handlers/fileChangeButtonAction.ts
+++ b/src/handlers/fileChangeButtonAction.ts
@@ -1,0 +1,98 @@
+import type { PlatformButtonInteraction } from '../platform/types';
+import type { ButtonAction } from './buttonHandler';
+import type { CdpBridge } from '../services/cdpBridgeManager';
+import { parseFileChangeCustomId } from '../services/cdpBridgeManager';
+import type { WorkspaceCommandHandler } from '../commands/workspaceCommandHandler';
+import { logger } from '../utils/logger';
+
+export interface FileChangeButtonActionDeps {
+    readonly bridge: CdpBridge;
+    readonly wsHandler: WorkspaceCommandHandler;
+}
+
+export function createFileChangeButtonAction(
+    deps: FileChangeButtonActionDeps,
+): ButtonAction {
+    return {
+        match(customId: string): Record<string, string> | null {
+            const parsed = parseFileChangeCustomId(customId);
+            if (!parsed) return null;
+            return {
+                action: parsed.action,
+                projectName: parsed.projectName ?? '',
+                channelId: parsed.channelId ?? '',
+            };
+        },
+
+        async execute(
+            interaction: PlatformButtonInteraction,
+            params: Record<string, string>,
+        ): Promise<void> {
+            const { action, channelId } = params;
+
+            // Acknowledge immediately so Telegram/Discord doesn't time out
+            await interaction.deferUpdate().catch(() => {});
+
+            if (channelId && channelId !== interaction.channel.id) {
+                await interaction
+                    .reply({ text: 'This file change action is linked to a different session channel.' })
+                    .catch(() => {});
+                return;
+            }
+
+            let projectName: string | undefined = params.projectName;
+            if (!projectName) {
+                const workspacePath = deps.wsHandler.getWorkspaceForChannel(interaction.channel.id);
+                projectName = workspacePath ? deps.bridge.pool.extractProjectName(workspacePath) : undefined;
+            }
+            const cdp = projectName ? deps.bridge.pool.getConnected(projectName) : undefined;
+
+            if (!cdp || !cdp.isConnected()) {
+                await interaction
+                    .reply({ text: 'Not connected to IDE.' })
+                    .catch(() => {});
+                return;
+            }
+
+            const targetText = action === 'accept' ? 'Accept all' : 'Reject all';
+
+            try {
+                // Send a CDP script to find and click the specific span containing "Accept all" or "Reject all"
+                const result = await cdp.call('Runtime.evaluate', {
+                    expression: `(() => {
+                        var spans = document.querySelectorAll('span');
+                        for (var i = 0; i < spans.length; i++) {
+                            if ((spans[i].textContent || '').trim() === '${targetText}') {
+                                spans[i].click();
+                                return true;
+                            }
+                        }
+                        return false;
+                    })()`,
+                    returnByValue: true,
+                    awaitPromise: true,
+                });
+
+                if (result?.result?.value === true) {
+                    await interaction
+                        .update({
+                            text: `${action === 'accept' ? '✅ Accepted' : '❌ Rejected'} file changes.`,
+                            components: [],
+                        })
+                        .catch((err) => {
+                            logger.warn('[FileChangeAction] update failed:', err);
+                        });
+                } else {
+                    await interaction
+                        .followUp({ text: `Could not find the "${targetText}" button in the IDE. The file change prompt may have been dismissed.` })
+                        .catch(() => {});
+                }
+            } catch (error) {
+                logger.error('[FileChangeAction] Error clicking button:', error);
+                await interaction
+                    .followUp({ text: 'An error occurred while interacting with the IDE.' })
+                    .catch(() => {});
+            }
+        },
+    };
+}

--- a/src/handlers/genericActionButtonAction.ts
+++ b/src/handlers/genericActionButtonAction.ts
@@ -1,0 +1,44 @@
+import type { ButtonAction } from './buttonHandler';
+import type { CdpBridge } from '../services/cdpBridgeManager';
+import { getCurrentCdp } from '../services/cdpBridgeManager';
+import { logger } from '../utils/logger';
+
+export interface GenericActionButtonActionDeps {
+    readonly bridge: CdpBridge;
+}
+
+export function createGenericActionButtonAction(deps: GenericActionButtonActionDeps): ButtonAction {
+    return {
+        match(customId: string): Record<string, string> | null {
+            if (!customId.startsWith('action_btn_')) return null;
+            const actionName = customId.replace('action_btn_', '').replace(/_/g, ' ');
+            // Capitalize first letter
+            const formattedName = actionName.charAt(0).toUpperCase() + actionName.slice(1);
+            return { actionName: formattedName };
+        },
+
+        async execute(interaction, params): Promise<void> {
+            const actionName = params.actionName;
+
+            await interaction.deferUpdate();
+
+            const cdp = getCurrentCdp(deps.bridge);
+            if (!cdp) {
+                await interaction.followUp({
+                    text: 'Not connected to Antigravity. Send the action as a message instead.',
+                }).catch(() => {});
+                return;
+            }
+
+            // Inject the action text
+            logger.info(`[GenericActionButton] Clicking action button "${actionName}" via chat injection`);
+            const result = await cdp.injectMessage(actionName);
+            if (!result.ok) {
+                await interaction.followUp({
+                    text: `Failed to execute action: ${result.error}`,
+                }).catch(() => {});
+                return;
+            }
+        },
+    };
+}

--- a/src/handlers/planningButtonAction.ts
+++ b/src/handlers/planningButtonAction.ts
@@ -9,10 +9,12 @@ import type { PlatformButtonInteraction } from '../platform/types';
 import type { ButtonAction } from './buttonHandler';
 import type { CdpBridge } from '../services/cdpBridgeManager';
 import { parsePlanningCustomId } from '../services/cdpBridgeManager';
+import type { WorkspaceCommandHandler } from '../commands/workspaceCommandHandler';
 import { logger } from '../utils/logger';
 
 export interface PlanningButtonActionDeps {
     readonly bridge: CdpBridge;
+    readonly wsHandler: WorkspaceCommandHandler;
 }
 
 const MAX_PLAN_CONTENT = 4096;
@@ -47,7 +49,11 @@ export function createPlanningButtonAction(
                 return;
             }
 
-            const projectName = params.projectName || deps.bridge.lastActiveWorkspace;
+            let projectName: string | undefined = params.projectName;
+            if (!projectName) {
+                const workspacePath = deps.wsHandler.getWorkspaceForChannel(interaction.channel.id);
+                projectName = workspacePath ? deps.bridge.pool.extractProjectName(workspacePath) : undefined;
+            }
             const detector = projectName
                 ? deps.bridge.pool.getPlanningDetector(projectName)
                 : undefined;
@@ -61,16 +67,13 @@ export function createPlanningButtonAction(
 
             if (action === 'open') {
 
-                const clicked = await detector.clickOpenButton();
-                if (!clicked) {
-                    await interaction
-                        .reply({ text: 'Open button not found.' })
-                        .catch(() => {});
-                    return;
+                let clicked = false;
+                if (detector.getLastDetectedInfo()?.hasOpenButton) {
+                    clicked = await detector.clickOpenButton();
+                    if (clicked) {
+                        await new Promise((resolve) => setTimeout(resolve, 500));
+                    }
                 }
-
-                // Wait for DOM to update after Open click
-                await new Promise((resolve) => setTimeout(resolve, 500));
 
                 // Extract plan content with retry
                 let planContent: string | null = null;
@@ -78,6 +81,13 @@ export function createPlanningButtonAction(
                     planContent = await detector.extractPlanContent();
                     if (planContent) break;
                     await new Promise((resolve) => setTimeout(resolve, 500));
+                }
+
+                if (!planContent && !clicked) {
+                    await interaction
+                        .reply({ text: 'Plan content could not be extracted from the IDE.' })
+                        .catch(() => {});
+                    return;
                 }
 
                 await interaction
@@ -103,6 +113,10 @@ export function createPlanningButtonAction(
                         .followUp({ text: 'Could not extract plan content from the editor.' })
                         .catch(() => {});
                 }
+            } else if (action === 'reject') {
+                // Reject action
+                await interaction.reply({ text: 'Rejection of the plan is not allowed.' }).catch(() => {});
+                return;
             } else {
                 // Proceed action
                 await interaction.deferUpdate().catch(() => {});

--- a/src/handlers/questionSelectAction.ts
+++ b/src/handlers/questionSelectAction.ts
@@ -1,0 +1,98 @@
+import type { PlatformSelectInteraction } from '../platform/types';
+import type { SelectAction } from './selectHandler';
+import type { CdpBridge } from '../services/cdpBridgeManager';
+import type { WorkspaceCommandHandler } from '../commands/workspaceCommandHandler';
+import { logger } from '../utils/logger';
+import { QUESTION_SELECT_ACTION_PREFIX } from '../services/notificationSender';
+
+export interface QuestionSelectActionDeps {
+    readonly bridge: CdpBridge;
+    readonly wsHandler: WorkspaceCommandHandler;
+}
+
+export function parseQuestionCustomId(customId: string): { action: string; projectName?: string; channelId?: string } | null {
+    if (!customId.startsWith(QUESTION_SELECT_ACTION_PREFIX)) return null;
+
+    const parts = customId.split(':');
+    const result: any = { action: parts[0] };
+    for (let i = 1; i < parts.length; i++) {
+        const [k, ...rest] = parts[i].split('=');
+        if (k === 'p') result.projectName = rest.join('=');
+        else if (k === 'c') result.channelId = rest.join('=');
+    }
+    return result;
+}
+
+export function createQuestionSelectAction(deps: QuestionSelectActionDeps): SelectAction {
+    return {
+        match(customId: string): boolean {
+            return customId.startsWith(QUESTION_SELECT_ACTION_PREFIX);
+        },
+
+        async execute(
+            interaction: PlatformSelectInteraction,
+            values: readonly string[],
+        ): Promise<void> {
+            const parsed = parseQuestionCustomId(interaction.customId);
+            if (!parsed) return;
+
+            const selectedOption = parseInt(values[0], 10);
+            if (isNaN(selectedOption)) return;
+
+            const channelId = parsed.channelId;
+            if (channelId && channelId !== interaction.channel.id) {
+                await interaction
+                    .reply({ text: 'This question is linked to a different session channel.', ephemeral: true })
+                    .catch(() => {});
+                return;
+            }
+
+            let projectName: string | undefined = parsed.projectName;
+            if (!projectName) {
+                const workspacePath = deps.wsHandler.getWorkspaceForChannel(interaction.channel.id);
+                projectName = workspacePath ? deps.bridge.pool.extractProjectName(workspacePath) : undefined;
+            }
+            logger.debug(`[QuestionSelectAction] project=${projectName ?? 'null'} channel=${interaction.channel.id}`);
+
+            const detector = projectName
+                ? deps.bridge.pool.getQuestionDetector(projectName)
+                : undefined;
+
+            if (!detector) {
+                logger.warn(`[QuestionSelectAction] No detector for project=${projectName}`);
+                await interaction
+                    .reply({ text: 'Question detector not found.', ephemeral: true })
+                    .catch(() => {});
+                return;
+            }
+
+            await interaction.deferUpdate().catch(() => {});
+
+            let success = false;
+            try {
+                success = await detector.submitOption(selectedOption);
+            } catch (err: unknown) {
+                const msg = err instanceof Error ? err.message : String(err);
+                logger.error(`[QuestionSelectAction] CDP click failed: ${msg}`);
+                await interaction
+                    .followUp({ text: `Failed to answer question: ${msg}`, ephemeral: true })
+                    .catch(() => {});
+                return;
+            }
+
+            if (success) {
+                const updatePayload = { text: `✅ Submitted option ${selectedOption + 1}`, components: [] as any[] };
+                try {
+                    await interaction.editReply(updatePayload);
+                } catch (editErr) {
+                    logger.warn('[QuestionSelectAction] editReply failed, sending followUp:', editErr);
+                    await interaction.followUp({ text: `✅ Submitted option ${selectedOption + 1}` }).catch(() => {});
+                }
+            } else {
+                await interaction
+                    .followUp({ text: 'Failed to answer question (it may have been resolved already).', ephemeral: true })
+                    .catch(() => {});
+            }
+        },
+    };
+}

--- a/src/handlers/questionSkipAction.ts
+++ b/src/handlers/questionSkipAction.ts
@@ -1,0 +1,96 @@
+import type { PlatformButtonInteraction } from '../platform/types';
+import type { ButtonAction } from './buttonHandler';
+import type { CdpBridge } from '../services/cdpBridgeManager';
+import type { WorkspaceCommandHandler } from '../commands/workspaceCommandHandler';
+import { logger } from '../utils/logger';
+import { QUESTION_SKIP_ACTION_PREFIX } from '../services/notificationSender';
+
+export interface QuestionSkipActionDeps {
+    readonly bridge: CdpBridge;
+    readonly wsHandler: WorkspaceCommandHandler;
+}
+
+export function parseQuestionSkipCustomId(customId: string): { action: string; projectName?: string; channelId?: string } | null {
+    if (!customId.startsWith(QUESTION_SKIP_ACTION_PREFIX)) return null;
+
+    const parts = customId.split(':');
+    const result: any = { action: parts[0] };
+    for (let i = 1; i < parts.length; i++) {
+        const [k, ...rest] = parts[i].split('=');
+        if (k === 'p') result.projectName = rest.join('=');
+        else if (k === 'c') result.channelId = rest.join('=');
+    }
+    return result;
+}
+
+export function createQuestionSkipAction(deps: QuestionSkipActionDeps): ButtonAction {
+    return {
+        match(customId: string): Record<string, string> | null {
+            const parsed = parseQuestionSkipCustomId(customId);
+            return parsed ? { action: parsed.action } : null;
+        },
+
+        async execute(
+            interaction: PlatformButtonInteraction,
+            params: Record<string, string>,
+        ): Promise<void> {
+            const parsed = parseQuestionSkipCustomId(interaction.customId);
+            if (!parsed) return;
+
+            const channelId = parsed.channelId;
+            if (channelId && channelId !== interaction.channel.id) {
+                await interaction
+                    .reply({ text: 'This question is linked to a different session channel.', ephemeral: true })
+                    .catch(() => {});
+                return;
+            }
+
+            let projectName: string | undefined = parsed.projectName;
+            if (!projectName) {
+                const workspacePath = deps.wsHandler.getWorkspaceForChannel(interaction.channel.id);
+                projectName = workspacePath ? deps.bridge.pool.extractProjectName(workspacePath) : undefined;
+            }
+            logger.debug(`[QuestionSkipAction] project=${projectName ?? 'null'} channel=${interaction.channel.id}`);
+
+            const detector = projectName
+                ? deps.bridge.pool.getQuestionDetector(projectName)
+                : undefined;
+
+            if (!detector) {
+                logger.warn(`[QuestionSkipAction] No detector for project=${projectName}`);
+                await interaction
+                    .reply({ text: 'Question detector not found.', ephemeral: true })
+                    .catch(() => {});
+                return;
+            }
+
+            await interaction.deferUpdate().catch(() => {});
+
+            let success = false;
+            try {
+                success = await detector.skipQuestion();
+            } catch (err: unknown) {
+                const msg = err instanceof Error ? err.message : String(err);
+                logger.error(`[QuestionSkipAction] CDP click failed: ${msg}`);
+                await interaction
+                    .followUp({ text: `Failed to skip question: ${msg}`, ephemeral: true })
+                    .catch(() => {});
+                return;
+            }
+
+            if (success) {
+                const updatePayload = { text: `✅ Skipped question`, components: [] as any[] };
+                try {
+                    await interaction.editReply(updatePayload);
+                } catch (editErr) {
+                    logger.warn('[QuestionSkipAction] editReply failed, sending followUp:', editErr);
+                    await interaction.followUp({ text: `✅ Skipped question` }).catch(() => {});
+                }
+            } else {
+                await interaction
+                    .followUp({ text: 'Failed to skip question (it may have been resolved already).', ephemeral: true })
+                    .catch(() => {});
+            }
+        },
+    };
+}

--- a/src/handlers/runCommandButtonAction.ts
+++ b/src/handlers/runCommandButtonAction.ts
@@ -9,10 +9,12 @@ import type { PlatformButtonInteraction } from '../platform/types';
 import type { ButtonAction } from './buttonHandler';
 import type { CdpBridge } from '../services/cdpBridgeManager';
 import { parseRunCommandCustomId } from '../services/cdpBridgeManager';
+import type { WorkspaceCommandHandler } from '../commands/workspaceCommandHandler';
 import { logger } from '../utils/logger';
 
 export interface RunCommandButtonActionDeps {
     readonly bridge: CdpBridge;
+    readonly wsHandler: WorkspaceCommandHandler;
 }
 
 export function createRunCommandButtonAction(
@@ -45,7 +47,11 @@ export function createRunCommandButtonAction(
                 return;
             }
 
-            const projectName = params.projectName || deps.bridge.lastActiveWorkspace;
+            let projectName: string | undefined = params.projectName;
+            if (!projectName) {
+                const workspacePath = deps.wsHandler.getWorkspaceForChannel(interaction.channel.id);
+                projectName = workspacePath ? deps.bridge.pool.extractProjectName(workspacePath) : undefined;
+            }
             const detector = projectName
                 ? deps.bridge.pool.getRunCommandDetector(projectName)
                 : undefined;

--- a/src/platform/discord/discordResponseRenderer.ts
+++ b/src/platform/discord/discordResponseRenderer.ts
@@ -86,8 +86,14 @@ export function renderDiscordResponse(result: ClassifyResult): MessageCreateOpti
         // Chunk into fields if necessary (max 25 fields, 1024 chars per field)
         let currentFieldVal = '';
         let fieldCount = 0;
+        let processedCount = 0;
+        let truncated = false;
         
         for (const file of result.fileChanges) {
+            if (fieldCount >= 24) {
+                truncated = true;
+                break;
+            }
             const line = `- \`${file.path}\` (${file.type})\n`;
             if (line.length > 1000) {
                 if (currentFieldVal) {
@@ -97,9 +103,12 @@ export function renderDiscordResponse(result: ClassifyResult): MessageCreateOpti
                 }
                 const splitLine = chunkText(line, 1000);
                 for (const sl of splitLine) {
+                    if (fieldCount >= 24) {
+                        truncated = true;
+                        break;
+                    }
                     embed.addFields({ name: fieldCount === 0 ? 'Files' : '...', value: sl || '-' });
                     fieldCount++;
-                    if (fieldCount >= 24) break;
                 }
             } else if (currentFieldVal.length + line.length > 1000) {
                 if (currentFieldVal) {
@@ -107,13 +116,20 @@ export function renderDiscordResponse(result: ClassifyResult): MessageCreateOpti
                     fieldCount++;
                 }
                 currentFieldVal = line;
-                if (fieldCount >= 24) break; // Leave one just in case
             } else {
                 currentFieldVal += line;
             }
+            if (!truncated) {
+                processedCount++;
+            }
         }
-        if (currentFieldVal) {
+        if (currentFieldVal && fieldCount < 24) {
             embed.addFields({ name: fieldCount === 0 ? 'Files' : '...', value: currentFieldVal });
+            fieldCount++;
+        }
+        if (processedCount < result.fileChanges.length) {
+            const remaining = result.fileChanges.length - processedCount;
+            embed.addFields({ name: '...', value: `*...and ${remaining} more*` });
         }
         
         embeds.push(embed);

--- a/src/platform/discord/discordResponseRenderer.ts
+++ b/src/platform/discord/discordResponseRenderer.ts
@@ -68,11 +68,13 @@ export function renderDiscordResponse(result: ClassifyResult): MessageCreateOpti
     if (result.planCards && result.planCards.length > 0) {
         const planText = result.planCards.join('\n\n');
         const chunks = chunkText(planText, 4000);
-        const embed = new EmbedBuilder()
-            .setTitle('Plan')
-            .setColor(0x5865f2) // Blurple
-            .setDescription(chunks[0]);
-        embeds.push(embed);
+        for (let i = 0; i < chunks.length && embeds.length < 10; i++) {
+            const embed = new EmbedBuilder()
+                .setTitle(i === 0 ? 'Plan' : undefined)
+                .setColor(0x5865f2) // Blurple
+                .setDescription(chunks[i]);
+            embeds.push(embed);
+        }
     }
 
     // 3. File Changes
@@ -87,10 +89,24 @@ export function renderDiscordResponse(result: ClassifyResult): MessageCreateOpti
         
         for (const file of result.fileChanges) {
             const line = `- \`${file.path}\` (${file.type})\n`;
-            if (currentFieldVal.length + line.length > 1000) {
-                embed.addFields({ name: fieldCount === 0 ? 'Files' : '...', value: currentFieldVal });
+            if (line.length > 1000) {
+                if (currentFieldVal) {
+                    embed.addFields({ name: fieldCount === 0 ? 'Files' : '...', value: currentFieldVal });
+                    currentFieldVal = '';
+                    fieldCount++;
+                }
+                const splitLine = chunkText(line, 1000);
+                for (const sl of splitLine) {
+                    embed.addFields({ name: fieldCount === 0 ? 'Files' : '...', value: sl || '-' });
+                    fieldCount++;
+                    if (fieldCount >= 24) break;
+                }
+            } else if (currentFieldVal.length + line.length > 1000) {
+                if (currentFieldVal) {
+                    embed.addFields({ name: fieldCount === 0 ? 'Files' : '...', value: currentFieldVal });
+                    fieldCount++;
+                }
                 currentFieldVal = line;
-                fieldCount++;
                 if (fieldCount >= 24) break; // Leave one just in case
             } else {
                 currentFieldVal += line;
@@ -109,7 +125,7 @@ export function renderDiscordResponse(result: ClassifyResult): MessageCreateOpti
         for (let i = 0; i < result.actionButtons.length && i < 5; i++) { // Max 5 buttons per row
             const btnText = result.actionButtons[i];
             const btn = new ButtonBuilder()
-                .setCustomId(`action_btn_${btnText.toLowerCase().replace(/\\s+/g, '_')}`)
+                .setCustomId(`action_btn_${btnText.toLowerCase().replace(/\s+/g, '_')}`)
                 .setLabel(btnText)
                 .setStyle(
                     btnText.toLowerCase() === 'proceed' || btnText.toLowerCase() === 'open' 

--- a/src/platform/discord/discordResponseRenderer.ts
+++ b/src/platform/discord/discordResponseRenderer.ts
@@ -1,0 +1,143 @@
+import {
+    EmbedBuilder,
+    ActionRowBuilder,
+    ButtonBuilder,
+    ButtonStyle,
+    type MessageCreateOptions,
+} from 'discord.js';
+import type { ClassifyResult } from '../../services/assistantDomExtractor';
+
+/**
+ * Splits a long string into chunks that fit within Discord's embed description limit (4096 chars).
+ * Tries to split on double newlines, then single newlines, then spaces, before hard splitting.
+ */
+function chunkText(text: string, limit = 4000): string[] {
+    if (!text) return [];
+    if (text.length <= limit) return [text];
+
+    const chunks: string[] = [];
+    let remaining = text;
+
+    while (remaining.length > 0) {
+        if (remaining.length <= limit) {
+            chunks.push(remaining);
+            break;
+        }
+
+        let slice = remaining.slice(0, limit);
+        let splitIndex = slice.lastIndexOf('\n\n');
+        
+        if (splitIndex === -1 || splitIndex < limit * 0.5) {
+            splitIndex = slice.lastIndexOf('\n');
+        }
+        if (splitIndex === -1 || splitIndex < limit * 0.5) {
+            splitIndex = slice.lastIndexOf(' ');
+        }
+        if (splitIndex === -1 || splitIndex < limit * 0.5) {
+            splitIndex = limit; // Hard split
+        }
+
+        chunks.push(remaining.slice(0, splitIndex).trim());
+        remaining = remaining.slice(splitIndex).trim();
+    }
+
+    return chunks;
+}
+
+/**
+ * Renders a classified Antigravity response into a Discord Message payload.
+ *
+ * Handles chunking for large outputs and structured cards (plan, files, actions).
+ */
+export function renderDiscordResponse(result: ClassifyResult): MessageCreateOptions {
+    const embeds: EmbedBuilder[] = [];
+    const components: ActionRowBuilder<ButtonBuilder>[] = [];
+
+    // 1. Final Output Text
+    if (result.finalOutputText) {
+        const textChunks = chunkText(result.finalOutputText, 4000); // leave some buffer
+        for (let i = 0; i < textChunks.length && i < 8; i++) { // max 10 embeds total, leave room
+            const embed = new EmbedBuilder()
+                .setColor(0x2b2d31) // Discord dark mode background-ish / neutral
+                .setDescription(textChunks[i]);
+            embeds.push(embed);
+        }
+    }
+
+    // 2. Plan Cards
+    if (result.planCards && result.planCards.length > 0) {
+        const planText = result.planCards.join('\n\n');
+        const chunks = chunkText(planText, 4000);
+        const embed = new EmbedBuilder()
+            .setTitle('Plan')
+            .setColor(0x5865f2) // Blurple
+            .setDescription(chunks[0]);
+        embeds.push(embed);
+    }
+
+    // 3. File Changes
+    if (result.fileChanges && result.fileChanges.length > 0) {
+        const embed = new EmbedBuilder()
+            .setTitle('File Changes')
+            .setColor(0x3ba55c); // Greenish
+            
+        // Chunk into fields if necessary (max 25 fields, 1024 chars per field)
+        let currentFieldVal = '';
+        let fieldCount = 0;
+        
+        for (const file of result.fileChanges) {
+            const line = `- \`${file.path}\` (${file.type})\n`;
+            if (currentFieldVal.length + line.length > 1000) {
+                embed.addFields({ name: fieldCount === 0 ? 'Files' : '...', value: currentFieldVal });
+                currentFieldVal = line;
+                fieldCount++;
+                if (fieldCount >= 24) break; // Leave one just in case
+            } else {
+                currentFieldVal += line;
+            }
+        }
+        if (currentFieldVal) {
+            embed.addFields({ name: fieldCount === 0 ? 'Files' : '...', value: currentFieldVal });
+        }
+        
+        embeds.push(embed);
+    }
+
+    // 4. Action Buttons
+    if (result.actionButtons && result.actionButtons.length > 0) {
+        const row = new ActionRowBuilder<ButtonBuilder>();
+        for (let i = 0; i < result.actionButtons.length && i < 5; i++) { // Max 5 buttons per row
+            const btnText = result.actionButtons[i];
+            const btn = new ButtonBuilder()
+                .setCustomId(`action_btn_${btnText.toLowerCase().replace(/\\s+/g, '_')}`)
+                .setLabel(btnText)
+                .setStyle(
+                    btnText.toLowerCase() === 'proceed' || btnText.toLowerCase() === 'open' 
+                    ? ButtonStyle.Primary 
+                    : ButtonStyle.Secondary
+                );
+            row.addComponents(btn);
+        }
+        components.push(row);
+    }
+
+    // 5. Fallback if absolutely empty
+    if (embeds.length === 0) {
+        if (result.activityLines && result.activityLines.length > 0) {
+            const embed = new EmbedBuilder()
+                .setColor(0x2b2d31)
+                .setDescription('*(Processing...)*\n' + result.activityLines.slice(-3).join('\n').slice(0, 3900));
+            embeds.push(embed);
+        } else {
+            return { content: '*(No output)*' };
+        }
+    }
+
+    // Discord allows max 10 embeds per message.
+    const finalEmbeds = embeds.slice(0, 10);
+    
+    return {
+        embeds: finalEmbeds,
+        components: components.length > 0 ? components : undefined,
+    };
+}

--- a/src/services/antigravityLauncher.ts
+++ b/src/services/antigravityLauncher.ts
@@ -31,6 +31,7 @@ export function checkPort(port: number): Promise<boolean> {
     });
 }
 
+
 /**
  * Waits for a specific port to respond within the given timeout.
  */

--- a/src/services/approvalDetector.ts
+++ b/src/services/approvalDetector.ts
@@ -1,4 +1,5 @@
 import { logger } from '../utils/logger';
+import { ConsecutiveEmptyPollGate } from '../utils/consecutiveEmptyPollGate';
 import { CdpService } from './cdpService';
 
 /** Approval button information */
@@ -282,10 +283,8 @@ export class ApprovalDetector {
     private lastDetectedKey: string | null = null;
     /** Full ApprovalInfo from the last detection (used for clicking) */
     private lastDetectedInfo: ApprovalInfo | null = null;
-    /** Number of consecutive polls without detecting buttons */
-    private emptyPollCount: number = 0;
-    /** Number of consecutive empty polls required before resetting state */
-    private static readonly REQUIRED_EMPTY_POLLS = 3;
+    /** Gate for empty polls before reset */
+    private emptyPollGate = new ConsecutiveEmptyPollGate(3);
 
     constructor(options: ApprovalDetectorOptions) {
         this.cdpService = options.cdpService;
@@ -302,7 +301,7 @@ export class ApprovalDetector {
         this.isRunning = true;
         this.lastDetectedKey = null;
         this.lastDetectedInfo = null;
-        this.emptyPollCount = 0;
+        this.emptyPollGate.reset();
         this.schedulePoll();
     }
 
@@ -358,7 +357,7 @@ export class ApprovalDetector {
             const info: ApprovalInfo | null = result?.result?.value ?? null;
 
             if (info) {
-                this.emptyPollCount = 0;
+                this.emptyPollGate.recordDetection();
                 // Duplicate prevention: use approveText + description combination as key
                 const key = `${info.approveText}::${info.description}`;
                 if (key !== this.lastDetectedKey) {
@@ -367,8 +366,7 @@ export class ApprovalDetector {
                     this.onApprovalRequired(info);
                 }
             } else {
-                this.emptyPollCount++;
-                if (this.emptyPollCount >= ApprovalDetector.REQUIRED_EMPTY_POLLS) {
+                if (this.emptyPollGate.recordEmptyPoll()) {
                     // Reset when buttons disappear for consecutive polls
                     const wasDetected = this.lastDetectedKey !== null;
                     this.lastDetectedKey = null;

--- a/src/services/approvalDetector.ts
+++ b/src/services/approvalDetector.ts
@@ -30,20 +30,21 @@ export interface ApprovalDetectorOptions {
  * Detects allow/deny button pairs and extracts descriptions with fallbacks.
  */
 const DETECT_APPROVAL_SCRIPT = `(() => {
-    const ALLOW_ONCE_PATTERNS = ['allow once', 'allow one time', '今回のみ許可', '1回のみ許可', '一度許可'];
+    const ALLOW_ONCE_PATTERNS = ['allow once', 'allow one time', 'yes, allow this time', '今回のみ許可', '1回のみ許可', '一度許可'];
     const ALWAYS_ALLOW_PATTERNS = [
         'allow this conversation',
         'allow this chat',
         'always allow',
+        'yes, and always allow',
         '常に許可',
         'この会話を許可',
     ];
-    const ALLOW_PATTERNS = ['allow', 'permit', '許可', '承認', '確認'];
-    const DENY_PATTERNS = ['deny', '拒否', 'decline'];
+    const ALLOW_PATTERNS = ['allow', 'permit', 'accept', 'approve', '許可', '承認', '確認'];
+    const DENY_PATTERNS = ['deny', 'reject', '拒否', 'decline', 'no (tell the agent'];
 
     const normalize = (text) => (text || '').toLowerCase().replace(/\\s+/g, ' ').trim();
 
-    const allButtons = Array.from(document.querySelectorAll('button'))
+    const allButtons = Array.from(document.querySelectorAll('button, [role="button"], span.cursor-pointer, div.cursor-pointer'))
         .filter(btn => btn.offsetParent !== null);
 
     let approveBtn = allButtons.find(btn => {
@@ -66,7 +67,7 @@ const DETECT_APPROVAL_SCRIPT = `(() => {
         || approveBtn.parentElement
         || document.body;
 
-    const containerButtons = Array.from(container.querySelectorAll('button'))
+    const containerButtons = Array.from(container.querySelectorAll('button, [role="button"], span.cursor-pointer, div.cursor-pointer'))
         .filter(btn => btn.offsetParent !== null);
 
     const denyBtn = containerButtons.find(btn => {
@@ -99,14 +100,48 @@ const DETECT_APPROVAL_SCRIPT = `(() => {
 
     // 2. Parent element text (excluding button text)
     if (!description) {
-        const parent = approveBtn.parentElement?.parentElement || approveBtn.parentElement;
-        if (parent) {
-            const clone = parent.cloneNode(true);
-            const buttons = clone.querySelectorAll('button');
-            buttons.forEach(b => b.remove());
-            const parentText = (clone.textContent || '').trim();
-            if (parentText.length > 5 && parentText.length < 500) {
-                description = parentText;
+        let modal = approveBtn.closest('.notify-user-container, [role="dialog"], .modal, .dialog, .approval-container, .permission-dialog');
+        
+        if (!modal) {
+            // New Antigravity IDE uses a sticky footer with no identifying modal classes.
+            // Traverse up until we find a container that includes the file list popup (.bottom-full)
+            let p = approveBtn.parentElement;
+            while (p && p.tagName !== 'BODY') {
+                if (p.querySelector('.bottom-full')) {
+                    modal = p;
+                    break;
+                }
+                p = p.parentElement;
+            }
+            if (!modal) {
+                modal = approveBtn.parentElement?.parentElement?.parentElement || approveBtn.parentElement?.parentElement;
+            }
+        }
+
+        if (modal) {
+            const parts = [];
+            const walk = (node) => {
+                if (node.nodeType === 1) {
+                    // Skip buttons entirely
+                    if (node.tagName === 'BUTTON' || node.getAttribute('role') === 'button' || node.classList.contains('cursor-pointer')) return;
+                    
+                    const display = window.getComputedStyle(node).display;
+                    if (display === 'none') return;
+                    
+                    const isBlock = display === 'block' || display === 'flex' || node.tagName === 'DIV' || node.tagName === 'LI';
+                    if (isBlock && parts.length > 0 && parts[parts.length - 1] !== '\\n') parts.push('\\n');
+                    for (const child of node.childNodes) walk(child);
+                    if (isBlock && parts.length > 0 && parts[parts.length - 1] !== '\\n') parts.push('\\n');
+                } else if (node.nodeType === 3) {
+                    const t = node.textContent || '';
+                    if (t.trim()) parts.push(t.trim());
+                }
+            };
+            walk(modal);
+            
+            const parentText = parts.join(' ').replace(/\\n\\s*/g, '\\n').replace(/\\n{3,}/g, '\\n\\n').trim();
+            if (parentText.length > 5) {
+                description = parentText.length > 2000 ? parentText.substring(0, 2000) + '...\\n(truncated)' : parentText;
             }
         }
     }
@@ -124,11 +159,12 @@ const DETECT_APPROVAL_SCRIPT = `(() => {
  * Press the toggle on the right side of Allow Once to expand the Always Allow dropdown.
  */
 const EXPAND_ALWAYS_ALLOW_MENU_SCRIPT = `(() => {
-    const ALLOW_ONCE_PATTERNS = ['allow once', 'allow one time', '今回のみ許可', '1回のみ許可', '一度許可'];
+    const ALLOW_ONCE_PATTERNS = ['allow once', 'allow one time', 'yes, allow this time', '今回のみ許可', '1回のみ許可', '一度許可'];
     const ALWAYS_ALLOW_PATTERNS = [
         'allow this conversation',
         'allow this chat',
         'always allow',
+        'yes, and always allow',
         '常に許可',
         'この会話を許可',
     ];
@@ -204,15 +240,16 @@ export function buildClickScript(buttonText: string): string {
         const normalize = (text) => (text || '').toLowerCase().replace(/\\s+/g, ' ').trim();
         const text = ${safeText};
         const wanted = normalize(text);
-        const allButtons = Array.from(document.querySelectorAll('button'));
+        const allButtons = Array.from(document.querySelectorAll('button, [role="button"], a, span, div')).reverse();
         const target = allButtons.find(btn => {
-            if (!btn.offsetParent) return false;
+            const style = window.getComputedStyle(btn);
+            if (style.display === 'none' || style.visibility === 'hidden' || btn.disabled) return false;
             const buttonText = normalize(btn.textContent || '');
             const ariaLabel = normalize(btn.getAttribute('aria-label') || '');
             return buttonText === wanted ||
                 ariaLabel === wanted ||
-                buttonText.includes(wanted) ||
-                ariaLabel.includes(wanted);
+                (buttonText.includes(wanted) && buttonText.length < wanted.length + 10) ||
+                (ariaLabel.includes(wanted) && ariaLabel.length < wanted.length + 10);
         });
         if (!target) return { ok: false, error: 'Button not found: ' + text };
         const rect = target.getBoundingClientRect();
@@ -222,6 +259,7 @@ export function buildClickScript(buttonText: string): string {
         for (const type of ['pointerdown', 'mousedown', 'pointerup', 'mouseup', 'click']) {
             target.dispatchEvent(new PointerEvent(type, { ...eventInit, pointerId: 1 }));
         }
+        if (typeof target.click === 'function') target.click();
         return { ok: true };
     })()`;
 }
@@ -244,6 +282,10 @@ export class ApprovalDetector {
     private lastDetectedKey: string | null = null;
     /** Full ApprovalInfo from the last detection (used for clicking) */
     private lastDetectedInfo: ApprovalInfo | null = null;
+    /** Number of consecutive polls without detecting buttons */
+    private emptyPollCount: number = 0;
+    /** Number of consecutive empty polls required before resetting state */
+    private static readonly REQUIRED_EMPTY_POLLS = 3;
 
     constructor(options: ApprovalDetectorOptions) {
         this.cdpService = options.cdpService;
@@ -260,6 +302,7 @@ export class ApprovalDetector {
         this.isRunning = true;
         this.lastDetectedKey = null;
         this.lastDetectedInfo = null;
+        this.emptyPollCount = 0;
         this.schedulePoll();
     }
 
@@ -315,6 +358,7 @@ export class ApprovalDetector {
             const info: ApprovalInfo | null = result?.result?.value ?? null;
 
             if (info) {
+                this.emptyPollCount = 0;
                 // Duplicate prevention: use approveText + description combination as key
                 const key = `${info.approveText}::${info.description}`;
                 if (key !== this.lastDetectedKey) {
@@ -323,12 +367,15 @@ export class ApprovalDetector {
                     this.onApprovalRequired(info);
                 }
             } else {
-                // Reset when buttons disappear (prepare for next approval detection)
-                const wasDetected = this.lastDetectedKey !== null;
-                this.lastDetectedKey = null;
-                this.lastDetectedInfo = null;
-                if (wasDetected && this.onResolved) {
-                    this.onResolved();
+                this.emptyPollCount++;
+                if (this.emptyPollCount >= ApprovalDetector.REQUIRED_EMPTY_POLLS) {
+                    // Reset when buttons disappear for consecutive polls
+                    const wasDetected = this.lastDetectedKey !== null;
+                    this.lastDetectedKey = null;
+                    this.lastDetectedInfo = null;
+                    if (wasDetected && this.onResolved) {
+                        this.onResolved();
+                    }
                 }
             }
         } catch (error) {

--- a/src/services/artifactService.ts
+++ b/src/services/artifactService.ts
@@ -329,14 +329,17 @@ export class ArtifactService {
     }
 
     /**
-     * Read the markdown content of a specific artifact file.
-     * Returns null if the file cannot be read.
+     * Build the filesystem path for a specific artifact file.
      */
     getArtifactPath(conversationId: string, filename: string): string {
         const safe = path.basename(filename);
         return path.join(this.brainBasePath, conversationId, safe);
     }
 
+    /**
+     * Read the markdown content of a specific artifact file.
+     * Returns null if the file cannot be read.
+     */
     getArtifactContent(conversationId: string, filename: string): string | null {
         // Sanitize: prevent path traversal
         const safe = path.basename(filename);

--- a/src/services/artifactService.ts
+++ b/src/services/artifactService.ts
@@ -167,11 +167,12 @@ export class ArtifactService {
     }
 
     /**
-     * Try to find a conversation UUID whose overview.txt contains the given session title.
+     * Try to find a conversation UUID whose transcript or overview contains the given session title.
      * Uses an exact match first, falling back to keyword overlap scoring.
+     * If workspaceFilter is provided, restricts matching exclusively to conversations belonging to that workspace.
      * Returns the UUID or null if not found.
      */
-    findConversationByTitle(title: string): string | null {
+    findConversationByTitle(title: string, workspaceFilter?: string): string | null {
         if (!title || !title.trim()) return null;
         const needle = title.trim().toLowerCase();
         const ids = this.listConversationIds();
@@ -207,45 +208,86 @@ export class ArtifactService {
         
         // Require a stronger minimum score of 2 to prevent weak one-word matches.
         const minScore = 2;
+        const filterStr = workspaceFilter ? workspaceFilter.toLowerCase() : null;
 
         for (const id of sortedIds) {
-            const overviewPath = path.join(
-                this.brainBasePath,
-                id,
-                '.system_generated',
-                'logs',
-                'overview.txt',
-            );
-            try {
-                if (!fs.existsSync(overviewPath)) continue;
-                // Only read the first 4KB to avoid huge files
-                let fd: number | null = null;
-                try {
-                    fd = fs.openSync(overviewPath, 'r');
-                    const buf = Buffer.alloc(4096);
-                    const bytesRead = fs.readSync(fd, buf, 0, buf.length, 0);
-                    const header = buf.slice(0, bytesRead).toString('utf-8').toLowerCase();
-                    
-                    if (header.includes(needle)) {
-                        return id; // Exact match takes precedence
-                    }
+            let score = 0;
+            let exactMatch = false;
+            let belongsToWorkspace = !filterStr; // True if no filter, or if we prove it belongs
 
-                    // Use same Unicode-aware split for header tokens
-                    const headerTokens = new Set(header.replace(/[^\p{L}\p{N}]+/gu, ' ').split(/\s+/));
-                    
-                    let score = 0;
-                    for (const word of uniqueNeedleWords) {
-                        if (headerTokens.has(word)) score++;
+            // 1. Check transcript.jsonl (modern)
+            const transcriptPath = path.join(this.brainBasePath, id, '.system_generated', 'logs', 'transcript.jsonl');
+            try {
+                if (fs.existsSync(transcriptPath)) {
+                    let fd = null;
+                    try {
+                        fd = fs.openSync(transcriptPath, 'r');
+                        const buf = Buffer.alloc(16384);
+                        const bytesRead = fs.readSync(fd, buf, 0, buf.length, 0);
+                        const content = buf.slice(0, bytesRead).toString('utf-8').toLowerCase();
+                        
+                        if (filterStr && content.includes(filterStr)) {
+                            belongsToWorkspace = true;
+                        }
+                        
+                        if (belongsToWorkspace) {
+                            if (content.includes(needle)) {
+                                exactMatch = true;
+                            } else {
+                                const contentTokens = new Set(content.replace(/[^\p{L}\p{N}]+/gu, ' ').split(/\s+/));
+                                let currentScore = 0;
+                                for (const word of uniqueNeedleWords) {
+                                    if (contentTokens.has(word)) currentScore++;
+                                }
+                                if (currentScore > score) score = currentScore;
+                            }
+                        }
+                    } finally {
+                        if (fd !== null) fs.closeSync(fd);
                     }
-                    if (score > bestScore) {
-                        bestScore = score;
-                        bestId = id;
-                    }
-                } finally {
-                    if (fd !== null) fs.closeSync(fd);
                 }
-            } catch {
-                // Skip unreadable files
+            } catch { /* ignore */ }
+
+            // 2. Check overview.txt (legacy)
+            const overviewPath = path.join(this.brainBasePath, id, '.system_generated', 'logs', 'overview.txt');
+            try {
+                if (fs.existsSync(overviewPath)) {
+                    let fd = null;
+                    try {
+                        fd = fs.openSync(overviewPath, 'r');
+                        const buf = Buffer.alloc(4096);
+                        const bytesRead = fs.readSync(fd, buf, 0, buf.length, 0);
+                        const header = buf.slice(0, bytesRead).toString('utf-8').toLowerCase();
+                        
+                        if (filterStr && header.includes(filterStr)) {
+                            belongsToWorkspace = true;
+                        }
+                        
+                        if (belongsToWorkspace) {
+                            if (header.includes(needle)) {
+                                exactMatch = true;
+                            } else {
+                                const headerTokens = new Set(header.replace(/[^\p{L}\p{N}]+/gu, ' ').split(/\s+/));
+                                let currentScore = 0;
+                                for (const word of uniqueNeedleWords) {
+                                    if (headerTokens.has(word)) currentScore++;
+                                }
+                                if (currentScore > score) score = currentScore;
+                            }
+                        }
+                    } finally {
+                        if (fd !== null) fs.closeSync(fd);
+                    }
+                }
+            } catch { /* ignore */ }
+
+            if (!belongsToWorkspace) continue;
+            
+            if (exactMatch) return id; // Exact match in the right workspace takes precedence immediately
+
+            if (score > bestScore) {
+                bestScore = score;
+                bestId = id;
             }
         }
 
@@ -290,6 +332,11 @@ export class ArtifactService {
      * Read the markdown content of a specific artifact file.
      * Returns null if the file cannot be read.
      */
+    getArtifactPath(conversationId: string, filename: string): string {
+        const safe = path.basename(filename);
+        return path.join(this.brainBasePath, conversationId, safe);
+    }
+
     getArtifactContent(conversationId: string, filename: string): string | null {
         // Sanitize: prevent path traversal
         const safe = path.basename(filename);

--- a/src/services/assistantDomExtractor.ts
+++ b/src/services/assistantDomExtractor.ts
@@ -19,7 +19,7 @@ import { htmlToDiscordMarkdown } from '../utils/htmlToDiscordMarkdown';
  */
 export interface AssistantDomSegment {
     /** The type of content: assistant text, thinking trace, tool interaction, etc. */
-    kind: 'assistant-body' | 'thinking' | 'tool-call' | 'tool-result' | 'feedback';
+    kind: 'assistant-body' | 'thinking' | 'tool-call' | 'tool-result' | 'feedback' | 'plan-card' | 'action-button' | 'file-change' | 'citation' | 'file-changes';
     /** The content (often HTML for body, plain text for logs) */
     text: string;
     /** The role is always 'assistant' for these segments */
@@ -46,6 +46,12 @@ export interface ClassifyResult {
     finalOutputText: string;
     activityLines: string[];
     feedback: string[];
+    planCards: string[];
+    actionButtons: string[];
+    fileChanges: { path: string; type: string }[];
+    citations: string[];
+    fileChangesTexts: string[];
+    citedFiles: string[];
     diagnostics: {
         source: 'dom-structured' | 'legacy-fallback';
         segmentCounts: Record<string, number>;
@@ -71,6 +77,12 @@ export function classifyAssistantSegments(payload: unknown): ClassifyResult {
             finalOutputText: '',
             activityLines: [],
             feedback: [],
+            planCards: [],
+            actionButtons: [],
+            fileChanges: [],
+            citations: [],
+            fileChangesTexts: [],
+            citedFiles: [],
             diagnostics: {
                 source: 'legacy-fallback',
                 segmentCounts: {},
@@ -87,9 +99,14 @@ export function classifyAssistantSegments(payload: unknown): ClassifyResult {
     const bodyTexts: string[] = [];
     const activityLines: string[] = [];
     const feedbackTexts: string[] = [];
+    const planCards: string[] = [];
+    const actionButtons: string[] = [];
+    const fileChanges: { path: string; type: string }[] = [];
+    const citations: string[] = [];
     const segmentCounts: Record<string, number> = {};
     const allFingerprints: string[] = [];
 
+    const fileChangesTexts: string[] = [];
     for (const seg of segments) {
         segmentCounts[seg.kind] = (segmentCounts[seg.kind] ?? 0) + 1;
 
@@ -113,6 +130,32 @@ export function classifyAssistantSegments(payload: unknown): ClassifyResult {
                     feedbackTexts.push(seg.text.trim());
                 }
                 break;
+            case 'plan-card':
+                if (seg.text && seg.text.trim()) {
+                    planCards.push(seg.text.trim());
+                }
+                break;
+            case 'action-button':
+                if (seg.text && seg.text.trim()) {
+                    actionButtons.push(seg.text.trim());
+                }
+                break;
+            case 'file-change':
+                if (seg.text && seg.text.trim()) {
+                    const parts = seg.text.split('|');
+                    fileChanges.push({ path: parts[0]?.trim() || '', type: parts[1]?.trim() || '' });
+                }
+                break;
+            case 'citation':
+                if (seg.text && seg.text.trim()) {
+                    citations.push(seg.text.trim());
+                }
+                break;
+            case 'file-changes':
+                if (seg.text && seg.text.trim()) {
+                    fileChangesTexts.push(seg.text.trim());
+                }
+                break;
         }
     }
 
@@ -121,10 +164,38 @@ export function classifyAssistantSegments(payload: unknown): ClassifyResult {
     const lastBody = bodyTexts.join('\n\n') || '';
     const finalOutputText = htmlToDiscordMarkdown(lastBody);
 
+    // Extract file:/// links from finalOutputText
+    const citedFiles: string[] = [];
+    const fileRegex = /\[.*?\]\((file:\/\/\/[^\)]+)\)/g;
+    let match;
+    while ((match = fileRegex.exec(finalOutputText)) !== null) {
+        const fileUrl = match[1];
+        if (!citedFiles.includes(fileUrl)) {
+            citedFiles.push(fileUrl);
+        }
+    }
+
+    // Also extract backticked inline code that looks like a filename with common extensions
+    // e.g., `implementation_plan.md`
+    const inlineCodeRegex = /`([a-zA-Z0-9_\-\.]+\.(?:md|ts|js|json|html|css|txt|csv|py|java|go|cpp|c))`[^`]?/g;
+    let inlineMatch;
+    while ((inlineMatch = inlineCodeRegex.exec(finalOutputText)) !== null) {
+        const filename = inlineMatch[1];
+        if (!citedFiles.includes(filename)) {
+            citedFiles.push(filename);
+        }
+    }
+
     return {
         finalOutputText,
         activityLines,
         feedback: feedbackTexts,
+        planCards,
+        actionButtons,
+        fileChanges,
+        citations,
+        fileChangesTexts,
+        citedFiles,
         diagnostics: {
             source: 'dom-structured',
             segmentCounts,
@@ -197,10 +268,11 @@ export function extractAssistantSegmentsPayloadScript(): string {
         if (node.closest('details')) return true;
         if (node.closest('[class*="feedback"], footer')) return true;
         if (node.closest('.notify-user-container')) return true;
-        if (node.closest('[role="dialog"]')) return true;
-        if (node.closest('form')) return true;
+        // removed form and dialog exclusions to allow interactive tool forms (ask_question, ask_permission)
         if (node.closest('[data-message-author-role="user"], [data-message-role="user"]')) return true;
-        if (node.querySelector('textarea') || node.closest('textarea')) return true;
+        // We do not exclude nodes just because they contain a textarea (e.g. ask_question "Other" option).
+        // The main chat input is excluded by the "ask anything" check below.
+        if (node.tagName && node.tagName.toLowerCase() === 'textarea') return true;
         var text = (node.innerText || '').toLowerCase();
         if (text.includes('ask anything, @ to mention')) return true;
         if (text.includes('0 files with changes')) return true;
@@ -413,6 +485,86 @@ export function extractAssistantSegmentsPayloadScript(): string {
             });
         }
     }
+
+    // Pass 4: Extract Antigravity 2.0 structured cards and artifacts
+    // 4a. Plan Cards
+    var planNodes = scope.querySelectorAll('[data-testid="plan-card"], [class*="plan-summary"]');
+    for (var pi2 = 0; pi2 < planNodes.length; pi2++) {
+        var pnode = planNodes[pi2];
+        var ptext = (pnode.innerText || pnode.textContent || '').trim();
+        if (ptext) {
+            segments.push({
+                kind: 'plan-card',
+                text: ptext,
+                role: 'assistant',
+                messageIndex: 0,
+                domPath: 'plan-card:nth(' + pi2 + ')'
+            });
+        }
+    }
+
+    // 4b. Action Buttons (Open, Proceed, Review, etc.) - outside feedback footers
+    var actionBtns = scope.querySelectorAll('.actions-container button, [class*="action-btn"], .review-button, [class*="review-btn"]');
+    for (var abi = 0; abi < actionBtns.length; abi++) {
+        var abtnText = (actionBtns[abi].textContent || '').trim();
+        if (!abtnText) continue;
+        var lower = abtnText.toLowerCase();
+        // Ignore approval buttons since they are handled by approvalDetector
+        if (lower.includes('accept all') || lower.includes('reject all')) continue;
+
+        segments.push({
+            kind: 'action-button',
+            text: abtnText,
+            role: 'assistant',
+            messageIndex: 0,
+            domPath: 'action-btn.' + abtnText.toLowerCase().replace(/\s+/g, '-')
+        });
+    }
+
+    // 4c. File Edits
+    var fileEdits = scope.querySelectorAll('[class*="file-edit-item"], .file-edit-item, .bottom-full .cursor-pointer');
+    for (var fei = 0; fei < fileEdits.length; fei++) {
+        var editNode = fileEdits[fei];
+        if (seen.has(editNode)) continue;
+        seen.add(editNode);
+        var fpath = (editNode.querySelector('.file-path, [class*="path"]') || {}).textContent || '';
+        var ftype = (editNode.querySelector('.edit-type, [class*="type"]') || {}).textContent || 'Modified';
+        
+        if (!fpath) {
+            var spans = editNode.querySelectorAll('span.whitespace-nowrap.text-sm');
+            if (spans.length > 0) {
+                fpath = spans[0].textContent || '';
+            }
+        }
+        if (!fpath) fpath = (editNode.textContent || '').trim();
+        if (fpath) {
+            segments.push({
+                kind: 'file-change',
+                text: fpath.trim() + '|' + ftype.trim(),
+                role: 'assistant',
+                messageIndex: 0,
+                domPath: 'file-edit:nth(' + fei + ')'
+            });
+        }
+    }
+
+    // 4d. Citations
+    var citationNodes = scope.querySelectorAll('[class*="citation"], a[href^="file://"]');
+    for (var cti = 0; cti < citationNodes.length; cti++) {
+        var cnode = citationNodes[cti];
+        var ctext = (cnode.getAttribute('href') || cnode.textContent || '').trim();
+        if (ctext) {
+            segments.push({
+                kind: 'citation',
+                text: ctext,
+                role: 'assistant',
+                messageIndex: 0,
+                domPath: 'citation:nth(' + cti + ')'
+            });
+        }
+    }
+
+
 
     if (!bodyFound && segments.length === 0) return null;
 

--- a/src/services/assistantDomExtractor.ts
+++ b/src/services/assistantDomExtractor.ts
@@ -536,7 +536,12 @@ export function extractAssistantSegmentsPayloadScript(): string {
                 fpath = spans[0].textContent || '';
             }
         }
-        if (!fpath) fpath = (editNode.textContent || '').trim();
+        if (!fpath) {
+            fpath = (editNode.textContent || '').trim();
+            if (fpath.endsWith(ftype)) {
+                fpath = fpath.slice(0, -ftype.length).trim();
+            }
+        }
         if (fpath) {
             segments.push({
                 kind: 'file-change',
@@ -563,8 +568,21 @@ export function extractAssistantSegmentsPayloadScript(): string {
             });
         }
     }
-
-
+    // 4e. File Changes Text Blocks
+    var fcbNodes = scope.querySelectorAll('.file-changes-block code, [class*="file-changes"] code');
+    for (var fci = 0; fci < fcbNodes.length; fci++) {
+        var fcNode = fcbNodes[fci];
+        var fcText = (fcNode.textContent || '').trim();
+        if (fcText) {
+            segments.push({
+                kind: 'file-changes',
+                text: fcText,
+                role: 'assistant',
+                messageIndex: 0,
+                domPath: 'file-changes:nth(' + fci + ')'
+            });
+        }
+    }
 
     if (!bodyFound && segments.length === 0) return null;
 

--- a/src/services/cdpBridgeManager.ts
+++ b/src/services/cdpBridgeManager.ts
@@ -796,6 +796,7 @@ export function ensureQuestionDetector(
         },
     });
 
+    detector.setProjectName(projectName);
     detector.start();
     bridge.pool.registerQuestionDetector(projectName, detector, accountName);
     logger.debug(`[QuestionDetector:${projectName}] Started question detection`);

--- a/src/services/cdpBridgeManager.ts
+++ b/src/services/cdpBridgeManager.ts
@@ -8,6 +8,7 @@ import {
     buildErrorPopupNotification,
     buildRunCommandNotification,
     buildResolvedOverlay,
+    buildQuestionNotification,
 } from './notificationSender';
 import { ApprovalDetector, ApprovalInfo } from './approvalDetector';
 import { AutoAcceptService } from './autoAcceptService';
@@ -18,6 +19,7 @@ import { PlanningDetector, PlanningInfo } from './planningDetector';
 import { RunCommandDetector, RunCommandInfo } from './runCommandDetector';
 import { QuotaService } from './quotaService';
 import { UserMessageDetector, UserMessageInfo } from './userMessageDetector';
+import { QuestionDetector, QuestionInfo } from './questionDetector';
 
 /** CDP connection state management */
 export interface CdpBridge {
@@ -42,11 +44,15 @@ const ALWAYS_ALLOW_ACTION_PREFIX = 'always_allow_action';
 const DENY_ACTION_PREFIX = 'deny_action';
 const PLANNING_OPEN_ACTION_PREFIX = 'planning_open_action';
 const PLANNING_PROCEED_ACTION_PREFIX = 'planning_proceed_action';
+const PLANNING_REJECT_ACTION_PREFIX = 'planning_reject_action';
 const ERROR_POPUP_DISMISS_ACTION_PREFIX = 'error_popup_dismiss_action';
 const ERROR_POPUP_COPY_DEBUG_ACTION_PREFIX = 'error_popup_copy_debug_action';
 const ERROR_POPUP_RETRY_ACTION_PREFIX = 'error_popup_retry_action';
 const RUN_COMMAND_RUN_ACTION_PREFIX = 'run_command_run_action';
 const RUN_COMMAND_REJECT_ACTION_PREFIX = 'run_command_reject_action';
+export const QUESTION_SELECT_ACTION_PREFIX = 'question_select_action';
+export const FILE_CHANGE_ACCEPT_ACTION_PREFIX = 'ide_file_accept_all';
+export const FILE_CHANGE_REJECT_ACTION_PREFIX = 'ide_file_reject_all';
 
 function normalizeSessionTitle(title: string): string {
     return title.trim().toLowerCase();
@@ -166,25 +172,30 @@ export function parseApprovalCustomId(customId: string): { action: 'approve' | '
 }
 
 export function buildPlanningCustomId(
-    action: 'open' | 'proceed',
+    action: 'open' | 'proceed' | 'reject',
     projectName: string,
     channelId?: string,
 ): string {
     const prefix = action === 'open'
         ? PLANNING_OPEN_ACTION_PREFIX
-        : PLANNING_PROCEED_ACTION_PREFIX;
+        : action === 'proceed'
+            ? PLANNING_PROCEED_ACTION_PREFIX
+            : PLANNING_REJECT_ACTION_PREFIX;
     if (channelId && channelId.trim().length > 0) {
         return `${prefix}:${projectName}:${channelId}`;
     }
     return `${prefix}:${projectName}`;
 }
 
-export function parsePlanningCustomId(customId: string): { action: 'open' | 'proceed'; projectName: string | null; channelId: string | null } | null {
+export function parsePlanningCustomId(customId: string): { action: 'open' | 'proceed' | 'reject'; projectName: string | null; channelId: string | null } | null {
     if (customId === PLANNING_OPEN_ACTION_PREFIX) {
         return { action: 'open', projectName: null, channelId: null };
     }
     if (customId === PLANNING_PROCEED_ACTION_PREFIX) {
         return { action: 'proceed', projectName: null, channelId: null };
+    }
+    if (customId === PLANNING_REJECT_ACTION_PREFIX) {
+        return { action: 'reject', projectName: null, channelId: null };
     }
     if (customId.startsWith(`${PLANNING_OPEN_ACTION_PREFIX}:`)) {
         const rest = customId.substring(`${PLANNING_OPEN_ACTION_PREFIX}:`.length);
@@ -195,6 +206,11 @@ export function parsePlanningCustomId(customId: string): { action: 'open' | 'pro
         const rest = customId.substring(`${PLANNING_PROCEED_ACTION_PREFIX}:`.length);
         const [projectName, channelId] = rest.split(':');
         return { action: 'proceed', projectName: projectName || null, channelId: channelId || null };
+    }
+    if (customId.startsWith(`${PLANNING_REJECT_ACTION_PREFIX}:`)) {
+        const rest = customId.substring(`${PLANNING_REJECT_ACTION_PREFIX}:`.length);
+        const [projectName, channelId] = rest.split(':');
+        return { action: 'reject', projectName: projectName || null, channelId: channelId || null };
     }
     return null;
 }
@@ -271,6 +287,40 @@ export function parseRunCommandCustomId(customId: string): { action: 'run' | 're
     }
     if (customId.startsWith(`${RUN_COMMAND_REJECT_ACTION_PREFIX}:`)) {
         const rest = customId.substring(`${RUN_COMMAND_REJECT_ACTION_PREFIX}:`.length);
+        const [projectName, channelId] = rest.split(':');
+        return { action: 'reject', projectName: projectName || null, channelId: channelId || null };
+    }
+    return null;
+}
+
+export function buildFileChangeCustomId(
+    action: 'accept' | 'reject',
+    projectName: string,
+    channelId?: string,
+): string {
+    const prefix = action === 'accept'
+        ? FILE_CHANGE_ACCEPT_ACTION_PREFIX
+        : FILE_CHANGE_REJECT_ACTION_PREFIX;
+    if (channelId && channelId.trim().length > 0) {
+        return `${prefix}:${projectName}:${channelId}`;
+    }
+    return `${prefix}:${projectName}`;
+}
+
+export function parseFileChangeCustomId(customId: string): { action: 'accept' | 'reject'; projectName: string | null; channelId: string | null } | null {
+    if (customId === FILE_CHANGE_ACCEPT_ACTION_PREFIX) {
+        return { action: 'accept', projectName: null, channelId: null };
+    }
+    if (customId === FILE_CHANGE_REJECT_ACTION_PREFIX) {
+        return { action: 'reject', projectName: null, channelId: null };
+    }
+    if (customId.startsWith(`${FILE_CHANGE_ACCEPT_ACTION_PREFIX}:`)) {
+        const rest = customId.substring(`${FILE_CHANGE_ACCEPT_ACTION_PREFIX}:`.length);
+        const [projectName, channelId] = rest.split(':');
+        return { action: 'accept', projectName: projectName || null, channelId: channelId || null };
+    }
+    if (customId.startsWith(`${FILE_CHANGE_REJECT_ACTION_PREFIX}:`)) {
+        const rest = customId.substring(`${FILE_CHANGE_REJECT_ACTION_PREFIX}:`.length);
         const [projectName, channelId] = rest.split(':');
         return { action: 'reject', projectName: projectName || null, channelId: channelId || null };
     }
@@ -381,17 +431,31 @@ export function ensureApprovalDetector(
                 }
             }
 
+            const extraFields = [
+                { name: t('Allow button'), value: info.approveText || t('(None)'), inline: true },
+            ];
+            
+            if (info.alwaysAllowText) {
+                extraFields.push({ name: t('Allow Chat button'), value: info.alwaysAllowText, inline: true });
+            }
+            
+            extraFields.push({ name: t('Deny button'), value: info.denyText || t('(None)'), inline: true });
+
             const payload = buildApprovalNotification({
                 title: t('Approval Required'),
                 description: info.description || t('Antigravity is requesting approval for an action'),
                 projectName,
                 channelId: targetChannelId,
-                extraFields: [
-                    { name: t('Allow button'), value: info.approveText, inline: true },
-                    { name: t('Allow Chat button'), value: info.alwaysAllowText || t('In Dropdown'), inline: true },
-                    { name: t('Deny button'), value: info.denyText || t('(None)'), inline: true },
-                ],
+                extraFields,
+                hasAlwaysAllow: !!info.alwaysAllowText,
+                alwaysAllowText: info.alwaysAllowText,
             });
+
+            if (lastNotification) {
+                lastNotification.payload = payload;
+                lastNotification.sent.edit(payload).catch(logger.error);
+                return;
+            }
 
             const sent = await targetChannel.send(payload).catch((err: any) => {
                 logger.error(err);
@@ -466,7 +530,16 @@ export function ensurePlanningDetector(
                 projectName,
                 channelId: targetChannelId,
                 extraFields,
+                hasOpenButton: info.hasOpenButton,
+                openText: info.openText,
+                proceedText: info.proceedText,
             });
+
+            if (lastNotification) {
+                lastNotification.payload = payload;
+                lastNotification.sent.edit(payload).catch(logger.error);
+                return;
+            }
 
             const sent = await targetChannel.send(payload).catch((err: any) => {
                 logger.error(err);
@@ -671,7 +744,59 @@ export function ensureUserMessageDetector(
     
     (detector as any).__userMsgHandler = onUserMessage;
     detector.on('message', onUserMessage);
+
     detector.start();
     bridge.pool.registerUserMessageDetector(projectName, detector, accountName);
     logger.debug(`[UserMessageDetector:${projectName}] Started user message detection`);
+}
+
+export function ensureQuestionDetector(
+    bridge: CdpBridge,
+    cdp: CdpService,
+    projectName: string,
+    accountName: string = 'default',
+): void {
+    const existing = bridge.pool.getQuestionDetector(projectName, accountName);
+    if (existing && existing.isActive) return;
+
+    let lastNotification: { sent: PlatformSentMessage; payload: MessagePayload } | null = null;
+
+    const detector = new QuestionDetector({
+        cdpService: cdp,
+        pollIntervalMs: 2000,
+        onResolved: () => {
+            if (!lastNotification) return;
+            const { sent, payload } = lastNotification;
+            lastNotification = null;
+            const resolved = buildResolvedOverlay(payload, t('Question answered'));
+            sent.edit(resolved).catch(logger.error);
+        },
+        onQuestionRequired: async (info: QuestionInfo) => {
+            const currentChatTitle = await getCurrentChatTitle(cdp);
+            const targetChannel = resolveApprovalChannelForCurrentChat(bridge, projectName, currentChatTitle);
+            const targetChannelId = targetChannel ? targetChannel.id : '';
+
+            if (!targetChannel || !targetChannelId) return;
+
+            const payload = buildQuestionNotification({
+                title: info.title,
+                description: info.description,
+                projectName,
+                channelId: targetChannelId,
+                options: info.options,
+            });
+
+            const sent = await targetChannel.send(payload).catch((err: any) => {
+                logger.error(err);
+                return null;
+            });
+            if (sent) {
+                lastNotification = { sent, payload };
+            }
+        },
+    });
+
+    detector.start();
+    bridge.pool.registerQuestionDetector(projectName, detector, accountName);
+    logger.debug(`[QuestionDetector:${projectName}] Started question detection`);
 }

--- a/src/services/cdpConnectionPool.ts
+++ b/src/services/cdpConnectionPool.ts
@@ -6,6 +6,7 @@ import { ErrorPopupDetector } from './errorPopupDetector';
 import { PlanningDetector } from './planningDetector';
 import { RunCommandDetector } from './runCommandDetector';
 import { UserMessageDetector } from './userMessageDetector';
+import { QuestionDetector } from './questionDetector';
 
 export interface AccountSelection {
     name?: string;
@@ -26,6 +27,7 @@ export class CdpConnectionPool {
     private readonly planningDetectors = new Map<string, PlanningDetector>();
     private readonly runCommandDetectors = new Map<string, RunCommandDetector>();
     private readonly userMessageDetectors = new Map<string, UserMessageDetector>();
+    private readonly questionDetectors = new Map<string, QuestionDetector>();
     private readonly connectingPromises = new Map<string, Promise<CdpService>>();
     private readonly cdpOptions: CdpServiceOptions;
 
@@ -97,6 +99,9 @@ export class CdpConnectionPool {
         this.errorPopupDetectors.get(key)?.stop();
         this.errorPopupDetectors.delete(key);
 
+        this.questionDetectors.get(key)?.stop();
+        this.questionDetectors.delete(key);
+
         this.planningDetectors.get(key)?.stop();
         this.planningDetectors.delete(key);
 
@@ -143,6 +148,18 @@ export class CdpConnectionPool {
         const key = buildConnectionKey(projectName, effectiveAccount);
         this.planningDetectors.get(key)?.stop();
         this.planningDetectors.set(key, detector);
+    }
+
+    getQuestionDetector(projectName: string, accountName: string = 'default'): QuestionDetector | undefined {
+        const effectiveAccount = this.resolveAccountName(projectName, accountName);
+        return this.questionDetectors.get(buildConnectionKey(projectName, effectiveAccount));
+    }
+
+    registerQuestionDetector(projectName: string, detector: QuestionDetector, accountName: string = 'default'): void {
+        const effectiveAccount = this.resolveAccountName(projectName, accountName);
+        const key = buildConnectionKey(projectName, effectiveAccount);
+        this.questionDetectors.get(key)?.stop();
+        this.questionDetectors.set(key, detector);
     }
 
     getPlanningDetector(projectName: string, accountName: string = 'default'): PlanningDetector | undefined {
@@ -224,6 +241,8 @@ export class CdpConnectionPool {
             this.errorPopupDetectors.delete(key);
             this.planningDetectors.get(key)?.stop();
             this.planningDetectors.delete(key);
+            this.questionDetectors.get(key)?.stop();
+            this.questionDetectors.delete(key);
             this.runCommandDetectors.get(key)?.stop();
             this.runCommandDetectors.delete(key);
             this.userMessageDetectors.get(key)?.stop();

--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -747,7 +747,8 @@ export class CdpService extends EventEmitter {
 
             // If we only have the project name to go on, make sure it's a discrete boundary in the URL path
             // e.g. "folder=.../test" or "workspace=.../test". We prevent false positives like "latest" matching "test".
-            const projectBoundaryRegex = new RegExp(`[=/]${projectName.toLowerCase()}(?:$|&|\\?)`);
+            const safeProjectName = projectName.toLowerCase().replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const projectBoundaryRegex = new RegExp(`[=/]${safeProjectName}(?:$|&|\\?)`);
             if (projectBoundaryRegex.test(pageUrl)) {
                 this.currentWorkspaceName = projectName;
                 logger.debug(`[CdpService] URL parameter match success: "${projectName}" (boundary regex)`);

--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -451,6 +451,10 @@ export class CdpService extends EventEmitter {
         return this.currentWorkspaceName;
     }
 
+    getCurrentWorkspacePath(): string | null {
+        return this.currentWorkspacePath;
+    }
+
     /**
      * Discover and connect to the workbench page for the specified workspace.
      * Does nothing if already connected to the correct page.
@@ -712,11 +716,14 @@ export class CdpService extends EventEmitter {
 
                 const normalizedDetected = detectedValue.toLowerCase();
                 const normalizedProject = projectName.toLowerCase();
-                const normalizedWorkspace = workspacePath.toLowerCase();
+                const normalizedWorkspace = workspacePath.toLowerCase().replace(/\\/g, '/');
+                
+                const detectedParts = normalizedDetected.split(',').map((s) => s.trim());
 
                 if (
-                    normalizedDetected.includes(normalizedProject) ||
-                    normalizedDetected.includes(normalizedWorkspace)
+                    detectedParts.includes(normalizedProject) ||
+                    normalizedDetected.includes(normalizedWorkspace) ||
+                    normalizedDetected.replace(/\\/g, '/').includes(normalizedWorkspace)
                 ) {
                     this.currentWorkspaceName = projectName;
                     logger.debug(`[CdpService] Folder path match success: "${projectName}"`);
@@ -729,11 +736,21 @@ export class CdpService extends EventEmitter {
                 expression: 'window.location.href',
                 returnByValue: true,
             });
-            const pageUrl = (urlResult?.result?.value || '').toLowerCase();
-            const normalizedWorkspaceUri = encodeURIComponent(workspacePath).toLowerCase();
-            if (pageUrl.includes(normalizedWorkspaceUri) || pageUrl.includes(projectName.toLowerCase())) {
+            const pageUrl = decodeURIComponent(urlResult?.result?.value || '').toLowerCase().replace(/\\/g, '/');
+            const normalizedWorkspaceUri = workspacePath.toLowerCase().replace(/\\/g, '/');
+            
+            if (pageUrl.includes(normalizedWorkspaceUri)) {
                 this.currentWorkspaceName = projectName;
-                logger.debug(`[CdpService] URL parameter match success: "${projectName}"`);
+                logger.debug(`[CdpService] URL parameter match success: "${projectName}" (workspace URI)`);
+                return true;
+            }
+
+            // If we only have the project name to go on, make sure it's a discrete boundary in the URL path
+            // e.g. "folder=.../test" or "workspace=.../test". We prevent false positives like "latest" matching "test".
+            const projectBoundaryRegex = new RegExp(`[=/]${projectName.toLowerCase()}(?:$|&|\\?)`);
+            if (projectBoundaryRegex.test(pageUrl)) {
+                this.currentWorkspaceName = projectName;
+                logger.debug(`[CdpService] URL parameter match success: "${projectName}" (boundary regex)`);
                 return true;
             }
 

--- a/src/services/errorPopupDetector.ts
+++ b/src/services/errorPopupDetector.ts
@@ -130,8 +130,12 @@ export class ErrorPopupDetector {
     private lastDetectedInfo: ErrorPopupInfo | null = null;
     /** Timestamp of last notification (for cooldown-based dedup) */
     private lastNotifiedAt: number = 0;
-    /** Cooldown period in ms to suppress duplicate notifications (10s for error popups) */
-    private static readonly COOLDOWN_MS = 10000;
+    /** Number of consecutive polls without detecting buttons */
+    private emptyPollCount: number = 0;
+    /** Cooldown period in ms to suppress duplicate notifications */
+    private static readonly COOLDOWN_MS = 5000;
+    /** Number of consecutive empty polls required before resetting state */
+    private static readonly REQUIRED_EMPTY_POLLS = 3;
 
     constructor(options: ErrorPopupDetectorOptions) {
         this.cdpService = options.cdpService;
@@ -147,6 +151,7 @@ export class ErrorPopupDetector {
         this.lastDetectedKey = null;
         this.lastDetectedInfo = null;
         this.lastNotifiedAt = 0;
+        this.emptyPollCount = 0;
         this.schedulePoll();
     }
 
@@ -241,6 +246,7 @@ export class ErrorPopupDetector {
             const info: ErrorPopupInfo | null = result?.result?.value ?? null;
 
             if (info) {
+                this.emptyPollCount = 0;
                 // Duplicate prevention: use title + body snippet as key
                 const key = `${info.title}::${info.body.slice(0, 100)}`;
                 const now = Date.now();
@@ -255,12 +261,15 @@ export class ErrorPopupDetector {
                     this.lastDetectedInfo = info;
                 }
             } else {
-                // Reset when popup disappears (prepare for next detection)
-                const wasDetected = this.lastDetectedKey !== null;
-                this.lastDetectedKey = null;
-                this.lastDetectedInfo = null;
-                if (wasDetected && this.onResolved) {
-                    this.onResolved();
+                this.emptyPollCount++;
+                if (this.emptyPollCount >= ErrorPopupDetector.REQUIRED_EMPTY_POLLS) {
+                    // Reset when popup disappears (prepare for next detection)
+                    const wasDetected = this.lastDetectedKey !== null;
+                    this.lastDetectedKey = null;
+                    this.lastDetectedInfo = null;
+                    if (wasDetected && this.onResolved) {
+                        this.onResolved();
+                    }
                 }
             }
         } catch (error) {

--- a/src/services/errorPopupDetector.ts
+++ b/src/services/errorPopupDetector.ts
@@ -1,3 +1,4 @@
+import { ConsecutiveEmptyPollGate } from '../utils/consecutiveEmptyPollGate';
 import { logger } from '../utils/logger';
 import { buildClickScript } from './approvalDetector';
 import { CdpService } from './cdpService';
@@ -130,12 +131,10 @@ export class ErrorPopupDetector {
     private lastDetectedInfo: ErrorPopupInfo | null = null;
     /** Timestamp of last notification (for cooldown-based dedup) */
     private lastNotifiedAt: number = 0;
-    /** Number of consecutive polls without detecting buttons */
-    private emptyPollCount: number = 0;
     /** Cooldown period in ms to suppress duplicate notifications */
     private static readonly COOLDOWN_MS = 5000;
-    /** Number of consecutive empty polls required before resetting state */
-    private static readonly REQUIRED_EMPTY_POLLS = 3;
+    /** Gate for empty polls before reset */
+    private emptyPollGate = new ConsecutiveEmptyPollGate(3);
 
     constructor(options: ErrorPopupDetectorOptions) {
         this.cdpService = options.cdpService;
@@ -151,7 +150,7 @@ export class ErrorPopupDetector {
         this.lastDetectedKey = null;
         this.lastDetectedInfo = null;
         this.lastNotifiedAt = 0;
-        this.emptyPollCount = 0;
+        this.emptyPollGate.reset();
         this.schedulePoll();
     }
 
@@ -246,23 +245,22 @@ export class ErrorPopupDetector {
             const info: ErrorPopupInfo | null = result?.result?.value ?? null;
 
             if (info) {
-                this.emptyPollCount = 0;
+                this.emptyPollGate.recordDetection();
                 // Duplicate prevention: use title + body snippet as key
                 const key = `${info.title}::${info.body.slice(0, 100)}`;
                 const now = Date.now();
                 const withinCooldown = (now - this.lastNotifiedAt) < ErrorPopupDetector.COOLDOWN_MS;
                 if (key !== this.lastDetectedKey && !withinCooldown) {
+                    this.lastNotifiedAt = now;
                     this.lastDetectedKey = key;
                     this.lastDetectedInfo = info;
-                    this.lastNotifiedAt = now;
                     this.onErrorPopup(info);
                 } else if (key === this.lastDetectedKey) {
                     // Same key -- update stored info silently
                     this.lastDetectedInfo = info;
                 }
             } else {
-                this.emptyPollCount++;
-                if (this.emptyPollCount >= ErrorPopupDetector.REQUIRED_EMPTY_POLLS) {
+                if (this.emptyPollGate.recordEmptyPoll()) {
                     // Reset when popup disappears (prepare for next detection)
                     const wasDetected = this.lastDetectedKey !== null;
                     this.lastDetectedKey = null;

--- a/src/services/notificationSender.ts
+++ b/src/services/notificationSender.ts
@@ -38,6 +38,9 @@ const ERROR_POPUP_COPY_DEBUG_ACTION_PREFIX = 'error_popup_copy_debug_action';
 const ERROR_POPUP_RETRY_ACTION_PREFIX = 'error_popup_retry_action';
 const RUN_COMMAND_RUN_ACTION_PREFIX = 'run_command_run_action';
 const RUN_COMMAND_REJECT_ACTION_PREFIX = 'run_command_reject_action';
+export const FEEDBACK_ACTION_PREFIX = 'feedback_action';
+export const QUESTION_SELECT_ACTION_PREFIX = 'question_select_action';
+export const QUESTION_SKIP_ACTION_PREFIX = 'question_skip_action';
 
 // ---------------------------------------------------------------------------
 // Notification colours
@@ -105,8 +108,11 @@ export function buildApprovalNotification(opts: {
     readonly toolNames?: readonly string[];
     /** Additional fields appended after default ones. */
     readonly extraFields?: readonly { readonly name: string; readonly value: string; readonly inline?: boolean }[];
+    /** Whether an 'Always Allow' / 'Allow Chat' button exists. */
+    readonly hasAlwaysAllow?: boolean;
+    readonly alwaysAllowText?: string;
 }): MessagePayload {
-    const { title, description, projectName, channelId, toolNames, extraFields } = opts;
+    const { title, description, projectName, channelId, toolNames, extraFields, hasAlwaysAllow, alwaysAllowText } = opts;
 
     const richContent = pipe(
         createRichContent(),
@@ -126,12 +132,18 @@ export function buildApprovalNotification(opts: {
         (rc) => withTimestamp(rc),
     );
 
+    const buttons = [
+        button(customId(APPROVE_ACTION_PREFIX, projectName, channelId), 'Allow', 'success'),
+    ];
+    
+    if (hasAlwaysAllow) {
+        buttons.push(button(customId(ALWAYS_ALLOW_ACTION_PREFIX, projectName, channelId), alwaysAllowText || 'Allow Chat', 'primary'));
+    }
+    
+    buttons.push(button(customId(DENY_ACTION_PREFIX, projectName, channelId), 'Deny', 'danger'));
+
     const components: readonly ComponentRow[] = [
-        buttonRow(
-            button(customId(APPROVE_ACTION_PREFIX, projectName, channelId), 'Allow', 'success'),
-            button(customId(ALWAYS_ALLOW_ACTION_PREFIX, projectName, channelId), 'Allow Chat', 'primary'),
-            button(customId(DENY_ACTION_PREFIX, projectName, channelId), 'Deny', 'danger'),
-        ),
+        buttonRow(...buttons),
     ];
 
     return { richContent, components };
@@ -145,6 +157,9 @@ export function buildPlanningNotification(opts: {
     readonly channelId: string | null;
     /** Additional fields appended before footer. */
     readonly extraFields?: readonly { readonly name: string; readonly value: string; readonly inline?: boolean }[];
+    readonly hasOpenButton?: boolean;
+    readonly openText?: string;
+    readonly proceedText?: string;
 }): MessagePayload {
     const { title, description, projectName, channelId, extraFields } = opts;
 
@@ -161,11 +176,16 @@ export function buildPlanningNotification(opts: {
         (rc) => withTimestamp(rc),
     );
 
+    const buttons = [];
+    const openLabel = opts.openText || 'Open';
+    if (opts.hasOpenButton !== false) {
+        buttons.push(button(customId(PLANNING_OPEN_ACTION_PREFIX, projectName, channelId), openLabel, 'primary'));
+    }
+    const buttonLabel = opts.proceedText || 'Proceed';
+    buttons.push(button(customId(PLANNING_PROCEED_ACTION_PREFIX, projectName, channelId), buttonLabel, 'success'));
+
     const components: readonly ComponentRow[] = [
-        buttonRow(
-            button(customId(PLANNING_OPEN_ACTION_PREFIX, projectName, channelId), 'Open', 'primary'),
-            button(customId(PLANNING_PROCEED_ACTION_PREFIX, projectName, channelId), 'Proceed', 'success'),
-        ),
+        buttonRow(...buttons),
     ];
 
     return { richContent, components };
@@ -335,6 +355,61 @@ export function buildStatusNotification(opts: {
     );
 
     return { richContent };
+}
+
+export interface BuildQuestionNotificationParams {
+    title: string;
+    description: string;
+    projectName: string;
+    channelId: string;
+    options: { text: string; x: number; y: number }[];
+}
+
+export function buildQuestionNotification(
+    params: BuildQuestionNotificationParams,
+): MessagePayload {
+    const { title, description, projectName, channelId, options } = params;
+
+    const baseContent = pipe(
+        createRichContent(),
+        (rc) => withTitle(rc, title),
+        (rc) => withColor(rc, COLOR_APPROVAL),
+    );
+
+    const embed = description ? withDescription(baseContent, description) : baseContent;
+
+    const selectMenuOptions = options.map((opt, i) => ({
+        label: opt.text.substring(0, 100), // Discord max length for label is 100
+        value: i.toString(),
+    })).slice(0, 25); // Discord max options in a select menu is 25
+
+    const encodedCustomId = `${QUESTION_SELECT_ACTION_PREFIX}:p=${projectName}:c=${channelId}`.substring(0, 100);
+
+    return {
+        richContent: embed,
+        components: [
+            {
+                components: [
+                    {
+                        type: 'selectMenu',
+                        customId: encodedCustomId,
+                        placeholder: 'Select an option...',
+                        options: selectMenuOptions,
+                    },
+                ],
+            },
+            {
+                components: [
+                    {
+                        type: 'button',
+                        customId: `${QUESTION_SKIP_ACTION_PREFIX}:p=${projectName}:c=${channelId}`.substring(0, 100),
+                        label: 'Skip',
+                        style: 'secondary',
+                    },
+                ],
+            },
+        ],
+    };
 }
 
 /** Build a progress / phase notification (e.g. "Thinking...", "Generating..."). */

--- a/src/services/notificationSender.ts
+++ b/src/services/notificationSender.ts
@@ -383,7 +383,18 @@ export function buildQuestionNotification(
         value: i.toString(),
     })).slice(0, 25); // Discord max options in a select menu is 25
 
-    const encodedCustomId = `${QUESTION_SELECT_ACTION_PREFIX}:p=${projectName}:c=${channelId}`.substring(0, 100);
+    // Ensure customIds fit within 100 chars without losing channelId
+    const selectOverhead = QUESTION_SELECT_ACTION_PREFIX.length + 6 + channelId.length;
+    const safeSelectProjectName = projectName.length > (100 - selectOverhead) 
+        ? projectName.substring(0, 100 - selectOverhead) 
+        : projectName;
+    const encodedCustomId = `${QUESTION_SELECT_ACTION_PREFIX}:p=${safeSelectProjectName}:c=${channelId}`;
+
+    const skipOverhead = QUESTION_SKIP_ACTION_PREFIX.length + 6 + channelId.length;
+    const safeSkipProjectName = projectName.length > (100 - skipOverhead) 
+        ? projectName.substring(0, 100 - skipOverhead) 
+        : projectName;
+    const encodedSkipCustomId = `${QUESTION_SKIP_ACTION_PREFIX}:p=${safeSkipProjectName}:c=${channelId}`;
 
     return {
         richContent: embed,
@@ -402,7 +413,7 @@ export function buildQuestionNotification(
                 components: [
                     {
                         type: 'button',
-                        customId: `${QUESTION_SKIP_ACTION_PREFIX}:p=${projectName}:c=${channelId}`.substring(0, 100),
+                        customId: encodedSkipCustomId,
                         label: 'Skip',
                         style: 'secondary',
                     },

--- a/src/services/planningDetector.ts
+++ b/src/services/planningDetector.ts
@@ -14,6 +14,10 @@ export interface PlanningInfo {
     planSummary: string;
     /** Plan description (markdown rendered in leading-relaxed container) */
     description: string;
+    /** Reject button text (optional, e.g. "Reject All") */
+    rejectText?: string;
+    /** Whether an Open button was found */
+    hasOpenButton?: boolean;
 }
 
 export interface PlanningDetectorOptions {
@@ -34,33 +38,59 @@ export interface PlanningDetectorOptions {
  * and extracts plan metadata from the surrounding DOM elements.
  */
 const DETECT_PLANNING_SCRIPT = `(() => {
-    const OPEN_PATTERNS = ['open'];
+    const OPEN_PATTERNS = ['open', 'review'];
     const PROCEED_PATTERNS = ['proceed'];
+    const REJECT_PATTERNS = ['reject'];
+    const ACCEPT_PATTERNS = ['accept'];
 
     const normalize = (text) => (text || '').toLowerCase().replace(/\\s+/g, ' ').trim();
 
-    // Find the notify container that holds planning UI
-    const container = document.querySelector('.notify-user-container');
+    const allButtons = Array.from(document.querySelectorAll('button, a'))
+        .filter(btn => btn.offsetParent !== null)
+        .reverse();
+
+    let proceedBtn = null;
+    let openBtn = null;
+    let rejectBtn = null;
+
+    for (const btn of allButtons) {
+        const t = normalize(btn.textContent || '');
+        if (t === 'review changes') continue; // Ignore file change review button
+
+        // If we hit an accept or reject button before finding a proceed button, 
+        // it means the most recent state is an Approval, not Planning.
+        if (!proceedBtn && (ACCEPT_PATTERNS.some(p => t === p || t.includes(p)) || REJECT_PATTERNS.some(p => t === p || t.includes(p)))) {
+            return null;
+        }
+
+        if (!proceedBtn && PROCEED_PATTERNS.some(p => t === p || t.includes(p))) {
+            proceedBtn = btn;
+            continue;
+        }
+
+        if (!openBtn && OPEN_PATTERNS.some(p => t === p || t.includes(p))) {
+            openBtn = btn;
+        }
+
+        if (!rejectBtn && REJECT_PATTERNS.some(p => t === p || t.includes(p))) {
+            rejectBtn = btn;
+        }
+        
+        if (proceedBtn && openBtn) break;
+    }
+
+    // Proceed button must exist for this to be a planning UI
+    if (!proceedBtn) return null;
+    
+    const container = proceedBtn.closest('.notify-user-container') || proceedBtn.closest('div[class*="rounded-lg"]') || proceedBtn.parentElement?.parentElement;
     if (!container) return null;
 
-    const allButtons = Array.from(container.querySelectorAll('button'))
-        .filter(btn => btn.offsetParent !== null);
+    // openBtn was already extracted in the loop above
 
-    const openBtn = allButtons.find(btn => {
-        const t = normalize(btn.textContent || '');
-        return OPEN_PATTERNS.some(p => t === p || t.includes(p));
-    }) || null;
-
-    const proceedBtn = allButtons.find(btn => {
-        const t = normalize(btn.textContent || '');
-        return PROCEED_PATTERNS.some(p => t === p || t.includes(p));
-    }) || null;
-
-    // Both buttons must exist for this to be a planning UI
-    if (!openBtn || !proceedBtn) return null;
-
-    const openText = (openBtn.textContent || '').trim();
+    const hasOpenButton = openBtn !== null;
+    const openText = openBtn ? (openBtn.textContent || '').trim() : 'Open';
     const proceedText = (proceedBtn.textContent || '').trim();
+    const rejectText = rejectBtn ? (rejectBtn.textContent || '').trim() : '';
 
     // Extract plan title from .inline-flex.break-all
     const titleEl = container.querySelector('span.inline-flex.break-all, .inline-flex.break-all');
@@ -91,7 +121,7 @@ const DETECT_PLANNING_SCRIPT = `(() => {
         description = parts.join(' ').slice(0, 500);
     }
 
-    return { openText, proceedText, planTitle, planSummary, description };
+    return { openText, proceedText, planTitle, planSummary, description, rejectText, hasOpenButton };
 })()`;
 
 /**
@@ -185,8 +215,12 @@ export class PlanningDetector {
     private lastDetectedInfo: PlanningInfo | null = null;
     /** Timestamp of last notification (for cooldown-based dedup) */
     private lastNotifiedAt: number = 0;
+    /** Number of consecutive polls without detecting buttons */
+    private emptyPollCount: number = 0;
     /** Cooldown period in ms to suppress duplicate notifications */
     private static readonly COOLDOWN_MS = 5000;
+    /** Number of consecutive empty polls required before resetting state */
+    private static readonly REQUIRED_EMPTY_POLLS = 3;
 
     constructor(options: PlanningDetectorOptions) {
         this.cdpService = options.cdpService;
@@ -202,6 +236,7 @@ export class PlanningDetector {
         this.lastDetectedKey = null;
         this.lastDetectedInfo = null;
         this.lastNotifiedAt = 0;
+        this.emptyPollCount = 0;
         this.schedulePoll();
     }
 
@@ -241,6 +276,16 @@ export class PlanningDetector {
      */
     async clickProceedButton(buttonText?: string): Promise<boolean> {
         const text = buttonText ?? this.lastDetectedInfo?.proceedText ?? 'Proceed';
+        return this.clickButton(text);
+    }
+
+    /**
+     * Click the Reject button via CDP.
+     * @param buttonText Text of the button to click (default: detected rejectText or "Reject All")
+     * @returns true if click succeeded
+     */
+    async clickRejectButton(buttonText?: string): Promise<boolean> {
+        const text = buttonText ?? this.lastDetectedInfo?.rejectText ?? 'Reject All';
         return this.clickButton(text);
     }
 
@@ -291,8 +336,9 @@ export class PlanningDetector {
             const info: PlanningInfo | null = result?.result?.value ?? null;
 
             if (info) {
-                // Duplicate prevention: use button text pair as key (stable across DOM redraws)
-                const key = `${info.openText}::${info.proceedText}`;
+                this.emptyPollCount = 0;
+                // Duplicate prevention: use plan title and content as key (stable across DOM redraws and button text updates)
+                const key = `${info.planTitle}::${info.planSummary}::${(info.description || '').substring(0, 50)}`;
                 const now = Date.now();
                 const withinCooldown = (now - this.lastNotifiedAt) < PlanningDetector.COOLDOWN_MS;
                 if (key !== this.lastDetectedKey && !withinCooldown) {
@@ -305,12 +351,15 @@ export class PlanningDetector {
                     this.lastDetectedInfo = info;
                 }
             } else {
-                // Reset when buttons disappear (prepare for next planning detection)
-                const wasDetected = this.lastDetectedKey !== null;
-                this.lastDetectedKey = null;
-                this.lastDetectedInfo = null;
-                if (wasDetected && this.onResolved) {
-                    this.onResolved();
+                this.emptyPollCount++;
+                if (this.emptyPollCount >= PlanningDetector.REQUIRED_EMPTY_POLLS) {
+                    // Reset when buttons disappear for consecutive polls
+                    const wasDetected = this.lastDetectedKey !== null;
+                    this.lastDetectedKey = null;
+                    this.lastDetectedInfo = null;
+                    if (wasDetected && this.onResolved) {
+                        this.onResolved();
+                    }
                 }
             }
         } catch (error) {

--- a/src/services/promptDispatcher.ts
+++ b/src/services/promptDispatcher.ts
@@ -59,19 +59,14 @@ export class PromptDispatcher {
     constructor(private readonly deps: PromptDispatcherDeps) { }
 
     async send(req: PromptDispatchRequest): Promise<void> {
-        await this.deps.sendPromptImpl(
-            this.deps.bridge,
-            req.message,
-            req.prompt,
-            req.cdp,
-            this.deps.modeService,
-            this.deps.modelService,
-            req.inboundImages ?? [],
-            req.options,
-        );
+        await this._dispatch(req, req.options);
     }
 
     async resume(req: PromptDispatchRequest): Promise<void> {
+        await this._dispatch(req, { ...req.options, resumeOnly: true } as PromptDispatchOptions);
+    }
+
+    private async _dispatch(req: PromptDispatchRequest, options?: PromptDispatchOptions): Promise<void> {
         await this.deps.sendPromptImpl(
             this.deps.bridge,
             req.message,
@@ -80,7 +75,7 @@ export class PromptDispatcher {
             this.deps.modeService,
             this.deps.modelService,
             req.inboundImages ?? [],
-            { ...req.options, resumeOnly: true } as PromptDispatchOptions,
+            options,
         );
     }
 }

--- a/src/services/promptDispatcher.ts
+++ b/src/services/promptDispatcher.ts
@@ -23,6 +23,7 @@ export interface PromptDispatchOptions {
     artifactService?: ArtifactService;
     onFullCompletion?: () => void;
     responseTimeoutMs?: number;
+    resumeOnly?: boolean;
 }
 
 
@@ -67,6 +68,19 @@ export class PromptDispatcher {
             this.deps.modelService,
             req.inboundImages ?? [],
             req.options,
+        );
+    }
+
+    async resume(req: PromptDispatchRequest): Promise<void> {
+        await this.deps.sendPromptImpl(
+            this.deps.bridge,
+            req.message,
+            req.prompt,
+            req.cdp,
+            this.deps.modeService,
+            this.deps.modelService,
+            req.inboundImages ?? [],
+            { ...req.options, resumeOnly: true } as PromptDispatchOptions,
         );
     }
 }

--- a/src/services/questionDetector.ts
+++ b/src/services/questionDetector.ts
@@ -90,8 +90,6 @@ export class QuestionDetector extends EventEmitter {
                     let submitBtn = null;
                     
                     for (const container of containers) {
-                        const hasList = container.querySelector('ul, [role="listbox"], [role="radiogroup"]') !== null;
-                        
                         const buttons = Array.from(container.querySelectorAll('button'));
                         let possibleSubmitBtn = null;
                         for (const btn of buttons) {
@@ -102,12 +100,12 @@ export class QuestionDetector extends EventEmitter {
                             }
                         }
                         
-                        if (hasList && possibleSubmitBtn) {
-                            const listElement = container.querySelector('ul, [role="listbox"], [role="radiogroup"]');
-                            const items = Array.from(listElement.querySelectorAll('li, [role="radio"], [role="option"], .cursor-pointer'));
+                        if (possibleSubmitBtn) {
+                            const items = Array.from(container.querySelectorAll('li, label, a, [role="radio"], [role="option"], [class*="cursor-pointer"]'))
+                                .filter(el => el.tagName !== 'BUTTON' && !el.closest('button'));
                             
                             if (items.length > 1) {
-                                targetList = listElement;
+                                targetList = container;
                                 submitBtn = possibleSubmitBtn;
                                 break;
                             }
@@ -116,7 +114,8 @@ export class QuestionDetector extends EventEmitter {
 
                     if (!targetList || !submitBtn) return { found: false };
 
-                    const items = Array.from(targetList.querySelectorAll('li, [role="radio"], [role="option"], .cursor-pointer'));
+                    const items = Array.from(targetList.querySelectorAll('li, label, a, [role="radio"], [role="option"], [class*="cursor-pointer"]'))
+                        .filter(el => el.tagName !== 'BUTTON' && !el.closest('button'));
                     if (items.length <= ${index}) return { found: false };
                     
                     const targetOption = items[${index}];

--- a/src/services/questionDetector.ts
+++ b/src/services/questionDetector.ts
@@ -1,0 +1,414 @@
+import { EventEmitter } from 'events';
+import { CdpService } from './cdpService';
+import { logger } from '../utils/logger';
+
+export interface QuestionOption {
+    text: string;
+    x: number;
+    y: number;
+}
+
+export interface QuestionInfo {
+    title: string;
+    description: string;
+    options: QuestionOption[];
+}
+
+export interface QuestionDetectorOptions {
+    cdpService: CdpService;
+    pollIntervalMs?: number;
+    onQuestionRequired: (info: QuestionInfo) => void;
+    onResolved?: () => void;
+}
+
+export class QuestionDetector extends EventEmitter {
+    private cdp: CdpService;
+    private pollIntervalMs: number;
+    private intervalId: NodeJS.Timeout | null = null;
+    private logger = logger;
+    private lastQuestionDetected: boolean = false;
+    private emptyPollCount: number = 0;
+    private static readonly REQUIRED_EMPTY_POLLS = 3;
+    private _isStarted: boolean = false;
+    private onQuestionRequired: (info: QuestionInfo) => void;
+    private onResolved?: () => void;
+    private projectName: string = 'unknown';
+
+    constructor(options: QuestionDetectorOptions) {
+        super();
+        this.cdp = options.cdpService;
+        this.pollIntervalMs = options.pollIntervalMs || 2000;
+        this.onQuestionRequired = options.onQuestionRequired;
+        this.onResolved = options.onResolved;
+        
+        // Listen to own events to call options callbacks (for compat)
+        this.on('question', (info) => this.onQuestionRequired(info));
+        this.on('resolved', () => {
+            if (this.onResolved) this.onResolved();
+        });
+    }
+    
+    setProjectName(name: string) {
+        this.projectName = name;
+    }
+
+    get isActive() {
+        return this._isStarted;
+    }
+
+    start() {
+        if (this._isStarted) return;
+        this._isStarted = true;
+        this.logger.debug(`[QuestionDetector:${this.projectName}] Starting polling`);
+        this.lastQuestionDetected = false;
+        this.emptyPollCount = 0;
+        
+        this.intervalId = setInterval(() => this.poll(), this.pollIntervalMs);
+        this.poll();
+    }
+
+    stop() {
+        if (!this._isStarted) return;
+        this._isStarted = false;
+        if (this.intervalId) {
+            clearInterval(this.intervalId);
+            this.intervalId = null;
+        }
+        this.logger.debug(`[QuestionDetector:${this.projectName}] Stopped polling`);
+    }
+
+    async submitOption(index: number): Promise<boolean> {
+        this.logger.debug(`[QuestionDetector:${this.projectName}] Submitting option ${index}`);
+        
+        try {
+            const contextId = this.cdp.getPrimaryContextId();
+            const callParams: any = {
+                expression: `
+                (() => {
+                    const containers = Array.from(document.querySelectorAll('div, form, dialog'));
+                    let targetList = null;
+                    let submitBtn = null;
+                    
+                    for (const container of containers) {
+                        const hasList = container.querySelector('ul, [role="listbox"], [role="radiogroup"]') !== null;
+                        
+                        const buttons = Array.from(container.querySelectorAll('button'));
+                        let possibleSubmitBtn = null;
+                        for (const btn of buttons) {
+                            const text = btn.textContent?.toLowerCase() || '';
+                            if (text.includes('submit')) {
+                                possibleSubmitBtn = btn;
+                                break;
+                            }
+                        }
+                        
+                        if (hasList && possibleSubmitBtn) {
+                            const listElement = container.querySelector('ul, [role="listbox"], [role="radiogroup"]');
+                            const items = Array.from(listElement.querySelectorAll('li, [role="radio"], [role="option"], .cursor-pointer'));
+                            
+                            if (items.length > 1) {
+                                targetList = listElement;
+                                submitBtn = possibleSubmitBtn;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (!targetList || !submitBtn) return { found: false };
+
+                    const items = Array.from(targetList.querySelectorAll('li, [role="radio"], [role="option"], .cursor-pointer'));
+                    if (items.length <= ${index}) return { found: false };
+                    
+                    const targetOption = items[${index}];
+                    
+                    const optionRect = targetOption.getBoundingClientRect();
+                    const btnRect = submitBtn.getBoundingClientRect();
+                    
+                    return {
+                        found: true,
+                        option: {
+                            x: Math.round(optionRect.left + optionRect.width / 2),
+                            y: Math.round(optionRect.top + optionRect.height / 2)
+                        },
+                        button: {
+                            x: Math.round(btnRect.left + btnRect.width / 2),
+                            y: Math.round(btnRect.top + btnRect.height / 2)
+                        }
+                    };
+                })()
+                `,
+                returnByValue: true,
+                awaitPromise: false,
+            };
+            if (contextId !== null) {
+                callParams.contextId = contextId;
+            }
+
+            const response = await this.cdp.call('Runtime.evaluate', callParams);
+            const result = response?.result?.value;
+
+            if (!result || !result.found) {
+                this.logger.warn(`[QuestionDetector:${this.projectName}] Could not find question modal elements during submission.`);
+                return false;
+            }
+
+            // Click the option
+            await this.cdp.call('Input.dispatchMouseEvent', {
+                type: 'mousePressed',
+                x: result.option.x,
+                y: result.option.y,
+                button: 'left',
+                clickCount: 1,
+            });
+            await this.cdp.call('Input.dispatchMouseEvent', {
+                type: 'mouseReleased',
+                x: result.option.x,
+                y: result.option.y,
+                button: 'left',
+                clickCount: 1,
+            });
+            
+            await new Promise(resolve => setTimeout(resolve, 50));
+
+            // Click the submit button
+            await this.cdp.call('Input.dispatchMouseEvent', {
+                type: 'mousePressed',
+                x: result.button.x,
+                y: result.button.y,
+                button: 'left',
+                clickCount: 1,
+            });
+            await this.cdp.call('Input.dispatchMouseEvent', {
+                type: 'mouseReleased',
+                x: result.button.x,
+                y: result.button.y,
+                button: 'left',
+                clickCount: 1,
+            });
+
+            this.lastQuestionDetected = false;
+            return true;
+        } catch (e: any) {
+            this.logger.error(`[QuestionDetector:${this.projectName}] submitOption error:`, e.message);
+            return false;
+        }
+    }
+
+    async skipQuestion(): Promise<boolean> {
+        this.logger.debug(`[QuestionDetector:${this.projectName}] Skipping question`);
+        
+        try {
+            const contextId = this.cdp.getPrimaryContextId();
+            const callParams: any = {
+                expression: `
+                (() => {
+                    const containers = Array.from(document.querySelectorAll('div, form, dialog')).reverse();
+                    let skipBtn = null;
+                    
+                    for (const container of containers) {
+                        const items = Array.from(container.querySelectorAll('li, [role="radio"], [role="option"], .cursor-pointer'))
+                            .filter(el => el.tagName !== 'BUTTON' && !el.closest('button'));
+                        const hasList = items.length > 1;
+                        
+                        const buttons = Array.from(container.querySelectorAll('button'));
+                        for (const btn of buttons) {
+                            const text = btn.textContent?.toLowerCase() || '';
+                            if (text.includes('skip') && hasList) {
+                                skipBtn = btn;
+                                break;
+                            }
+                        }
+                        if (skipBtn) break;
+                    }
+
+                    if (!skipBtn) return { found: false };
+                    
+                    const btnRect = skipBtn.getBoundingClientRect();
+                    return {
+                        found: true,
+                        button: {
+                            x: Math.round(btnRect.left + btnRect.width / 2),
+                            y: Math.round(btnRect.top + btnRect.height / 2)
+                        }
+                    };
+                })()
+                `,
+                returnByValue: true,
+                awaitPromise: false,
+            };
+            if (contextId !== null) callParams.contextId = contextId;
+
+            const response = await this.cdp.call('Runtime.evaluate', callParams);
+            const result = response?.result?.value;
+
+            if (!result || !result.found) {
+                this.logger.warn(`[QuestionDetector:${this.projectName}] Could not find skip button.`);
+                return false;
+            }
+
+            await this.cdp.call('Input.dispatchMouseEvent', {
+                type: 'mousePressed',
+                x: result.button.x,
+                y: result.button.y,
+                button: 'left',
+                clickCount: 1,
+            });
+            await this.cdp.call('Input.dispatchMouseEvent', {
+                type: 'mouseReleased',
+                x: result.button.x,
+                y: result.button.y,
+                button: 'left',
+                clickCount: 1,
+            });
+
+            this.lastQuestionDetected = false;
+            return true;
+        } catch (e: any) {
+            this.logger.error(`[QuestionDetector:${this.projectName}] skipQuestion error:`, e.message);
+            return false;
+        }
+    }
+
+    private async poll() {
+        if (!this.cdp.isConnected()) return;
+
+        try {
+            const callParams: any = {
+                expression: `
+                (() => {
+                    const containers = Array.from(document.querySelectorAll('div, form, dialog')).reverse();
+                    let targetList = null;
+                    let submitBtn = null;
+                    
+                    for (const container of containers) {
+                        const buttons = Array.from(container.querySelectorAll('button'));
+                        let possibleSubmitBtn = null;
+                        for (const btn of buttons) {
+                            const text = btn.textContent?.toLowerCase() || '';
+                            if (text.includes('submit')) {
+                                possibleSubmitBtn = btn;
+                                break;
+                            }
+                        }
+                        
+                        if (possibleSubmitBtn) {
+                            const items = Array.from(container.querySelectorAll('li, label, a, [role="radio"], [role="option"], [class*="cursor-pointer"]'))
+                                .filter(el => el.tagName !== 'BUTTON' && !el.closest('button'));
+                            
+                            if (items.length > 1) {
+                                targetList = container;
+                                submitBtn = possibleSubmitBtn;
+                                break;
+                            }
+                        }
+                    }
+                    if (!targetList || !submitBtn) return { detected: false, reason: "No targetList or submitBtn found" };
+
+                    let titleEl = targetList.querySelector('h1, h2, h3, [role="heading"], .text-lg');
+                    if (!titleEl) {
+                        let p = targetList;
+                        while (p && p.tagName !== 'BODY') {
+                            titleEl = p.querySelector('h1, h2, h3, [role="heading"], .text-lg, p');
+                            if (titleEl && titleEl !== p && (titleEl.innerText || titleEl.textContent || '').trim().length > 0) break;
+                            p = p.parentElement;
+                        }
+                    }
+                    const title = titleEl ? (titleEl.innerText || titleEl.textContent || '').trim() : 'Question';
+                    
+                    const items = Array.from(targetList.querySelectorAll('li, label, a, [role="radio"], [role="option"], [class*="cursor-pointer"]'))
+                        .filter(el => el.tagName !== 'BUTTON' && !el.closest('button'));
+                    const options = items.map(n => {
+                        const rect = n.getBoundingClientRect();
+                        const finalLabel = n.innerText || n.textContent || 'Option';
+
+                        return {
+                            text: finalLabel.replace(/\\n/g, ' ').replace(/\\s+/g, ' ').trim().substring(0, 100),
+                            x: Math.round(rect.left + rect.width / 2),
+                            y: Math.round(rect.top + rect.height / 2)
+                        };
+                    });
+
+                    if (options.length === 0) return { detected: false, reason: "options length 0" };
+
+                    return {
+                        detected: true,
+                        title,
+                        options
+                    };
+                })()
+                `,
+                returnByValue: true,
+                awaitPromise: false,
+            };
+
+            const contexts = this.cdp.getContexts();
+            const contextIds = [
+                this.cdp.getPrimaryContextId(),
+                ...contexts.map((ctx) => ctx.id),
+            ].filter((value, index, arr): value is number => typeof value === 'number' && arr.indexOf(value) === index);
+            const targets: Array<number | null> = contextIds.length > 0 ? contextIds : [null];
+
+            let detectedResult = null;
+            let lastReason = null;
+
+            for (const contextId of targets) {
+                if (contextId !== null) {
+                    callParams.contextId = contextId;
+                }
+                const response = await this.cdp.call('Runtime.evaluate', callParams).catch(e => {
+                    this.logger.debug(`[QuestionDetector] Error evaluating on ctx ${contextId}: ${e.message}`);
+                    return null;
+                });
+                
+                if (response?.exceptionDetails) {
+                    this.logger.debug(`[QuestionDetector] Exception on ctx ${contextId}: ${response.exceptionDetails.exception?.description || response.exceptionDetails.text}`);
+                }
+
+                const result = response?.result?.value;
+                if (result) {
+                    this.logger.debug(`[QuestionDetector] Context ${contextId} evaluated successfully, detected: ${result.detected}, reason: ${result.reason}`);
+                }
+
+                if (result && result.detected) {
+                    detectedResult = result;
+                    break;
+                } else if (result && result.reason) {
+                    lastReason = result.reason;
+                }
+            }
+
+            const result = detectedResult;
+
+            if (result && result.detected) {
+                this.emptyPollCount = 0;
+                if (!this.lastQuestionDetected) {
+                    this.lastQuestionDetected = true;
+                    this.logger.debug(`[QuestionDetector:${this.projectName}] Question modal detected`);
+                    this.emit('question', {
+                        title: result.title || 'Question',
+                        description: 'Please answer the question below.',
+                        options: result.options,
+                    });
+                }
+            } else {
+                if (!result && lastReason) {
+                    this.logger.debug(`[QuestionDetector:${this.projectName}] Evaluate returned false: ${lastReason}`);
+                }
+                this.emptyPollCount++;
+                if (this.emptyPollCount >= QuestionDetector.REQUIRED_EMPTY_POLLS) {
+                    if (this.lastQuestionDetected) {
+                        this.logger.debug(`[QuestionDetector:${this.projectName}] Question modal disappeared`);
+                        this.lastQuestionDetected = false;
+                        this.emit('resolved');
+                    }
+                }
+            }
+        } catch (e: any) {
+            if (e.message?.includes('Target closed') || e.message?.includes('Session closed')) {
+                // Ignore disconnect errors
+            } else {
+                this.logger.error(`[QuestionDetector:${this.projectName}] Error:`, e.message);
+            }
+        }
+    }
+}

--- a/src/services/responseMonitor.ts
+++ b/src/services/responseMonitor.ts
@@ -4,6 +4,7 @@ import { CdpService } from './cdpService';
 import {
     extractAssistantSegmentsPayloadScript,
     classifyAssistantSegments,
+    type ClassifyResult,
 } from './assistantDomExtractor';
 
 /** Lean DOM selectors for response extraction */
@@ -486,7 +487,11 @@ export interface ResponseMonitorOptions {
     /** Text update callback */
     onProgress?: (text: string) => void;
     /** Generation complete callback */
-    onComplete?: (finalText: string) => void;
+    onComplete?: (finalText: string, citedFiles?: string[], fileChanges?: string[]) => void;
+    /** Structured update callback */
+    onStructuredProgress?: (result: ClassifyResult) => void;
+    /** Structured generation complete callback */
+    onStructuredComplete?: (result: ClassifyResult) => void;
     /** Timeout callback */
     onTimeout?: (lastText: string) => void;
     /** Phase change callback */
@@ -684,7 +689,9 @@ export class ResponseMonitor {
     private readonly stopGoneConfirmCount: number;
     private readonly extractionMode: ExtractionMode;
     private readonly onProgress?: (text: string) => void;
-    private readonly onComplete?: (finalText: string) => void;
+    private readonly onComplete?: (finalText: string, citedFiles?: string[], fileChanges?: string[]) => void;
+    private readonly onStructuredProgress?: (result: ClassifyResult) => void;
+    private readonly onStructuredComplete?: (result: ClassifyResult) => void;
     private readonly onTimeout?: (lastText: string) => void;
     private readonly onPhaseChange?: (phase: ResponsePhase, text: string | null) => void;
     private readonly onProcessLog?: (text: string) => void;
@@ -694,12 +701,15 @@ export class ResponseMonitor {
     private pollTimer: ReturnType<typeof setTimeout> | null = null;
     private isRunning: boolean = false;
     private lastText: string | null = null;
+    private lastClassified: ClassifyResult | null = null;
     private baselineText: string | null = null;
     private generationStarted: boolean = false;
     private currentPhase: ResponsePhase = 'waiting';
     private stopGoneCount: number = 0;
     private quotaDetected: boolean = false;
     private seenProcessLogKeys: Set<string> = new Set();
+    private currentCitedFiles: string[] = [];
+    private currentFileChanges: string[] = [];
     private structuredDiagLogged: boolean = false;
     private lastContentContextId: number | null = null;
 
@@ -720,11 +730,17 @@ export class ResponseMonitor {
         this.extractionMode = options.extractionMode ?? 'structured';
         this.onProgress = options.onProgress;
         this.onComplete = options.onComplete;
+        this.onStructuredProgress = options.onStructuredProgress;
+        this.onStructuredComplete = options.onStructuredComplete;
         this.onTimeout = options.onTimeout;
         this.onPhaseChange = options.onPhaseChange;
         this.onProcessLog = options.onProcessLog;
         this.initialBaselineText = options.initialBaselineText;
         this.initialSeenProcessLogKeys = options.initialSeenProcessLogKeys;
+    }
+
+    public getLastClassified(): ClassifyResult | null {
+        return this.lastClassified;
     }
 
     /** Start monitoring */
@@ -1138,6 +1154,7 @@ export class ResponseMonitor {
                     if (classified.diagnostics.source === 'dom-structured') {
                         currentText = classified.finalOutputText.trim() || null;
                         structuredHandledLogs = true;
+                        this.lastClassified = classified;
 
                         if (!this.structuredDiagLogged) {
                             this.structuredDiagLogged = true;
@@ -1147,6 +1164,11 @@ export class ResponseMonitor {
                         // Emit structured activity lines as process logs
                         if (classified.activityLines.length > 0) {
                             this.emitNewProcessLogs(classified.activityLines);
+                        }
+                        
+                        if (classified.citedFiles && classified.citedFiles.length > 0) {
+                            this.currentCitedFiles = classified.citedFiles;
+                            this.currentFileChanges = classified.fileChangesTexts;
                         }
                     } else if (!this.structuredDiagLogged) {
                         this.structuredDiagLogged = true;
@@ -1209,6 +1231,7 @@ export class ResponseMonitor {
                     await this.stop();
                     try {
                         await Promise.resolve(this.onComplete?.(''));
+                        if (this.lastClassified) await Promise.resolve(this.onStructuredComplete?.(this.lastClassified));
                     } catch (error) {
                         logger.error('[ResponseMonitor] complete callback failed:', error);
                     }
@@ -1238,7 +1261,14 @@ export class ResponseMonitor {
                     }
                 }
 
-                this.onProgress?.(effectiveText);
+                this.onProgress?.(effectiveText || '');
+                if (this.lastClassified) this.onStructuredProgress?.(this.lastClassified);
+            } else if (this.lastClassified && this.extractionMode === 'structured') {
+                // If text didn't change but structured data did (e.g. new file changes), emit structured progress anyway
+                // To keep it simple, we just emit on structured mode if generation is active.
+                if (isGenerating && this.generationStarted) {
+                    this.onStructuredProgress?.(this.lastClassified);
+                }
             }
 
             // Completion: stop button gone N consecutive times
@@ -1249,7 +1279,8 @@ export class ResponseMonitor {
                     this.setPhase('complete', finalText);
                     await this.stop();
                     try {
-                        await Promise.resolve(this.onComplete?.(finalText));
+                        await Promise.resolve(this.onComplete?.(finalText, this.currentCitedFiles, this.currentFileChanges));
+                        if (this.lastClassified) await Promise.resolve(this.onStructuredComplete?.(this.lastClassified));
                     } catch (error) {
                         logger.error('[ResponseMonitor] complete callback failed:', error);
                     }

--- a/src/services/runCommandDetector.ts
+++ b/src/services/runCommandDetector.ts
@@ -1,3 +1,4 @@
+import { ConsecutiveEmptyPollGate } from '../utils/consecutiveEmptyPollGate';
 import { logger } from '../utils/logger';
 import { CdpService } from './cdpService';
 import { buildClickScript } from './approvalDetector';
@@ -137,10 +138,8 @@ export class RunCommandDetector {
     private lastDetectedKey: string | null = null;
     /** Full RunCommandInfo from the last detection */
     private lastDetectedInfo: RunCommandInfo | null = null;
-    /** Number of consecutive polls without detecting buttons */
-    private emptyPollCount: number = 0;
-    /** Number of consecutive empty polls required before resetting state */
-    private static readonly REQUIRED_EMPTY_POLLS = 3;
+    /** Gate for empty polls before reset */
+    private emptyPollGate = new ConsecutiveEmptyPollGate(3);
 
     constructor(options: RunCommandDetectorOptions) {
         this.cdpService = options.cdpService;
@@ -155,7 +154,7 @@ export class RunCommandDetector {
         this.isRunning = true;
         this.lastDetectedKey = null;
         this.lastDetectedInfo = null;
-        this.emptyPollCount = 0;
+        this.emptyPollGate.reset();
         this.schedulePoll();
     }
 
@@ -206,7 +205,7 @@ export class RunCommandDetector {
             const info: RunCommandInfo | null = result?.result?.value ?? null;
 
             if (info) {
-                this.emptyPollCount = 0;
+                this.emptyPollGate.recordDetection();
                 // Duplicate prevention: use commandText as key
                 const key = `${info.commandText}::${info.workingDirectory}`;
                 if (key !== this.lastDetectedKey) {
@@ -215,8 +214,7 @@ export class RunCommandDetector {
                     this.onRunCommandRequired(info);
                 }
             } else {
-                this.emptyPollCount++;
-                if (this.emptyPollCount >= RunCommandDetector.REQUIRED_EMPTY_POLLS) {
+                if (this.emptyPollGate.recordEmptyPoll()) {
                     const wasDetected = this.lastDetectedKey !== null;
                     this.lastDetectedKey = null;
                     this.lastDetectedInfo = null;

--- a/src/services/runCommandDetector.ts
+++ b/src/services/runCommandDetector.ts
@@ -47,7 +47,7 @@ export interface RunCommandDetectorOptions {
  */
 const DETECT_RUN_COMMAND_SCRIPT = `(() => {
     const RUN_COMMAND_HEADER_PATTERNS = [
-        'run command?', 'run command', 'execute command',
+        'run command?', 'run command', 'execute command', 'command execution',
         'コマンドを実行', 'コマンド実行'
     ];
     const RUN_PATTERNS = ['run', 'accept', '実行', 'execute'];
@@ -135,8 +135,12 @@ export class RunCommandDetector {
     private isRunning: boolean = false;
     /** Key of the last detected dialog (for duplicate notification prevention) */
     private lastDetectedKey: string | null = null;
-    /** Full RunCommandInfo from the last detection (used for clicking) */
+    /** Full RunCommandInfo from the last detection */
     private lastDetectedInfo: RunCommandInfo | null = null;
+    /** Number of consecutive polls without detecting buttons */
+    private emptyPollCount: number = 0;
+    /** Number of consecutive empty polls required before resetting state */
+    private static readonly REQUIRED_EMPTY_POLLS = 3;
 
     constructor(options: RunCommandDetectorOptions) {
         this.cdpService = options.cdpService;
@@ -151,6 +155,7 @@ export class RunCommandDetector {
         this.isRunning = true;
         this.lastDetectedKey = null;
         this.lastDetectedInfo = null;
+        this.emptyPollCount = 0;
         this.schedulePoll();
     }
 
@@ -201,6 +206,7 @@ export class RunCommandDetector {
             const info: RunCommandInfo | null = result?.result?.value ?? null;
 
             if (info) {
+                this.emptyPollCount = 0;
                 // Duplicate prevention: use commandText as key
                 const key = `${info.commandText}::${info.workingDirectory}`;
                 if (key !== this.lastDetectedKey) {
@@ -209,11 +215,14 @@ export class RunCommandDetector {
                     this.onRunCommandRequired(info);
                 }
             } else {
-                const wasDetected = this.lastDetectedKey !== null;
-                this.lastDetectedKey = null;
-                this.lastDetectedInfo = null;
-                if (wasDetected && this.onResolved) {
-                    this.onResolved();
+                this.emptyPollCount++;
+                if (this.emptyPollCount >= RunCommandDetector.REQUIRED_EMPTY_POLLS) {
+                    const wasDetected = this.lastDetectedKey !== null;
+                    this.lastDetectedKey = null;
+                    this.lastDetectedInfo = null;
+                    if (wasDetected && this.onResolved) {
+                        this.onResolved();
+                    }
                 }
             }
         } catch (error) {

--- a/src/ui/artifactsUi.ts
+++ b/src/ui/artifactsUi.ts
@@ -14,6 +14,7 @@ import {
     StringSelectMenuBuilder,
     MessageFlags,
 } from 'discord.js';
+import * as path from 'path';
 import { UserPreferenceRepository } from '../database/userPreferenceRepository';
 import { ChatSessionRepository } from '../database/chatSessionRepository';
 
@@ -197,14 +198,17 @@ export async function sendArtifactPickerUI(
             // Fallback to title matching if ID is not in DB or doesn't match a real folder
             if (!conversationId || !artifactService.listArtifacts(conversationId).length) {
                 const sessionTitle = session.displayName?.trim() ?? '';
-                const matchedId = sessionTitle ? artifactService.findConversationByTitle(sessionTitle) : null;
+                let workspaceDirName: string | undefined;
+                if (session.workspacePath) {
+                    workspaceDirName = path.basename(session.workspacePath);
+                }
+                const matchedId = sessionTitle ? artifactService.findConversationByTitle(sessionTitle, workspaceDirName) : null;
                 if (matchedId) conversationId = matchedId;
             }
             // Note: We do NOT fallback to getLatestConversationWithArtifacts() for managed sessions
             // to avoid showing artifacts from other projects/chats.
         } else {
-            // Final fallback: latest overall (only for non-session channels)
-            conversationId = artifactService.getLatestConversationWithArtifacts();
+            conversationId = null;
         }
     }
 

--- a/src/utils/consecutiveEmptyPollGate.ts
+++ b/src/utils/consecutiveEmptyPollGate.ts
@@ -1,0 +1,18 @@
+export class ConsecutiveEmptyPollGate {
+    private count: number = 0;
+    
+    constructor(private readonly requiredEmptyPolls: number = 3) {}
+    
+    recordDetection(): void {
+        this.count = 0;
+    }
+    
+    recordEmptyPoll(): boolean {
+        this.count++;
+        return this.count >= this.requiredEmptyPolls;
+    }
+    
+    reset(): void {
+        this.count = 0;
+    }
+}

--- a/src/utils/htmlToDiscordMarkdown.ts
+++ b/src/utils/htmlToDiscordMarkdown.ts
@@ -54,7 +54,7 @@ export function htmlToDiscordMarkdown(html: string): string {
     
     // First, Antigravity 2.0 wrapped code blocks
     result = result.replace(
-        /<div[^>]*class="[^"]*code-block[^"]*"[^>]*>[\s\S]*?<div[^>]*class="[^"]*code-header[^"]*"[^>]*>([\s\S]*?)<\/div>[\s\S]*?<pre[^>]*>\s*<code[^>]*>([\s\S]*?)<\/code>\s*<\/pre>[\s\S]*?<\/div>/gi,
+        /<div[^>]*class="[^"]*code-block[^"]*"[^>]*>(?:(?!<div[^>]*class="[^"]*code-block[^"]*"[^>]*>)[\s\S])*?<div[^>]*class="[^"]*code-header[^"]*"[^>]*>([\s\S]*?)<\/div>(?:(?!<div[^>]*class="[^"]*code-block[^"]*"[^>]*>)[\s\S])*?<pre[^>]*>\s*<code[^>]*>([\s\S]*?)<\/code>\s*<\/pre>(?:(?!<div[^>]*class="[^"]*code-block[^"]*"[^>]*>)[\s\S])*?<\/div>/gi,
         (_m, lang, content) => `\n\`\`\`${stripTags(lang).trim()}\n${content}\n\`\`\`\n`
     );
 

--- a/src/utils/htmlToDiscordMarkdown.ts
+++ b/src/utils/htmlToDiscordMarkdown.ts
@@ -51,6 +51,14 @@ export function htmlToDiscordMarkdown(html: string): string {
     // Extract language from class="language-xxx" if present.
     // Do NOT decode entities here — let the final decodeEntities() handle them
     // after stripTags() has run, to avoid decoded < > being stripped as tags.
+    
+    // First, Antigravity 2.0 wrapped code blocks
+    result = result.replace(
+        /<div[^>]*class="[^"]*code-block[^"]*"[^>]*>[\s\S]*?<div[^>]*class="[^"]*code-header[^"]*"[^>]*>([\s\S]*?)<\/div>[\s\S]*?<pre[^>]*>\s*<code[^>]*>([\s\S]*?)<\/code>\s*<\/pre>[\s\S]*?<\/div>/gi,
+        (_m, lang, content) => `\n\`\`\`${stripTags(lang).trim()}\n${content}\n\`\`\`\n`
+    );
+
+    // Standard <pre><code> blocks
     result = result.replace(
         /<pre[^>]*>\s*<code(?:\s+class="language-([^"]*)")?[^>]*>([\s\S]*?)<\/code>\s*<\/pre>/gi,
         (_m, lang, content) => `\n\`\`\`${lang || ''}\n${content}\n\`\`\`\n`,
@@ -74,9 +82,9 @@ export function htmlToDiscordMarkdown(html: string): string {
         '*$1*',
     );
 
-    // Handle <span class="context-scope-mention"> → `text`
+    // Handle <span class="context-scope-mention"> or <span class="file-chip"> → `text`
     result = result.replace(
-        /<span[^>]*class="[^"]*context-scope-mention[^"]*"[^>]*>([\s\S]*?)<\/span>/gi,
+        /<span[^>]*class="[^"]*(?:context-scope-mention|file-chip)[^"]*"[^>]*>([\s\S]*?)<\/span>/gi,
         (_m, text) => `\`${stripTags(text).trim()}\``,
     );
 

--- a/tests/bot/telegramMessageHandler.test.ts
+++ b/tests/bot/telegramMessageHandler.test.ts
@@ -23,6 +23,7 @@ jest.mock('../../src/services/cdpBridgeManager', () => ({
     ensureErrorPopupDetector: jest.fn(),
     ensurePlanningDetector: jest.fn(),
     ensureRunCommandDetector: jest.fn(),
+    ensureQuestionDetector: jest.fn(),
     getCurrentCdp: jest.fn().mockReturnValue(null),
 }));
 
@@ -377,6 +378,7 @@ describe('createTelegramMessageHandler', () => {
             ensureErrorPopupDetector,
             ensurePlanningDetector,
             ensureRunCommandDetector,
+            ensureQuestionDetector,
         } = jest.requireMock('../../src/services/cdpBridgeManager');
 
         const mockCdp = createMockCdp();
@@ -398,6 +400,7 @@ describe('createTelegramMessageHandler', () => {
         expect(ensureErrorPopupDetector).toHaveBeenCalledWith(bridge, mockCdp, 'test-project', 'default');
         expect(ensurePlanningDetector).toHaveBeenCalledWith(bridge, mockCdp, 'test-project', 'default');
         expect(ensureRunCommandDetector).toHaveBeenCalledWith(bridge, mockCdp, 'test-project', 'default');
+        expect(ensureQuestionDetector).toHaveBeenCalledWith(bridge, mockCdp, 'test-project', 'default');
     });
 
     it('sets lastActiveWorkspace and lastActiveChannel on bridge', async () => {

--- a/tests/events/interactionCreateHandler.errorPopup.test.ts
+++ b/tests/events/interactionCreateHandler.errorPopup.test.ts
@@ -34,6 +34,7 @@ describe('interactionCreateHandler - error popup buttons', () => {
             getCurrentCdp: jest.fn(),
             parseApprovalCustomId: jest.fn().mockReturnValue(null),
             parseErrorPopupCustomId: jest.fn().mockReturnValue(null),
+            parseFileChangeCustomId: jest.fn().mockReturnValue(null),
             parsePlanningCustomId: jest.fn().mockReturnValue(null),
             parseRunCommandCustomId: jest.fn().mockReturnValue(null),
             handleSlashInteraction: jest.fn(),

--- a/tests/events/interactionCreateHandler.planning.test.ts
+++ b/tests/events/interactionCreateHandler.planning.test.ts
@@ -34,6 +34,7 @@ describe('interactionCreateHandler - planning buttons', () => {
             parseApprovalCustomId: jest.fn().mockReturnValue(null),
             parseErrorPopupCustomId: jest.fn().mockReturnValue(null),
             parsePlanningCustomId: jest.fn().mockReturnValue(null),
+            parseFileChangeCustomId: jest.fn().mockReturnValue(null),
             parseRunCommandCustomId: jest.fn().mockReturnValue(null),
             handleSlashInteraction: jest.fn(),
             ...overrides,
@@ -243,6 +244,80 @@ describe('interactionCreateHandler - planning buttons', () => {
                         }),
                     }),
                 ]),
+            }),
+        );
+    });
+
+    it('handles Reject button: disallows rejection and replies with ephemeral warning', async () => {
+        const reply = jest.fn().mockResolvedValue(undefined);
+
+        const planDetector = {
+            clickRejectButton: jest.fn().mockResolvedValue(true),
+        };
+
+        const interaction = {
+            isAutocomplete: () => false,
+            isButton: () => true,
+            user: { id: 'allowed' },
+            customId: 'planning_reject_action:ws-a:channel-a',
+            channelId: 'channel-a',
+            reply,
+            channel: { send: jest.fn() },
+            message: {
+                embeds: [{
+                    title: 'Planning Mode',
+                    description: 'Test',
+                    color: 0x3498DB,
+                }],
+                components: [{
+                    components: [
+                        {
+                            type: 2,
+                            data: { type: 2 },
+                            toJSON: () => ({
+                                type: 2,
+                                style: 1,
+                                label: 'Proceed',
+                                custom_id: 'planning_proceed_action:ws-a:channel-a',
+                            }),
+                        },
+                        {
+                            type: 2,
+                            data: { type: 2 },
+                            toJSON: () => ({
+                                type: 2,
+                                style: 4,
+                                label: 'Reject',
+                                custom_id: 'planning_reject_action:ws-a:channel-a',
+                            }),
+                        },
+                    ],
+                }],
+            },
+        } as any;
+
+        const handler = createInteractionCreateHandler(createBaseDeps({
+            parsePlanningCustomId: jest.fn().mockReturnValue({
+                action: 'reject',
+                projectName: 'ws-a',
+                channelId: 'channel-a',
+            }),
+            bridge: {
+                pool: {
+                    getApprovalDetector: jest.fn(),
+                    getPlanningDetector: jest.fn().mockReturnValue(planDetector),
+                },
+                lastActiveWorkspace: null,
+            } as any,
+        }));
+
+        await handler(interaction);
+
+        expect(planDetector.clickRejectButton).not.toHaveBeenCalled();
+        expect(reply).toHaveBeenCalledWith(
+            expect.objectContaining({
+                content: 'Rejection of a plan is not allowed.',
+                flags: expect.any(Number),
             }),
         );
     });

--- a/tests/events/interactionCreateHandler.test.ts
+++ b/tests/events/interactionCreateHandler.test.ts
@@ -28,6 +28,7 @@ describe('interactionCreateHandler', () => {
             parseApprovalCustomId: jest.fn(),
             parseErrorPopupCustomId: jest.fn().mockReturnValue(null),
             parsePlanningCustomId: jest.fn().mockReturnValue(null),
+            parseFileChangeCustomId: jest.fn().mockReturnValue(null),
             parseRunCommandCustomId: jest.fn().mockReturnValue(null),
             handleSlashInteraction: jest.fn(),
         });
@@ -82,6 +83,7 @@ describe('interactionCreateHandler', () => {
             }),
             parseErrorPopupCustomId: jest.fn().mockReturnValue(null),
             parsePlanningCustomId: jest.fn().mockReturnValue(null),
+            parseFileChangeCustomId: jest.fn().mockReturnValue(null),
             parseRunCommandCustomId: jest.fn().mockReturnValue(null),
             handleSlashInteraction: jest.fn(),
         });
@@ -132,6 +134,7 @@ describe('interactionCreateHandler', () => {
             parseApprovalCustomId: jest.fn().mockReturnValue(null),
             parseErrorPopupCustomId: jest.fn().mockReturnValue(null),
             parsePlanningCustomId: jest.fn().mockReturnValue(null),
+            parseFileChangeCustomId: jest.fn().mockReturnValue(null),
             parseRunCommandCustomId: jest.fn().mockReturnValue(null),
             handleSlashInteraction: jest.fn(),
         });
@@ -144,6 +147,55 @@ describe('interactionCreateHandler', () => {
         expect(followUp).toHaveBeenCalledWith(
             expect.objectContaining({ content: 'ok', flags: 64 }),
         );
+    });
+
+    it('handles generic action_btn_ by injecting into CDP', async () => {
+        const deferUpdate = jest.fn().mockResolvedValue(undefined);
+        const cdp = {
+            injectMessage: jest.fn().mockResolvedValue({ ok: true }),
+        };
+        const interaction = {
+            isAutocomplete: () => false,
+            isButton: () => true,
+            isStringSelectMenu: () => false,
+            isChatInputCommand: () => false,
+            user: { id: 'allowed' },
+            customId: 'action_btn_proceed',
+            channelId: 'channel-x',
+            deferUpdate,
+        } as any;
+
+        const handler = createInteractionCreateHandler({
+            config: { allowedUserIds: ['allowed'] },
+            bridge: {
+                pool: {
+                    getConnected: jest.fn().mockReturnValue(cdp),
+                },
+            } as any,
+            cleanupHandler: {} as any,
+            modeService: {} as any,
+            modelService: {} as any,
+            slashCommandHandler: {} as any,
+            wsHandler: {} as any,
+            chatHandler: {} as any,
+            client: {} as any,
+            sendModeUI: jest.fn(),
+            sendModelsUI: jest.fn(),
+            sendAutoAcceptUI: jest.fn(),
+            handleScreenshot: jest.fn(),
+            getCurrentCdp: jest.fn().mockResolvedValue(cdp),
+            parseApprovalCustomId: jest.fn().mockReturnValue(null),
+            parseErrorPopupCustomId: jest.fn().mockReturnValue(null),
+            parsePlanningCustomId: jest.fn().mockReturnValue(null),
+            parseFileChangeCustomId: jest.fn().mockReturnValue(null),
+            parseRunCommandCustomId: jest.fn().mockReturnValue(null),
+            handleSlashInteraction: jest.fn(),
+        });
+
+        await handler(interaction);
+
+        expect(deferUpdate).toHaveBeenCalled();
+        expect(cdp.injectMessage).toHaveBeenCalledWith('Proceed');
     });
 
     it('handles account dropdown selection and persists global/channel account choice for non-session channels', async () => {
@@ -189,6 +241,7 @@ describe('interactionCreateHandler', () => {
             parseApprovalCustomId: jest.fn().mockReturnValue(null),
             parseErrorPopupCustomId: jest.fn().mockReturnValue(null),
             parsePlanningCustomId: jest.fn().mockReturnValue(null),
+            parseFileChangeCustomId: jest.fn().mockReturnValue(null),
             parseRunCommandCustomId: jest.fn().mockReturnValue(null),
             handleSlashInteraction: jest.fn(),
             accountPrefRepo: accountPrefRepo as any,
@@ -256,6 +309,7 @@ describe('interactionCreateHandler', () => {
             parseApprovalCustomId: jest.fn().mockReturnValue(null),
             parseErrorPopupCustomId: jest.fn().mockReturnValue(null),
             parsePlanningCustomId: jest.fn().mockReturnValue(null),
+            parseFileChangeCustomId: jest.fn().mockReturnValue(null),
             parseRunCommandCustomId: jest.fn().mockReturnValue(null),
             handleSlashInteraction: jest.fn(),
             accountPrefRepo: accountPrefRepo as any,

--- a/tests/events/messageCreateHandler.test.ts
+++ b/tests/events/messageCreateHandler.test.ts
@@ -42,6 +42,7 @@ function buildDeps(overrides: Record<string, any> = {}) {
         ensureErrorPopupDetector: jest.fn(),
         ensurePlanningDetector: jest.fn(),
         ensureRunCommandDetector: jest.fn(),
+        ensureQuestionDetector: jest.fn(),
         registerApprovalWorkspaceChannel: jest.fn(),
         registerApprovalSessionChannel: jest.fn(),
         downloadInboundImageAttachments: jest.fn().mockResolvedValue([]),
@@ -371,6 +372,35 @@ describe('messageCreateHandler', () => {
         expect(updateDisplayName).not.toHaveBeenCalled();
         expect(sendPromptToAntigravity).not.toHaveBeenCalled();
         expect(reply).toHaveBeenCalled();
+    });
+
+    it('prepends replied-to message context', async () => {
+        const sendPromptToAntigravity = mockSendPromptImmediate();
+        const handler = createMessageCreateHandler(buildDeps({ sendPromptToAntigravity }));
+
+        const repliedToMsg = {
+            author: { username: 'someone' },
+            content: 'Original message text',
+        };
+        const fetch = jest.fn().mockResolvedValue(repliedToMsg);
+        
+        await handler(buildMessage({
+            content: 'My reply',
+            reference: { messageId: '123' },
+            channel: { messages: { fetch } },
+        }));
+
+        expect(fetch).toHaveBeenCalledWith('123');
+        expect(sendPromptToAntigravity).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.anything(),
+            '[Replying to context: "Original message text"]\n\nMy reply',
+            expect.anything(),
+            expect.anything(),
+            expect.anything(),
+            expect.anything(),
+            expect.anything(),
+        );
     });
 
     describe('workspace prompt queue', () => {

--- a/tests/fixtures/antigravity-2/plan_approval_flow.html
+++ b/tests/fixtures/antigravity-2/plan_approval_flow.html
@@ -1,0 +1,32 @@
+<div class="antigravity-agent-side-panel">
+    <!-- Plan card -->
+    <div class="plan-summary-card" data-testid="plan-card">
+        <div class="font-bold">Implementation Plan</div>
+        <div class="text-sm">We will extract the DOM nodes...</div>
+    </div>
+    
+    <!-- Actions -->
+    <div class="actions-container">
+        <button class="btn-open">Open</button>
+        <button class="btn-proceed">Proceed</button>
+    </div>
+    
+    <!-- File edits summary -->
+    <div class="file-edits">
+        <div class="file-edit-item">
+            <span class="file-path" title="src/services/assistantDomExtractor.ts">src/services/assistantDomExtractor.ts</span>
+            <span class="edit-type">Modified</span>
+        </div>
+    </div>
+    
+    <!-- Progress / Activity -->
+    <div class="flex flex-row">
+        <span>Analyzed src/utils/htmlToDiscordMarkdown.ts</span>
+    </div>
+    
+    <!-- Final Output -->
+    <article class="prose rendered-markdown" data-message-role="assistant">
+        <p>The implementation plan is ready for review.</p>
+        <p>Please click <strong>Proceed</strong> to continue.</p>
+    </article>
+</div>

--- a/tests/handlers/approvalButtonAction.test.ts
+++ b/tests/handlers/approvalButtonAction.test.ts
@@ -72,7 +72,7 @@ describe('createApprovalButtonAction', () => {
     describe('match', () => {
         it('matches approve_action customId', () => {
             const bridge = makeBridge();
-            const action = createApprovalButtonAction({ bridge });
+            const action = createApprovalButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const result = action.match('approve_action:myProject:ch-1');
             expect(result).toEqual({
                 action: 'approve',
@@ -83,7 +83,7 @@ describe('createApprovalButtonAction', () => {
 
         it('matches always_allow_action customId', () => {
             const bridge = makeBridge();
-            const action = createApprovalButtonAction({ bridge });
+            const action = createApprovalButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const result = action.match('always_allow_action:proj');
             expect(result).toEqual({
                 action: 'always_allow',
@@ -94,7 +94,7 @@ describe('createApprovalButtonAction', () => {
 
         it('matches deny_action customId', () => {
             const bridge = makeBridge();
-            const action = createApprovalButtonAction({ bridge });
+            const action = createApprovalButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const result = action.match('deny_action:proj:ch-2');
             expect(result).toEqual({
                 action: 'deny',
@@ -105,7 +105,7 @@ describe('createApprovalButtonAction', () => {
 
         it('returns null for unrelated customId', () => {
             const bridge = makeBridge();
-            const action = createApprovalButtonAction({ bridge });
+            const action = createApprovalButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             expect(action.match('planning_open_action:proj')).toBeNull();
             expect(action.match('random_button')).toBeNull();
         });
@@ -117,7 +117,7 @@ describe('createApprovalButtonAction', () => {
             const bridge = makeBridge();
             (bridge.pool.getApprovalDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createApprovalButtonAction({ bridge });
+            const action = createApprovalButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction({ customId: 'approve_action:myProject:ch-1' });
 
             await action.execute(interaction, {
@@ -138,7 +138,7 @@ describe('createApprovalButtonAction', () => {
             const bridge = makeBridge();
             (bridge.pool.getApprovalDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createApprovalButtonAction({ bridge });
+            const action = createApprovalButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -159,7 +159,7 @@ describe('createApprovalButtonAction', () => {
             const bridge = makeBridge();
             (bridge.pool.getApprovalDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createApprovalButtonAction({ bridge });
+            const action = createApprovalButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -179,7 +179,7 @@ describe('createApprovalButtonAction', () => {
             const bridge = makeBridge();
             (bridge.pool.getApprovalDetector as jest.Mock).mockReturnValue(undefined);
 
-            const action = createApprovalButtonAction({ bridge });
+            const action = createApprovalButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -198,7 +198,7 @@ describe('createApprovalButtonAction', () => {
             const bridge = makeBridge();
             (bridge.pool.getApprovalDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createApprovalButtonAction({ bridge });
+            const action = createApprovalButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -214,7 +214,7 @@ describe('createApprovalButtonAction', () => {
 
         it('rejects interaction from wrong channel', async () => {
             const bridge = makeBridge();
-            const action = createApprovalButtonAction({ bridge });
+            const action = createApprovalButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction({
                 channel: makeChannel({ id: 'ch-other' }),
             });
@@ -230,12 +230,13 @@ describe('createApprovalButtonAction', () => {
             });
         });
 
-        it('falls back to lastActiveWorkspace when projectName is empty', async () => {
+        it('falls back to wsHandler when projectName is empty', async () => {
             const mockDetector = { approveButton: jest.fn().mockResolvedValue(true), getLastDetectedInfo: jest.fn().mockReturnValue(null) };
-            const bridge = makeBridge({ lastActiveWorkspace: 'fallbackProject' });
+            const bridge = makeBridge();
             (bridge.pool.getApprovalDetector as jest.Mock).mockReturnValue(mockDetector);
+            bridge.pool.extractProjectName = jest.fn().mockReturnValue('fallbackProject');
 
-            const action = createApprovalButtonAction({ bridge });
+            const action = createApprovalButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn().mockReturnValue('/path/to/ws') } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {

--- a/tests/handlers/errorPopupButtonAction.test.ts
+++ b/tests/handlers/errorPopupButtonAction.test.ts
@@ -72,7 +72,7 @@ describe('createErrorPopupButtonAction', () => {
     describe('match', () => {
         it('matches error_popup_dismiss_action customId', () => {
             const bridge = makeBridge();
-            const action = createErrorPopupButtonAction({ bridge });
+            const action = createErrorPopupButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const result = action.match('error_popup_dismiss_action:proj:ch-1');
             expect(result).toEqual({
                 action: 'dismiss',
@@ -83,7 +83,7 @@ describe('createErrorPopupButtonAction', () => {
 
         it('matches error_popup_copy_debug_action customId', () => {
             const bridge = makeBridge();
-            const action = createErrorPopupButtonAction({ bridge });
+            const action = createErrorPopupButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const result = action.match('error_popup_copy_debug_action:proj');
             expect(result).toEqual({
                 action: 'copy_debug',
@@ -94,7 +94,7 @@ describe('createErrorPopupButtonAction', () => {
 
         it('matches error_popup_retry_action customId', () => {
             const bridge = makeBridge();
-            const action = createErrorPopupButtonAction({ bridge });
+            const action = createErrorPopupButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const result = action.match('error_popup_retry_action:proj:ch-2');
             expect(result).toEqual({
                 action: 'retry',
@@ -105,7 +105,7 @@ describe('createErrorPopupButtonAction', () => {
 
         it('returns null for unrelated customId', () => {
             const bridge = makeBridge();
-            const action = createErrorPopupButtonAction({ bridge });
+            const action = createErrorPopupButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             expect(action.match('approve_action:proj')).toBeNull();
             expect(action.match('random')).toBeNull();
         });
@@ -117,7 +117,7 @@ describe('createErrorPopupButtonAction', () => {
             const bridge = makeBridge();
             (bridge.pool.getErrorPopupDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createErrorPopupButtonAction({ bridge });
+            const action = createErrorPopupButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -138,7 +138,7 @@ describe('createErrorPopupButtonAction', () => {
             const bridge = makeBridge();
             (bridge.pool.getErrorPopupDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createErrorPopupButtonAction({ bridge });
+            const action = createErrorPopupButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -162,7 +162,7 @@ describe('createErrorPopupButtonAction', () => {
             const bridge = makeBridge();
             (bridge.pool.getErrorPopupDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createErrorPopupButtonAction({ bridge });
+            const action = createErrorPopupButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -191,7 +191,7 @@ describe('createErrorPopupButtonAction', () => {
             const bridge = makeBridge();
             (bridge.pool.getErrorPopupDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createErrorPopupButtonAction({ bridge });
+            const action = createErrorPopupButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -212,7 +212,7 @@ describe('createErrorPopupButtonAction', () => {
             const bridge = makeBridge();
             (bridge.pool.getErrorPopupDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createErrorPopupButtonAction({ bridge });
+            const action = createErrorPopupButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -234,7 +234,7 @@ describe('createErrorPopupButtonAction', () => {
             const bridge = makeBridge();
             (bridge.pool.getErrorPopupDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createErrorPopupButtonAction({ bridge });
+            const action = createErrorPopupButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -255,7 +255,7 @@ describe('createErrorPopupButtonAction', () => {
             const bridge = makeBridge();
             (bridge.pool.getErrorPopupDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createErrorPopupButtonAction({ bridge });
+            const action = createErrorPopupButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -276,7 +276,7 @@ describe('createErrorPopupButtonAction', () => {
             const bridge = makeBridge();
             (bridge.pool.getErrorPopupDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createErrorPopupButtonAction({ bridge });
+            const action = createErrorPopupButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -296,7 +296,7 @@ describe('createErrorPopupButtonAction', () => {
             const bridge = makeBridge();
             (bridge.pool.getErrorPopupDetector as jest.Mock).mockReturnValue(undefined);
 
-            const action = createErrorPopupButtonAction({ bridge });
+            const action = createErrorPopupButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -312,7 +312,7 @@ describe('createErrorPopupButtonAction', () => {
 
         it('rejects interaction from wrong channel', async () => {
             const bridge = makeBridge();
-            const action = createErrorPopupButtonAction({ bridge });
+            const action = createErrorPopupButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction({
                 channel: makeChannel({ id: 'ch-other' }),
             });
@@ -328,12 +328,13 @@ describe('createErrorPopupButtonAction', () => {
             });
         });
 
-        it('falls back to lastActiveWorkspace when projectName is empty', async () => {
+        it('falls back to wsHandler when projectName is empty', async () => {
             const mockDetector = { clickRetryButton: jest.fn().mockResolvedValue(true) };
-            const bridge = makeBridge({ lastActiveWorkspace: 'fallbackWs' });
+            const bridge = makeBridge();
             (bridge.pool.getErrorPopupDetector as jest.Mock).mockReturnValue(mockDetector);
+            bridge.pool.extractProjectName = jest.fn().mockReturnValue('fallbackWs');
 
-            const action = createErrorPopupButtonAction({ bridge });
+            const action = createErrorPopupButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn().mockReturnValue('/path/to/ws') } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {

--- a/tests/handlers/genericActionButtonAction.test.ts
+++ b/tests/handlers/genericActionButtonAction.test.ts
@@ -1,0 +1,92 @@
+import { createGenericActionButtonAction } from '../../src/handlers/genericActionButtonAction';
+import type { CdpBridge } from '../../src/services/cdpBridgeManager';
+import { getCurrentCdp } from '../../src/services/cdpBridgeManager';
+import { CdpService } from '../../src/services/cdpService';
+
+jest.mock('../../src/services/cdpBridgeManager');
+jest.mock('../../src/services/cdpService');
+
+describe('genericActionButtonAction', () => {
+    let mockBridge: jest.Mocked<CdpBridge>;
+    let mockCdp: jest.Mocked<CdpService>;
+
+    beforeEach(() => {
+        mockCdp = {} as any;
+        mockCdp.injectMessage = jest.fn().mockResolvedValue({ ok: true });
+
+        mockBridge = {} as any;
+        (getCurrentCdp as jest.Mock).mockReturnValue(mockCdp);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('matches customIds starting with action_btn_', () => {
+        const handler = createGenericActionButtonAction({ bridge: mockBridge });
+        expect(handler.match('action_btn_proceed')).toEqual({ actionName: 'Proceed' });
+        expect(handler.match('action_btn_review_plan')).toEqual({ actionName: 'Review plan' });
+        expect(handler.match('other_btn')).toBe(null);
+    });
+
+    it('injects formatted action name into CDP', async () => {
+        const handler = createGenericActionButtonAction({ bridge: mockBridge });
+        const deferUpdate = jest.fn().mockResolvedValue(undefined);
+        
+        await handler.execute({
+            customId: 'action_btn_review_plan',
+            channelId: 'ch-1',
+            userId: 'u-1',
+            message: {} as any,
+            deferUpdate,
+        } as any, { actionName: 'Review plan' });
+
+        expect(getCurrentCdp).toHaveBeenCalledWith(mockBridge);
+        expect(deferUpdate).toHaveBeenCalled();
+        expect(mockCdp.injectMessage).toHaveBeenCalledWith('Review plan');
+    });
+
+    it('shows error if CDP is not connected', async () => {
+        (getCurrentCdp as jest.Mock).mockReturnValue(null);
+        const handler = createGenericActionButtonAction({ bridge: mockBridge });
+        const deferUpdate = jest.fn().mockResolvedValue(undefined);
+        const followUp = jest.fn().mockResolvedValue(undefined);
+        
+        await handler.execute({
+            customId: 'action_btn_proceed',
+            channelId: 'ch-1',
+            userId: 'u-1',
+            message: {} as any,
+            deferUpdate,
+            followUp,
+        } as any, { actionName: 'Proceed' });
+
+        expect(mockCdp.injectMessage).not.toHaveBeenCalled();
+        expect(deferUpdate).toHaveBeenCalled();
+        expect(followUp).toHaveBeenCalledWith(expect.objectContaining({
+            text: expect.stringContaining('Not connected')
+        }));
+    });
+
+    it('shows error if injectMessage fails', async () => {
+        mockCdp.injectMessage = jest.fn().mockResolvedValue({ ok: false, error: 'DOM element not found' });
+        const handler = createGenericActionButtonAction({ bridge: mockBridge });
+        const deferUpdate = jest.fn().mockResolvedValue(undefined);
+        const followUp = jest.fn().mockResolvedValue(undefined);
+        
+        await handler.execute({
+            customId: 'action_btn_proceed',
+            channelId: 'ch-1',
+            userId: 'u-1',
+            message: {} as any,
+            deferUpdate,
+            followUp,
+        } as any, { actionName: 'Proceed' });
+
+        expect(deferUpdate).toHaveBeenCalled();
+        expect(mockCdp.injectMessage).toHaveBeenCalledWith('Proceed');
+        expect(followUp).toHaveBeenCalledWith(expect.objectContaining({
+            text: expect.stringContaining('DOM element not found')
+        }));
+    });
+});

--- a/tests/handlers/planningButtonAction.test.ts
+++ b/tests/handlers/planningButtonAction.test.ts
@@ -72,7 +72,7 @@ describe('createPlanningButtonAction', () => {
     describe('match', () => {
         it('matches planning_open_action customId', () => {
             const bridge = makeBridge();
-            const action = createPlanningButtonAction({ bridge });
+            const action = createPlanningButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const result = action.match('planning_open_action:proj:ch-1');
             expect(result).toEqual({
                 action: 'open',
@@ -83,7 +83,7 @@ describe('createPlanningButtonAction', () => {
 
         it('matches planning_proceed_action customId', () => {
             const bridge = makeBridge();
-            const action = createPlanningButtonAction({ bridge });
+            const action = createPlanningButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const result = action.match('planning_proceed_action:proj');
             expect(result).toEqual({
                 action: 'proceed',
@@ -94,7 +94,7 @@ describe('createPlanningButtonAction', () => {
 
         it('returns null for unrelated customId', () => {
             const bridge = makeBridge();
-            const action = createPlanningButtonAction({ bridge });
+            const action = createPlanningButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             expect(action.match('approve_action:proj')).toBeNull();
             expect(action.match('random')).toBeNull();
         });
@@ -105,11 +105,12 @@ describe('createPlanningButtonAction', () => {
             const mockDetector = {
                 clickOpenButton: jest.fn().mockResolvedValue(true),
                 extractPlanContent: jest.fn().mockResolvedValue('Plan details here'),
+                getLastDetectedInfo: jest.fn().mockReturnValue({ hasOpenButton: true }),
             };
             const bridge = makeBridge();
             (bridge.pool.getPlanningDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createPlanningButtonAction({ bridge });
+            const action = createPlanningButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -134,11 +135,12 @@ describe('createPlanningButtonAction', () => {
             const mockDetector = {
                 clickOpenButton: jest.fn().mockResolvedValue(true),
                 extractPlanContent: jest.fn().mockResolvedValue(longContent),
+                getLastDetectedInfo: jest.fn().mockReturnValue({ hasOpenButton: true }),
             };
             const bridge = makeBridge();
             (bridge.pool.getPlanningDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createPlanningButtonAction({ bridge });
+            const action = createPlanningButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -155,11 +157,13 @@ describe('createPlanningButtonAction', () => {
         it('replies with error when open button not found', async () => {
             const mockDetector = {
                 clickOpenButton: jest.fn().mockResolvedValue(false),
+                extractPlanContent: jest.fn().mockResolvedValue(null),
+                getLastDetectedInfo: jest.fn().mockReturnValue({ hasOpenButton: true }),
             };
             const bridge = makeBridge();
             (bridge.pool.getPlanningDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createPlanningButtonAction({ bridge });
+            const action = createPlanningButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -169,7 +173,7 @@ describe('createPlanningButtonAction', () => {
             });
 
             expect(interaction.reply).toHaveBeenCalledWith({
-                text: 'Open button not found.',
+                text: 'Plan content could not be extracted from the IDE.',
             });
         });
 
@@ -177,11 +181,12 @@ describe('createPlanningButtonAction', () => {
             const mockDetector = {
                 clickOpenButton: jest.fn().mockResolvedValue(true),
                 extractPlanContent: jest.fn().mockResolvedValue(null),
+                getLastDetectedInfo: jest.fn().mockReturnValue({ hasOpenButton: true }),
             };
             const bridge = makeBridge();
             (bridge.pool.getPlanningDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createPlanningButtonAction({ bridge });
+            const action = createPlanningButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -204,7 +209,7 @@ describe('createPlanningButtonAction', () => {
             const bridge = makeBridge();
             (bridge.pool.getPlanningDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createPlanningButtonAction({ bridge });
+            const action = createPlanningButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -227,7 +232,7 @@ describe('createPlanningButtonAction', () => {
             const bridge = makeBridge();
             (bridge.pool.getPlanningDetector as jest.Mock).mockReturnValue(mockDetector);
 
-            const action = createPlanningButtonAction({ bridge });
+            const action = createPlanningButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -242,12 +247,36 @@ describe('createPlanningButtonAction', () => {
         });
     });
 
+    describe('execute - reject', () => {
+        it('does not allow plan rejection and replies with error message', async () => {
+            const mockDetector = {
+                clickRejectButton: jest.fn().mockResolvedValue(true),
+            };
+            const bridge = makeBridge();
+            (bridge.pool.getPlanningDetector as jest.Mock).mockReturnValue(mockDetector);
+
+            const action = createPlanningButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
+            const interaction = makeInteraction();
+
+            await action.execute(interaction, {
+                action: 'reject',
+                projectName: 'proj',
+                channelId: '',
+            });
+
+            expect(mockDetector.clickRejectButton).not.toHaveBeenCalled();
+            expect(interaction.reply).toHaveBeenCalledWith({
+                text: 'Rejection of the plan is not allowed.',
+            });
+        });
+    });
+
     describe('execute - shared', () => {
         it('replies with error when detector not found', async () => {
             const bridge = makeBridge();
             (bridge.pool.getPlanningDetector as jest.Mock).mockReturnValue(undefined);
 
-            const action = createPlanningButtonAction({ bridge });
+            const action = createPlanningButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {
@@ -263,7 +292,7 @@ describe('createPlanningButtonAction', () => {
 
         it('rejects interaction from wrong channel', async () => {
             const bridge = makeBridge();
-            const action = createPlanningButtonAction({ bridge });
+            const action = createPlanningButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn() } as any });
             const interaction = makeInteraction({
                 channel: makeChannel({ id: 'ch-other' }),
             });
@@ -279,14 +308,15 @@ describe('createPlanningButtonAction', () => {
             });
         });
 
-        it('falls back to lastActiveWorkspace when projectName is empty', async () => {
+        it('falls back to wsHandler when projectName is empty', async () => {
             const mockDetector = {
                 clickProceedButton: jest.fn().mockResolvedValue(true),
             };
-            const bridge = makeBridge({ lastActiveWorkspace: 'fallbackWs' });
+            const bridge = makeBridge();
             (bridge.pool.getPlanningDetector as jest.Mock).mockReturnValue(mockDetector);
+            bridge.pool.extractProjectName = jest.fn().mockReturnValue('fallbackWs');
 
-            const action = createPlanningButtonAction({ bridge });
+            const action = createPlanningButtonAction({ bridge, wsHandler: { getWorkspaceForChannel: jest.fn().mockReturnValue('/path/to/ws') } as any });
             const interaction = makeInteraction();
 
             await action.execute(interaction, {

--- a/tests/platform/discord/discordResponseRenderer.test.ts
+++ b/tests/platform/discord/discordResponseRenderer.test.ts
@@ -49,13 +49,13 @@ describe('discordResponseRenderer', () => {
         expect((output.embeds![1] as any).data.description).toBe('Plan: Do A then B.');
     });
 
-    it('renders action buttons in a component row', () => {
+    it('renders action buttons in a component row and formats customIds correctly', () => {
         const result: ClassifyResult = {
             finalOutputText: 'Ready.',
             activityLines: [],
             feedback: [],
             planCards: [],
-            actionButtons: ['Proceed', 'Open'],
+            actionButtons: ['Proceed', 'Open File', 'Review Code'],
             fileChanges: [],
             citations: [],
             fileChangesTexts: [],
@@ -65,9 +65,19 @@ describe('discordResponseRenderer', () => {
 
         const output = renderDiscordResponse(result);
         expect(output.components).toBeDefined();
-        expect((output.components![0] as any).components.length).toBe(2);
-        expect((output.components![0] as any).components[0].data.label).toBe('Proceed');
-        expect((output.components![0] as any).components[1].data.label).toBe('Open');
+        expect((output.components![0] as any).components.length).toBe(3);
+        
+        const btn1 = (output.components![0] as any).components[0].data;
+        expect(btn1.label).toBe('Proceed');
+        expect(btn1.custom_id).toBe('action_btn_proceed');
+        
+        const btn2 = (output.components![0] as any).components[1].data;
+        expect(btn2.label).toBe('Open File');
+        expect(btn2.custom_id).toBe('action_btn_open_file');
+
+        const btn3 = (output.components![0] as any).components[2].data;
+        expect(btn3.label).toBe('Review Code');
+        expect(btn3.custom_id).toBe('action_btn_review_code');
     });
 
     it('chunks very long descriptions', () => {

--- a/tests/platform/discord/discordResponseRenderer.test.ts
+++ b/tests/platform/discord/discordResponseRenderer.test.ts
@@ -1,0 +1,145 @@
+import { renderDiscordResponse } from '../../../src/platform/discord/discordResponseRenderer';
+import type { ClassifyResult } from '../../../src/services/assistantDomExtractor';
+
+describe('discordResponseRenderer', () => {
+    it('renders final output as a primary embed', () => {
+        const result: ClassifyResult = {
+            finalOutputText: 'This is the final answer.',
+            activityLines: [],
+            feedback: [],
+            planCards: [],
+            actionButtons: [],
+            fileChanges: [],
+            citations: [],
+            fileChangesTexts: [],
+            citedFiles: [],
+            diagnostics: {
+                source: 'dom-structured',
+                segmentCounts: {},
+                allFingerprints: [],
+                totalSegments: 1,
+            },
+        };
+
+        const output = renderDiscordResponse(result);
+        expect(output.embeds).toBeDefined();
+        expect(output.embeds!.length).toBe(1);
+        expect((output.embeds![0] as any).data.description).toBe('This is the final answer.');
+        expect(output.components).toBeUndefined();
+    });
+
+    it('renders plan cards as a separate embed', () => {
+        const result: ClassifyResult = {
+            finalOutputText: 'Done.',
+            activityLines: [],
+            feedback: [],
+            planCards: ['Plan: Do A then B.'],
+            actionButtons: [],
+            fileChanges: [],
+            citations: [],
+            fileChangesTexts: [],
+            citedFiles: [],
+            diagnostics: { source: 'dom-structured', segmentCounts: {}, allFingerprints: [], totalSegments: 1 },
+        };
+
+        const output = renderDiscordResponse(result);
+        expect(output.embeds!.length).toBe(2);
+        expect((output.embeds![0] as any).data.description).toBe('Done.');
+        expect((output.embeds![1] as any).data.title).toBe('Plan');
+        expect((output.embeds![1] as any).data.description).toBe('Plan: Do A then B.');
+    });
+
+    it('renders action buttons in a component row', () => {
+        const result: ClassifyResult = {
+            finalOutputText: 'Ready.',
+            activityLines: [],
+            feedback: [],
+            planCards: [],
+            actionButtons: ['Proceed', 'Open'],
+            fileChanges: [],
+            citations: [],
+            fileChangesTexts: [],
+            citedFiles: [],
+            diagnostics: { source: 'dom-structured', segmentCounts: {}, allFingerprints: [], totalSegments: 1 },
+        };
+
+        const output = renderDiscordResponse(result);
+        expect(output.components).toBeDefined();
+        expect((output.components![0] as any).components.length).toBe(2);
+        expect((output.components![0] as any).components[0].data.label).toBe('Proceed');
+        expect((output.components![0] as any).components[1].data.label).toBe('Open');
+    });
+
+    it('chunks very long descriptions', () => {
+        const longText = 'A'.repeat(5000);
+        const result: ClassifyResult = {
+            finalOutputText: longText,
+            activityLines: [],
+            feedback: [],
+            planCards: [],
+            actionButtons: [],
+            fileChanges: [],
+            citations: [],
+            fileChangesTexts: [],
+            citedFiles: [],
+            diagnostics: { source: 'dom-structured', segmentCounts: {}, allFingerprints: [], totalSegments: 1 },
+        };
+
+        const output = renderDiscordResponse(result);
+        // 5000 chars should be split into 2 embeds of 4000 and 1000 roughly
+        expect(output.embeds!.length).toBe(2);
+        expect((output.embeds![0] as any).data.description?.length).toBeLessThanOrEqual(4000);
+        expect((output.embeds![1] as any).data.description?.length).toBeGreaterThan(0);
+    });
+
+    it('renders file changes into embed fields', () => {
+        const result: ClassifyResult = {
+            finalOutputText: 'Edited files.',
+            activityLines: [],
+            feedback: [],
+            planCards: [],
+            actionButtons: [],
+            fileChanges: [
+                { path: 'src/a.ts', type: 'Modified' },
+                { path: 'src/b.ts', type: 'Modified' },
+            ],
+            citations: [],
+            fileChangesTexts: [],
+            citedFiles: [],
+            diagnostics: { source: 'dom-structured', segmentCounts: {}, allFingerprints: [], totalSegments: 1 },
+        };
+
+        const output = renderDiscordResponse(result);
+        const fileEmbed = output.embeds!.find(e => (e as any).data.title === 'File Changes');
+        expect(fileEmbed).toBeDefined();
+        expect((fileEmbed as any).data.fields).toBeDefined();
+        expect((fileEmbed as any).data.fields![0].value).toContain('src/a.ts');
+        expect((fileEmbed as any).data.fields![0].value).toContain('src/b.ts');
+    });
+
+    it('chunks file changes if there are too many for one field', () => {
+        const fileChanges = Array.from({ length: 50 }, (_, i) => ({
+            path: `src/file_${i}.ts`,
+            type: 'Modified',
+        }));
+        
+        const result: ClassifyResult = {
+            finalOutputText: 'Lots of files.',
+            activityLines: [],
+            feedback: [],
+            planCards: [],
+            actionButtons: [],
+            fileChanges,
+            citations: [],
+            fileChangesTexts: [],
+            citedFiles: [],
+            diagnostics: { source: 'dom-structured', segmentCounts: {}, allFingerprints: [], totalSegments: 1 },
+        };
+
+        const output = renderDiscordResponse(result);
+        const fileEmbed = output.embeds!.find(e => (e as any).data.title === 'File Changes');
+        expect(fileEmbed).toBeDefined();
+        // 50 files * ~30 chars each = 1500 chars -> should be split into 2 fields
+        expect((fileEmbed as any).data.fields!.length).toBeGreaterThan(1);
+    });
+});

--- a/tests/platform/discord/discordResponseRenderer.test.ts
+++ b/tests/platform/discord/discordResponseRenderer.test.ts
@@ -142,4 +142,52 @@ describe('discordResponseRenderer', () => {
         // 50 files * ~30 chars each = 1500 chars -> should be split into 2 fields
         expect((fileEmbed as any).data.fields!.length).toBeGreaterThan(1);
     });
+
+    it('chunks very long plan cards into multiple embeds', () => {
+        const longPlan = 'A'.repeat(5000);
+        const result: ClassifyResult = {
+            finalOutputText: 'Plan follows.',
+            activityLines: [],
+            feedback: [],
+            planCards: [longPlan],
+            actionButtons: [],
+            fileChanges: [],
+            citations: [],
+            fileChangesTexts: [],
+            citedFiles: [],
+            diagnostics: { source: 'dom-structured', segmentCounts: {}, allFingerprints: [], totalSegments: 1 },
+        };
+
+        const output = renderDiscordResponse(result);
+        const planEmbeds = output.embeds!.filter(e => (e as any).data.color === 0x5865f2);
+        expect(planEmbeds.length).toBe(2);
+        expect((planEmbeds[0] as any).data.title).toBe('Plan');
+        expect((planEmbeds[1] as any).data.title).toBeUndefined(); // Second part has no title
+        expect((planEmbeds[0] as any).data.description?.length).toBeLessThanOrEqual(4000);
+    });
+
+    it('handles a single oversized file change path', () => {
+        const longPath = 'src/' + 'a/'.repeat(500) + 'file.ts'; // ~1000+ chars
+        const result: ClassifyResult = {
+            finalOutputText: 'Long file.',
+            activityLines: [],
+            feedback: [],
+            planCards: [],
+            actionButtons: [],
+            fileChanges: [
+                { path: longPath, type: 'Modified' },
+            ],
+            citations: [],
+            fileChangesTexts: [],
+            citedFiles: [],
+            diagnostics: { source: 'dom-structured', segmentCounts: {}, allFingerprints: [], totalSegments: 1 },
+        };
+
+        const output = renderDiscordResponse(result);
+        const fileEmbed = output.embeds!.find(e => (e as any).data.title === 'File Changes');
+        expect(fileEmbed).toBeDefined();
+        // The oversized line should be split across multiple fields
+        expect((fileEmbed as any).data.fields!.length).toBeGreaterThan(1);
+        expect((fileEmbed as any).data.fields![0].value.length).toBeLessThanOrEqual(1000);
+    });
 });

--- a/tests/services/antigravityLauncher.test.ts
+++ b/tests/services/antigravityLauncher.test.ts
@@ -163,7 +163,6 @@ describe('Antigravity lifecycle', () => {
             }
         );
     }
-
     it('reports already stopped when the requested CDP port is unavailable', async () => {
         mockHttpErrorAlways();
 
@@ -208,7 +207,6 @@ describe('Antigravity lifecycle', () => {
         await expect(stopAntigravity(9222)).rejects.toThrow('Refusing to stop non-Antigravity');
         expect(execFile).not.toHaveBeenCalled();
     });
-
     it('stops the process when only User-Agent contains Antigravity', async () => {
         mockHttpSuccessOnce(9222);
         mockHttpSuccessOnce(9222, { Browser: 'Chrome/142.0.0.0', 'User-Agent': 'Mozilla/5.0 (...) Chrome/142.0.0.0 AntigravityIDE/2.0' });

--- a/tests/services/approvalDetector.test.ts
+++ b/tests/services/approvalDetector.test.ts
@@ -340,7 +340,7 @@ describe('ApprovalDetector - approval button detection and remote execution', ()
         await jest.advanceTimersByTimeAsync(500); // detection
         expect(detector.getLastDetectedInfo()).not.toBeNull();
 
-        await jest.advanceTimersByTimeAsync(500); // disappearance
+        await jest.advanceTimersByTimeAsync(1500); // disappearance
         expect(detector.getLastDetectedInfo()).toBeNull();
     });
 
@@ -452,7 +452,7 @@ describe('ApprovalDetector - approval button detection and remote execution', ()
         await jest.advanceTimersByTimeAsync(500); // detection
         expect(onResolved).not.toHaveBeenCalled();
 
-        await jest.advanceTimersByTimeAsync(500); // disappearance
+        await jest.advanceTimersByTimeAsync(1500); // disappearance
         expect(onResolved).toHaveBeenCalledTimes(1);
     });
 

--- a/tests/services/assistantDomExtractor.test.ts
+++ b/tests/services/assistantDomExtractor.test.ts
@@ -397,6 +397,27 @@ describe('assistantDomExtractor', () => {
             expect(result.citations).toEqual(['file:///C:/Workspace/test.py']);
         });
 
+        it('extracts fileChangesTexts correctly from a file-changes block', () => {
+            const html = `
+                <div class="message" data-message-role="assistant">
+                    <div class="file-changes-block">
+                        <pre><code>Some file changes text</code></pre>
+                    </div>
+                </div>
+            `;
+            document.body.innerHTML = html;
+
+            const script = extractAssistantSegmentsPayloadScript();
+            const scriptEl = document.createElement('script');
+            scriptEl.textContent = `window.__testPayload = ${script};`;
+            document.body.appendChild(scriptEl);
+            const payload = (window as any).__testPayload;
+
+            const result = classifyAssistantSegments(payload);
+            
+            expect(result.fileChangesTexts).toEqual(['Some file changes text']);
+        });
+
         it('extracts file names from the sticky footer .bottom-full .cursor-pointer', () => {
             const html = `
                 <div class="antigravity-agent-side-panel">

--- a/tests/services/assistantDomExtractor.test.ts
+++ b/tests/services/assistantDomExtractor.test.ts
@@ -8,6 +8,8 @@ import {
     type AssistantDomSegmentPayload,
     type AssistantDomSegment,
 } from '../../src/services/assistantDomExtractor';
+import * as fs from 'fs';
+import * as path from 'path';
 
 describe('assistantDomExtractor', () => {
     const buildPayload = (segments: AssistantDomSegment[]): AssistantDomSegmentPayload => ({
@@ -209,22 +211,18 @@ describe('assistantDomExtractor', () => {
             }
         });
 
-        it('skips mode description inside role="dialog" container', () => {
+        it('captures text inside role="dialog" container for interactive tools', () => {
             const panel = document.createElement('div');
             panel.className = 'antigravity-agent-side-panel';
-
-            // AG mode selector popup: role="dialog" container
             const dialog = document.createElement('div');
             dialog.setAttribute('role', 'dialog');
             const modeOption = document.createElement('div');
-            modeOption.className = 'flex flex-col';
-            const modeName = document.createElement('div');
-            modeName.className = 'font-medium';
+            modeOption.className = 'mode-select-option';
+            const modeName = document.createElement('span');
             modeName.textContent = 'Planning';
-            const modeDesc = document.createElement('div');
-            modeDesc.className = 'text-xs opacity-50';
-            modeDesc.textContent =
-                'Agent can plan before executing tasks. Use for deep research, complex tasks, or collaborative work';
+            const modeDesc = document.createElement('span');
+            modeDesc.textContent = 'Configure planning mode options';
+            
             modeOption.appendChild(modeName);
             modeOption.appendChild(modeDesc);
             dialog.appendChild(modeOption);
@@ -239,8 +237,7 @@ describe('assistantDomExtractor', () => {
             const payload = (window as any).__pass25DialogPayload;
             const result = classifyAssistantSegments(payload);
 
-            // Neither "Planning" nor the description should appear in activity
-            expect(result.activityLines).toEqual([]);
+            expect(result.activityLines).toEqual(['Planning']);
         });
 
         it('skips container elements with more than 3 children', () => {
@@ -344,6 +341,92 @@ describe('assistantDomExtractor', () => {
 
             // Expected: file path is restored from title attribute to "src/bot/index.ts:54"
             expect(output).toContain('src/bot/index.ts:54');
+        });
+    });
+
+    describe('Antigravity 2.0 DOM Fixtures', () => {
+        beforeEach(() => {
+            document.body.innerHTML = '';
+        });
+
+        it('extracts plan cards, actions, file edits, and final output', () => {
+            const fixturePath = path.join(__dirname, '../fixtures/antigravity-2/plan_approval_flow.html');
+            const html = fs.readFileSync(fixturePath, 'utf8');
+            document.body.innerHTML = html;
+
+            const script = extractAssistantSegmentsPayloadScript();
+            
+            const scriptEl = document.createElement('script');
+            scriptEl.textContent = `window.__fixturePayload = ${script};`;
+            document.body.appendChild(scriptEl);
+            const payload = (window as any).__fixturePayload;
+
+            const result = classifyAssistantSegments(payload);
+
+            expect(result.finalOutputText).toContain('The implementation plan is ready for review.');
+            expect(result.planCards[0]).toContain('Implementation Plan');
+            expect(result.planCards[0]).toContain('We will extract the DOM nodes...');
+            expect(result.actionButtons).toEqual(['Open', 'Proceed']);
+            expect(result.fileChanges).toEqual([{ path: 'src/services/assistantDomExtractor.ts', type: 'Modified' }]);
+        });
+
+        it('extracts file changes toolbar without tooltip ID and prefers absolute path for citations', () => {
+            const html = `
+                <div class="message" data-message-role="assistant">
+                    <p>Done!</p>
+                    <a href="file:///C:/Workspace/test.py" class="citation">test.py</a>
+                    
+                    <div class="toolbar">
+                        <span>2 Files With Changes</span>
+                        <button>Reject all</button>
+                        <button>Accept all</button>
+                    </div>
+                </div>
+            `;
+            document.body.innerHTML = html;
+
+            const script = extractAssistantSegmentsPayloadScript();
+            const scriptEl = document.createElement('script');
+            scriptEl.textContent = `window.__testPayload = ${script};`;
+            document.body.appendChild(scriptEl);
+            const payload = (window as any).__testPayload;
+
+            const result = classifyAssistantSegments(payload);
+            
+            // Should extract the absolute file path because of href
+            expect(result.citations).toEqual(['file:///C:/Workspace/test.py']);
+        });
+
+        it('extracts file names from the sticky footer .bottom-full .cursor-pointer', () => {
+            const html = `
+                <div class="antigravity-agent-side-panel">
+                    <div class="bottom-full">
+                        <div class="cursor-pointer">
+                            <span>src/components/MyComponent.tsx</span>
+                        </div>
+                        <div class="cursor-pointer">
+                            <span>src/utils/helpers.ts</span>
+                        </div>
+                        <div>
+                            <span>Not a file edit</span>
+                        </div>
+                    </div>
+                </div>
+            `;
+            document.body.innerHTML = html;
+
+            const script = extractAssistantSegmentsPayloadScript();
+            const scriptEl = document.createElement('script');
+            scriptEl.textContent = `window.__testPayload = ${script};`;
+            document.body.appendChild(scriptEl);
+            const payload = (window as any).__testPayload;
+
+            const result = classifyAssistantSegments(payload);
+            
+            expect(result.fileChanges).toEqual([
+                { path: 'src/components/MyComponent.tsx', type: 'Modified' },
+                { path: 'src/utils/helpers.ts', type: 'Modified' }
+            ]);
         });
     });
 });

--- a/tests/services/errorPopupDetector.test.ts
+++ b/tests/services/errorPopupDetector.test.ts
@@ -433,7 +433,7 @@ describe('ErrorPopupDetector - error popup detection and remote execution', () =
         await jest.advanceTimersByTimeAsync(500); // detection
         expect(detector.getLastDetectedInfo()).not.toBeNull();
 
-        await jest.advanceTimersByTimeAsync(500); // disappearance
+        await jest.advanceTimersByTimeAsync(1500); // disappearance
         expect(detector.getLastDetectedInfo()).toBeNull();
     });
 
@@ -546,7 +546,7 @@ describe('ErrorPopupDetector - error popup detection and remote execution', () =
         await jest.advanceTimersByTimeAsync(500); // detection
         expect(onResolved).not.toHaveBeenCalled();
 
-        await jest.advanceTimersByTimeAsync(500); // disappearance
+        await jest.advanceTimersByTimeAsync(1500); // disappearance
         expect(onResolved).toHaveBeenCalledTimes(1);
     });
 

--- a/tests/services/notificationSender.test.ts
+++ b/tests/services/notificationSender.test.ts
@@ -37,6 +37,7 @@ describe('buildApprovalNotification', () => {
         projectName: 'my-project',
         channelId: 'ch-123',
         toolNames: ['Bash', 'Write'],
+        hasAlwaysAllow: true,
     } as const;
 
     it('returns a MessagePayload with richContent', () => {
@@ -154,11 +155,19 @@ describe('buildPlanningNotification', () => {
         expect(payload.richContent!.timestamp).toBeInstanceOf(Date);
     });
 
-    it('contains exactly 2 buttons in one row', () => {
+    it('contains exactly 2 buttons in one row by default', () => {
         const payload = buildPlanningNotification(baseOpts);
         expect(payload.components).toHaveLength(1);
         const buttons = extractButtons(payload);
         expect(buttons).toHaveLength(2);
+    });
+
+    it('contains exactly 1 button when hasOpenButton is false', () => {
+        const payload = buildPlanningNotification({ ...baseOpts, hasOpenButton: false });
+        expect(payload.components).toHaveLength(1);
+        const buttons = extractButtons(payload);
+        expect(buttons).toHaveLength(1);
+        expect(buttons[0].label).toBe('Proceed');
     });
 
     it('has Open and Proceed buttons with correct styles', () => {
@@ -682,6 +691,7 @@ describe('buildResolvedOverlay', () => {
             description: 'Tool execution requires approval',
             projectName: 'my-project',
             channelId: 'ch-123',
+            hasAlwaysAllow: true,
         });
     }
 

--- a/tests/services/planningDetector.test.ts
+++ b/tests/services/planningDetector.test.ts
@@ -378,7 +378,7 @@ describe('PlanningDetector - planning button detection and remote execution', ()
         await jest.advanceTimersByTimeAsync(500); // detection
         expect(detector.getLastDetectedInfo()).not.toBeNull();
 
-        await jest.advanceTimersByTimeAsync(500); // disappearance
+        await jest.advanceTimersByTimeAsync(1500); // disappearance
         expect(detector.getLastDetectedInfo()).toBeNull();
     });
 
@@ -547,7 +547,7 @@ describe('PlanningDetector - planning button detection and remote execution', ()
         await jest.advanceTimersByTimeAsync(500); // detection
         expect(onResolved).not.toHaveBeenCalled();
 
-        await jest.advanceTimersByTimeAsync(500); // disappearance
+        await jest.advanceTimersByTimeAsync(1500); // disappearance
         expect(onResolved).toHaveBeenCalledTimes(1);
     });
 

--- a/tests/services/runCommandDetector.test.ts
+++ b/tests/services/runCommandDetector.test.ts
@@ -271,7 +271,7 @@ describe('RunCommandDetector - run command dialog detection and remote execution
         await jest.advanceTimersByTimeAsync(500);
         expect(detector.getLastDetectedInfo()).not.toBeNull();
 
-        await jest.advanceTimersByTimeAsync(500);
+        await jest.advanceTimersByTimeAsync(1500);
         expect(detector.getLastDetectedInfo()).toBeNull();
     });
 
@@ -431,7 +431,7 @@ describe('RunCommandDetector - run command dialog detection and remote execution
         await jest.advanceTimersByTimeAsync(500);
         expect(onResolved).not.toHaveBeenCalled();
 
-        await jest.advanceTimersByTimeAsync(500);
+        await jest.advanceTimersByTimeAsync(1500);
         expect(onResolved).toHaveBeenCalledTimes(1);
     });
 

--- a/tests/utils/htmlToDiscordMarkdown.test.ts
+++ b/tests/utils/htmlToDiscordMarkdown.test.ts
@@ -52,6 +52,12 @@ describe('htmlToDiscordMarkdown', () => {
             const html = '<pre><code>if (a &lt; b &amp;&amp; c &gt; d) {}</code></pre>';
             expect(htmlToDiscordMarkdown(html)).toContain('if (a < b && c > d) {}');
         });
+
+        it('handles Antigravity 2.0 wrapped code blocks', () => {
+            const html = '<div class="code-block"><div class="code-header">typescript</div><pre><code>const x = 1;</code></pre></div>';
+            const expected = '```typescript\nconst x = 1;\n```';
+            expect(htmlToDiscordMarkdown(html)).toBe(expected);
+        });
     });
 
     describe('lists', () => {
@@ -68,6 +74,12 @@ describe('htmlToDiscordMarkdown', () => {
             const result = htmlToDiscordMarkdown(html);
             expect(result).toContain('- Alpha');
             expect(result).toContain('- Beta');
+        });
+
+        it('handles nested lists', () => {
+            const html = '<ul><li>Parent<ul><li>Child</li></ul></li></ul>';
+            const result = htmlToDiscordMarkdown(html);
+            expect(result).toContain('- Parent\n  - Child');
         });
     });
 
@@ -105,6 +117,11 @@ describe('htmlToDiscordMarkdown', () => {
         it('removes style tags completely', () => {
             const html = '<style>.foo { color: red; }</style><p>visible</p>';
             expect(htmlToDiscordMarkdown(html)).toBe('visible');
+        });
+
+        it('converts Antigravity 2.0 file chips to inline code', () => {
+            const html = '<span class="file-chip">src/utils/htmlToDiscordMarkdown.ts</span>';
+            expect(htmlToDiscordMarkdown(html)).toBe('`src/utils/htmlToDiscordMarkdown.ts`');
         });
     });
 


### PR DESCRIPTION
Part of #194

**Milestone 2: Planning Mode & Interactive Approval Workflows**
- Added logic to extract the exact DOM plan from the IDE and beam it to Discord.
- Correctly render native Discord Review/Proceed buttons to route accept/reject actions.
- Patched edge cases causing duplicate planning notifications on rapid DOM updates.
- Enforced strict channel isolation to prevent file-change approvals from cross-contaminating

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added interactive question flows with select options and a skip action.
  - Added new action buttons for approving, rejecting, opening files, and running quick actions.
  - Added a new command to open files directly from chat.

- **Bug Fixes**
  - Improved workspace/project matching so actions work more reliably from the current channel.
  - Better handling of replies, text attachments, and image fallbacks when sending prompts.
  - Discord responses now render more consistently, including plan details and file changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->