### PR TITLE
Feature: Optional heartbeat / keep-alive notification (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Just type in any bound channel:
 - `🛑 /shutdown` — Shut down the IDE while keeping the active CDP project connections and session bindings
 - `📸 /screenshot` — Capture and send Antigravity's current screen
 - `🔧 /status` — Show bot connection status, current mode, and active project
+- `💓 /heartbeat [on|off|status]` — Configure periodic bot heartbeat notifications
 - `✅ /autoaccept [on|off|status]` — Toggle auto-approval of file edit dialogs
 - `📝 /output [embed|plain]` — Toggle output format between Embed and Plain Text (plain text is easier to copy on mobile)
 - `📋 /logs [lines] [level]` — View recent bot logs (ephemeral)

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -2726,6 +2726,16 @@ export async function handleSlashInteraction(
                 break;
             }
 
+            const envOverrides: string[] = [];
+            if (process.env.HEARTBEAT_ENABLED !== undefined) envOverrides.push('HEARTBEAT_ENABLED');
+            if (process.env.HEARTBEAT_INTERVAL_MS !== undefined) envOverrides.push('HEARTBEAT_INTERVAL_MS');
+            if (process.env.HEARTBEAT_CHANNEL_ID !== undefined) envOverrides.push('HEARTBEAT_CHANNEL_ID');
+
+            let warningPrefix = '';
+            if (envOverrides.length > 0) {
+                warningPrefix = `⚠️ **Warning**: Environment override(s) active: ${envOverrides.join(', ')}. Changes saved to config.json may not take effect until overrides are removed.\n\n`;
+            }
+
             if (subcommand === 'on') {
                 const intervalStr = interaction.options.getString('interval') || '1h';
                 const targetChannel = interaction.options.getChannel('channel') || interaction.channel;
@@ -2745,7 +2755,7 @@ export async function handleSlashInteraction(
 
                 const intervalMs = parseInterval(intervalStr);
                 if (intervalMs === null || intervalMs <= 0) {
-                    await interaction.editReply({ content: '⚠️ Invalid interval format. Use e.g. "1h", "6h", "30m".' });
+                    await interaction.editReply({ content: '⚠️ Invalid interval format. Use a value with a unit, e.g. "1h", "6h", "30m" (bare numbers are not allowed).' });
                     break;
                 }
 
@@ -2754,13 +2764,18 @@ export async function handleSlashInteraction(
                     break;
                 }
 
+                if (intervalMs > 2147483647) {
+                    await interaction.editReply({ content: '⚠️ Interval cannot be greater than 24.8 days (2147483647 ms).' });
+                    break;
+                }
+
                 await heartbeatService.updateConfig(true, intervalMs, targetChannel.id);
                 await interaction.editReply({ 
-                    content: `💓 Heartbeat enabled! Sending updates every **${intervalStr}** to channel <#${targetChannel.id}>.` 
+                    content: `${warningPrefix}💓 Heartbeat enabled! Sending updates every **${intervalStr}** to channel <#${targetChannel.id}>.` 
                 });
             } else if (subcommand === 'off') {
                 await heartbeatService.disable();
-                await interaction.editReply({ content: '💓 Heartbeat disabled.' });
+                await interaction.editReply({ content: `${warningPrefix}💓 Heartbeat disabled.` });
             } else if (subcommand === 'status') {
                 const config = loadConfig();
                 const uptimeMs = Date.now() - heartbeatService.botStartTime;

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -2755,7 +2755,7 @@ export async function handleSlashInteraction(
 
                 const intervalMs = parseInterval(intervalStr);
                 if (intervalMs === null || intervalMs <= 0) {
-                    await interaction.editReply({ content: '⚠️ Invalid interval format. Use a value with a unit, e.g. "1h", "6h", "30m" (bare numbers are not allowed).' });
+                    await interaction.editReply({ content: '⚠️ Invalid interval format. Use a value with a unit, e.g. "1d", "1h", "30m" (bare numbers are not allowed).' });
                     break;
                 }
 

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -2735,6 +2735,14 @@ export async function handleSlashInteraction(
                     break;
                 }
 
+                // Check permissions
+                const botUser = interaction.client.user;
+                const permissions = (targetChannel as any).permissionsFor?.(botUser);
+                if (!permissions || !permissions.has('SendMessages')) {
+                    await interaction.editReply({ content: '⚠️ Bot does not have permission to send messages in that channel.' });
+                    break;
+                }
+
                 const intervalMs = parseInterval(intervalStr);
                 if (intervalMs === null || intervalMs <= 0) {
                     await interaction.editReply({ content: '⚠️ Invalid interval format. Use e.g. "1h", "6h", "30m".' });
@@ -2759,13 +2767,20 @@ export async function handleSlashInteraction(
                 const uptimeStr = formatDuration(uptimeMs);
                 const lastActivityStr = formatRelativeTime(heartbeatService.lastActivityTimestamp);
 
+                const activeWorkspaces = bridge.pool.getActiveWorkspaceNames();
+                const activeCount = activeWorkspaces.length;
+                const activeList = activeCount > 0 ? activeWorkspaces.join(', ') : 'None';
+
+                const intervalVal = config.heartbeatIntervalMs != null ? formatDuration(config.heartbeatIntervalMs) : 'N/A';
+
                 const statusEmbed = new EmbedBuilder()
                     .setTitle('💓 Heartbeat Status')
                     .setColor(config.heartbeatEnabled ? 0x00CC88 : 0x888888)
                     .addFields(
                         { name: 'Enabled', value: config.heartbeatEnabled ? '🟢 Yes' : '⚪ No', inline: true },
-                        { name: 'Interval', value: config.heartbeatEnabled ? `${config.heartbeatIntervalMs}ms` : 'N/A', inline: true },
+                        { name: 'Interval', value: config.heartbeatEnabled ? intervalVal : 'N/A', inline: true },
                         { name: 'Target Channel', value: config.heartbeatChannelId ? `<#${config.heartbeatChannelId}>` : 'N/A', inline: true },
+                        { name: 'Active Sessions', value: `${activeCount} (${activeList})`, inline: true },
                         { name: 'Uptime', value: uptimeStr, inline: true },
                         { name: 'Last Activity', value: lastActivityStr, inline: true },
                     )

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -118,6 +118,7 @@ import { createPlatformButtonHandler } from '../handlers/buttonHandler';
 import { createPlatformSelectHandler } from '../handlers/selectHandler';
 import { createApprovalButtonAction } from '../handlers/approvalButtonAction';
 import { createPlanningButtonAction } from '../handlers/planningButtonAction';
+import { HeartbeatService, parseInterval, formatDuration, formatRelativeTime } from '../services/heartbeatService';
 import { createErrorPopupButtonAction } from '../handlers/errorPopupButtonAction';
 import { createRunCommandButtonAction } from '../handlers/runCommandButtonAction';
 import { createModelButtonAction } from '../handlers/modelButtonAction';
@@ -1332,6 +1333,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
     const artifactService = new ArtifactService();
     const workspaceService = new WorkspaceService(config.workspaceBaseDir);
     const channelManager = new ChannelManager();
+    const heartbeatService = new HeartbeatService();
 
     // Auto-launch Antigravity with CDP port if not already running
     await ensureAntigravityRunning();
@@ -1488,6 +1490,9 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
     client.once(Events.ClientReady, async (readyClient) => {
         logger.info(`Ready! Logged in as ${readyClient.user.tag} | extractionMode=${config.extractionMode}`);
 
+        heartbeatService.init(readyClient, bridge);
+        heartbeatService.start();
+
         try {
             await registerSlashCommands(discordToken, discordClientId, config.guildId);
         } catch (error) {
@@ -1577,6 +1582,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         channelManager,
         titleGenerator,
         antigravityAccounts: config.antigravityAccounts,
+        heartbeatService,
         handleSlashInteraction: async (
             interaction,
             handler,
@@ -1615,6 +1621,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
             chatSessionRepoArg,
             artifactService,
             scheduleServiceArg,
+            heartbeatService,
         ),
         handleTemplateUse: async (interaction, templateId) => {
             const template = templateRepo.findById(templateId);
@@ -1757,6 +1764,7 @@ export const startBot = async (cliLogLevel?: LogLevel) => {
         accountPrefRepo,
         channelPrefRepo,
         antigravityAccounts: config.antigravityAccounts,
+        heartbeatService,
     }));
 
     await client.login(discordToken);
@@ -2077,6 +2085,7 @@ export async function handleSlashInteraction(
     chatSessionRepo?: ChatSessionRepository,
     artifactService?: ArtifactService,
     scheduleService?: ScheduleService,
+    heartbeatService?: HeartbeatService,
 ): Promise<void> {
     const commandName = interaction.commandName;
     const getAccountPort = (accountName: string): number | null => {
@@ -2707,6 +2716,62 @@ export async function handleSlashInteraction(
                 chatSessionRepo, 
                 artifactService 
             });
+            break;
+        }
+
+        case 'heartbeat': {
+            const subcommand = interaction.options.getSubcommand();
+            if (!heartbeatService) {
+                await interaction.editReply({ content: 'Heartbeat service not available.' });
+                break;
+            }
+
+            if (subcommand === 'on') {
+                const intervalStr = interaction.options.getString('interval') || '1h';
+                const targetChannel = interaction.options.getChannel('channel') || interaction.channel;
+                
+                if (!targetChannel || typeof (targetChannel as any).isTextBased !== 'function' || !(targetChannel as any).isTextBased()) {
+                    await interaction.editReply({ content: '⚠️ Please select a valid text channel.' });
+                    break;
+                }
+
+                const intervalMs = parseInterval(intervalStr);
+                if (intervalMs === null || intervalMs <= 0) {
+                    await interaction.editReply({ content: '⚠️ Invalid interval format. Use e.g. "1h", "6h", "30m".' });
+                    break;
+                }
+
+                if (intervalMs < 10000) {
+                    await interaction.editReply({ content: '⚠️ Interval must be at least 10 seconds.' });
+                    break;
+                }
+
+                await heartbeatService.updateConfig(true, intervalMs, targetChannel.id);
+                await interaction.editReply({ 
+                    content: `💓 Heartbeat enabled! Sending updates every **${intervalStr}** to channel <#${targetChannel.id}>.` 
+                });
+            } else if (subcommand === 'off') {
+                await heartbeatService.disable();
+                await interaction.editReply({ content: '💓 Heartbeat disabled.' });
+            } else if (subcommand === 'status') {
+                const config = loadConfig();
+                const uptimeMs = Date.now() - heartbeatService.botStartTime;
+                const uptimeStr = formatDuration(uptimeMs);
+                const lastActivityStr = formatRelativeTime(heartbeatService.lastActivityTimestamp);
+
+                const statusEmbed = new EmbedBuilder()
+                    .setTitle('💓 Heartbeat Status')
+                    .setColor(config.heartbeatEnabled ? 0x00CC88 : 0x888888)
+                    .addFields(
+                        { name: 'Enabled', value: config.heartbeatEnabled ? '🟢 Yes' : '⚪ No', inline: true },
+                        { name: 'Interval', value: config.heartbeatEnabled ? `${config.heartbeatIntervalMs}ms` : 'N/A', inline: true },
+                        { name: 'Target Channel', value: config.heartbeatChannelId ? `<#${config.heartbeatChannelId}>` : 'N/A', inline: true },
+                        { name: 'Uptime', value: uptimeStr, inline: true },
+                        { name: 'Last Activity', value: lastActivityStr, inline: true },
+                    )
+                    .setTimestamp();
+                await interaction.editReply({ embeds: [statusEmbed] });
+            }
             break;
         }
 

--- a/src/commands/registerSlashCommands.ts
+++ b/src/commands/registerSlashCommands.ts
@@ -4,6 +4,7 @@ import {
     PermissionFlagsBits,
     REST,
     Routes,
+    ChannelType,
 } from 'discord.js';
 import { t } from "../utils/i18n";
 
@@ -253,6 +254,7 @@ const heartbeatCommand = new SlashCommandBuilder()
                 option
                     .setName('channel')
                     .setDescription(t('Target channel for heartbeat (defaults to current)'))
+                    .addChannelTypes(ChannelType.GuildText, ChannelType.GuildAnnouncement)
                     .setRequired(false)
             )
     )

--- a/src/commands/registerSlashCommands.ts
+++ b/src/commands/registerSlashCommands.ts
@@ -247,7 +247,7 @@ const heartbeatCommand = new SlashCommandBuilder()
             .addStringOption((option) =>
                 option
                     .setName('interval')
-                    .setDescription(t('Interval (e.g., 1h, 6h, 30m - unit required)'))
+                    .setDescription(t('Interval (e.g., 1d, 1h, 30m - unit required)'))
                     .setRequired(false)
             )
             .addChannelOption((option) =>

--- a/src/commands/registerSlashCommands.ts
+++ b/src/commands/registerSlashCommands.ts
@@ -247,7 +247,7 @@ const heartbeatCommand = new SlashCommandBuilder()
             .addStringOption((option) =>
                 option
                     .setName('interval')
-                    .setDescription(t('Interval (e.g., 1h, 6h, 30m)'))
+                    .setDescription(t('Interval (e.g., 1h, 6h, 30m - unit required)'))
                     .setRequired(false)
             )
             .addChannelOption((option) =>

--- a/src/commands/registerSlashCommands.ts
+++ b/src/commands/registerSlashCommands.ts
@@ -235,6 +235,38 @@ const openCommand = new SlashCommandBuilder()
             .setRequired(true)
     );
 
+/** /heartbeat command definition */
+const heartbeatCommand = new SlashCommandBuilder()
+    .setName('heartbeat')
+    .setDescription(t('Configure periodic bot heartbeat notifications'))
+    .addSubcommand((sub) =>
+        sub
+            .setName('on')
+            .setDescription(t('Enable periodic heartbeats'))
+            .addStringOption((option) =>
+                option
+                    .setName('interval')
+                    .setDescription(t('Interval (e.g., 1h, 6h, 30m)'))
+                    .setRequired(false)
+            )
+            .addChannelOption((option) =>
+                option
+                    .setName('channel')
+                    .setDescription(t('Target channel for heartbeat (defaults to current)'))
+                    .setRequired(false)
+            )
+    )
+    .addSubcommand((sub) =>
+        sub
+            .setName('off')
+            .setDescription(t('Disable periodic heartbeats'))
+    )
+    .addSubcommand((sub) =>
+        sub
+            .setName('status')
+            .setDescription(t('Display current heartbeat config and status'))
+    );
+
 /** Array of commands to register */
 export const slashCommands = [
     helpCommand,
@@ -258,6 +290,7 @@ export const slashCommands = [
     logsCommand,
     artifactsCommand,
     openCommand,
+    heartbeatCommand,
 ];
 
 /**

--- a/src/events/interactionCreateHandler.ts
+++ b/src/events/interactionCreateHandler.ts
@@ -63,6 +63,7 @@ import { JoinCommandHandler } from '../commands/joinCommandHandler';
 import { isSessionSelectId } from '../ui/sessionPickerUi';
 import { ARTIFACT_SELECT_ID, ARTIFACT_THREAD_BTN, ARTIFACT_INLINE_BTN, buildArtifactPickerUI, sendArtifactPickerUI } from '../ui/artifactsUi';
 import { ArtifactService } from '../services/artifactService';
+import { HeartbeatService } from '../services/heartbeatService';
 import { ArtifactThreadRepository } from '../database/artifactThreadRepository';
 import { ScheduleService } from '../services/scheduleService';
 import type { AntigravityAccountConfig } from '../utils/configLoader';
@@ -111,6 +112,7 @@ export interface InteractionCreateHandlerDeps {
         antigravityAccounts?: AntigravityAccountConfig[],
         chatSessionRepo?: ChatSessionRepository,
         scheduleService?: ScheduleService,
+        heartbeatService?: HeartbeatService,
     ) => Promise<void>;
     handleTemplateUse?: (interaction: ButtonInteraction, templateId: number) => Promise<void>;
     joinHandler?: JoinCommandHandler;
@@ -126,6 +128,7 @@ export interface InteractionCreateHandlerDeps {
     promptDispatcher?: import('../services/promptDispatcher').PromptDispatcher;
     channelManager?: import('../services/channelManager').ChannelManager;
     titleGenerator?: import('../services/titleGeneratorService').TitleGeneratorService;
+    heartbeatService?: HeartbeatService;
 }
 
 export function createInteractionCreateHandler(deps: InteractionCreateHandlerDeps) {
@@ -224,6 +227,10 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
     };
 
     return async (interaction: Interaction): Promise<void> => {
+        if (deps.heartbeatService && deps.config.allowedUserIds.includes(interaction.user.id)) {
+            deps.heartbeatService.recordActivity();
+        }
+
         if (interaction.isAutocomplete()) {
             if (!deps.config.allowedUserIds.includes(interaction.user.id)) {
                 await interaction.respond([]).catch(logger.error);
@@ -1720,6 +1727,7 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
                 deps.antigravityAccounts,
                 deps.chatSessionRepo,
                 deps.scheduleService,
+                deps.heartbeatService,
             );
         } catch (error) {
             logger.error(

--- a/src/events/interactionCreateHandler.ts
+++ b/src/events/interactionCreateHandler.ts
@@ -227,7 +227,8 @@ export function createInteractionCreateHandler(deps: InteractionCreateHandlerDep
     };
 
     return async (interaction: Interaction): Promise<void> => {
-        if (deps.heartbeatService && deps.config.allowedUserIds.includes(interaction.user.id)) {
+        const isHeartbeatCommand = 'commandName' in interaction && interaction.commandName === 'heartbeat';
+        if (deps.heartbeatService && deps.config.allowedUserIds.includes(interaction.user.id) && !isHeartbeatCommand) {
             deps.heartbeatService.recordActivity();
         }
 

--- a/src/events/messageCreateHandler.ts
+++ b/src/events/messageCreateHandler.ts
@@ -36,6 +36,7 @@ import {
 } from '../utils/imageHandler';
 import { listAccountNames, resolveScopedAccountName } from '../utils/accountUtils';
 import { logger } from '../utils/logger';
+import { HeartbeatService } from '../services/heartbeatService';
 
 export interface MessageCreateHandlerDeps {
     config: { allowedUserIds: string[]; extractionMode?: import('../utils/config').ExtractionMode; responseTimeoutMs?: number };
@@ -83,6 +84,7 @@ export interface MessageCreateHandlerDeps {
     accountPrefRepo?: AccountPreferenceRepository;
     channelPrefRepo?: ChannelPreferenceRepository;
     antigravityAccounts?: { name: string; cdpPort: number }[];
+    heartbeatService?: HeartbeatService;
 }
 
 export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
@@ -135,6 +137,10 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
 
         if (!deps.config.allowedUserIds.includes(message.author.id)) {
             return;
+        }
+
+        if (deps.heartbeatService) {
+            deps.heartbeatService.recordActivity();
         }
 
         const parsed = parseMessageContent(message.content);
@@ -259,7 +265,7 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
                 return;
             }
 
-            const slashOnlyCommands = ['help', 'stop', 'model', 'mode', 'project', 'chat', 'new', 'cleanup', 'join', 'mirror', 'output'];
+            const slashOnlyCommands = ['help', 'stop', 'model', 'mode', 'project', 'chat', 'new', 'cleanup', 'join', 'mirror', 'output', 'heartbeat'];
             if (slashOnlyCommands.includes(parsed.commandName)) {
                 await message.reply({
                     content: `💡 Please use \`/${parsed.commandName}\` as a slash command.\nType \`/${parsed.commandName}\` in the Discord input field to see suggestions.`,

--- a/src/services/heartbeatService.ts
+++ b/src/services/heartbeatService.ts
@@ -39,7 +39,14 @@ export class HeartbeatService {
             return;
         }
 
-        const interval = config.heartbeatIntervalMs ?? 3600000;
+        let interval = config.heartbeatIntervalMs ?? 3600000;
+        if (interval < 10000) {
+            logger.warn(`[HeartbeatService] Interval ${interval}ms is too low. Clamping to 10000ms.`);
+            interval = 10000;
+        } else if (interval > 2147483647) {
+            logger.warn(`[HeartbeatService] Interval ${interval}ms is too high (max is 2147483647ms). Clamping to 2147483647ms.`);
+            interval = 2147483647;
+        }
         logger.info(`[HeartbeatService] Starting periodic heartbeat every ${interval}ms to channel ${channelId}`);
 
         // Run immediately on start
@@ -66,6 +73,19 @@ export class HeartbeatService {
         
         // If channel changed, clear the last message ID
         if (config.heartbeatChannelId !== channelId) {
+            if (config.heartbeatChannelId && config.heartbeatLastMessageId) {
+                try {
+                    const oldChannel = await this.client?.channels.fetch(config.heartbeatChannelId);
+                    if (oldChannel && oldChannel.isTextBased()) {
+                        const oldMsg = await (oldChannel as TextChannel).messages.fetch(config.heartbeatLastMessageId);
+                        if (oldMsg) {
+                            await oldMsg.delete().catch(() => {});
+                        }
+                    }
+                } catch (err) {
+                    logger.debug('[HeartbeatService] Failed to delete old heartbeat message from previous channel:', err);
+                }
+            }
             ConfigLoader.save({ heartbeatLastMessageId: undefined });
         }
 
@@ -83,8 +103,23 @@ export class HeartbeatService {
     }
 
     public async disable() {
+        const config = ConfigLoader.load();
+        if (config.heartbeatChannelId && config.heartbeatLastMessageId) {
+            try {
+                const oldChannel = await this.client?.channels.fetch(config.heartbeatChannelId);
+                if (oldChannel && oldChannel.isTextBased()) {
+                    const oldMsg = await (oldChannel as TextChannel).messages.fetch(config.heartbeatLastMessageId);
+                    if (oldMsg) {
+                        await oldMsg.delete().catch(() => {});
+                    }
+                }
+            } catch (err) {
+                logger.debug('[HeartbeatService] Failed to delete heartbeat message upon disabling:', err);
+            }
+        }
         ConfigLoader.save({
             heartbeatEnabled: false,
+            heartbeatLastMessageId: undefined,
         });
         this.stop();
         logger.info('[HeartbeatService] Heartbeat disabled.');
@@ -157,13 +192,14 @@ export class HeartbeatService {
 }
 
 /**
- * Parse a duration string like "1h", "6h", "30m", or pure numbers to milliseconds
+ * Parse a duration string like "1h", "6h", "30m", or "2d" to milliseconds.
+ * Requiring a unit prevents ambiguity with bare numbers.
  */
 export function parseInterval(str: string): number | null {
-    const match = str.trim().toLowerCase().match(/^(\d+)(ms|s|m|h|d)?$/);
+    const match = str.trim().toLowerCase().match(/^(\d+)(ms|s|m|h|d)$/);
     if (!match) return null;
     const value = parseInt(match[1], 10);
-    const unit = match[2] || 'h'; // default to hours
+    const unit = match[2];
 
     switch (unit) {
         case 'ms': return value;
@@ -171,7 +207,7 @@ export function parseInterval(str: string): number | null {
         case 'm': return value * 60 * 1000;
         case 'h': return value * 60 * 60 * 1000;
         case 'd': return value * 24 * 60 * 60 * 1000;
-        default: return value * 60 * 60 * 1000;
+        default: return null;
     }
 }
 

--- a/src/services/heartbeatService.ts
+++ b/src/services/heartbeatService.ts
@@ -1,0 +1,209 @@
+import { Client, EmbedBuilder, TextChannel } from 'discord.js';
+import { logger } from '../utils/logger';
+import { ConfigLoader } from '../utils/configLoader';
+import { CdpBridge } from './cdpBridgeManager';
+
+export class HeartbeatService {
+    private client: Client | null = null;
+    private bridge: CdpBridge | null = null;
+    private intervalId: NodeJS.Timeout | null = null;
+    
+    public botStartTime: number = Date.now();
+    public lastActivityTimestamp: number = Date.now();
+
+    constructor() {}
+
+    public init(client: Client, bridge: CdpBridge) {
+        this.client = client;
+        this.bridge = bridge;
+        this.botStartTime = Date.now();
+        this.lastActivityTimestamp = Date.now();
+    }
+
+    public recordActivity() {
+        this.lastActivityTimestamp = Date.now();
+    }
+
+    public start() {
+        this.stop();
+
+        const config = ConfigLoader.load();
+        if (!config.heartbeatEnabled) {
+            logger.info('[HeartbeatService] Periodic heartbeat is disabled.');
+            return;
+        }
+
+        const channelId = config.heartbeatChannelId;
+        if (!channelId) {
+            logger.warn('[HeartbeatService] Enabled but heartbeatChannelId is not configured.');
+            return;
+        }
+
+        const interval = config.heartbeatIntervalMs || 3600000;
+        logger.info(`[HeartbeatService] Starting periodic heartbeat every ${interval}ms to channel ${channelId}`);
+
+        // Run immediately on start
+        this.sendHeartbeat().catch(err => {
+            logger.error('[HeartbeatService] Failed to send initial heartbeat:', err);
+        });
+
+        this.intervalId = setInterval(() => {
+            this.sendHeartbeat().catch(err => {
+                logger.error('[HeartbeatService] Failed to send periodic heartbeat:', err);
+            });
+        }, interval);
+    }
+
+    public stop() {
+        if (this.intervalId) {
+            clearInterval(this.intervalId);
+            this.intervalId = null;
+        }
+    }
+
+    public async updateConfig(enabled: boolean, intervalMs: number, channelId: string) {
+        const config = ConfigLoader.load();
+        
+        // If channel changed, clear the last message ID
+        if (config.heartbeatChannelId !== channelId) {
+            ConfigLoader.save({ heartbeatLastMessageId: undefined });
+        }
+
+        // Save to config.json
+        ConfigLoader.save({
+            heartbeatEnabled: enabled,
+            heartbeatIntervalMs: intervalMs,
+            heartbeatChannelId: channelId,
+        });
+
+        logger.info(`[HeartbeatService] Config updated: enabled=${enabled}, interval=${intervalMs}ms, channel=${channelId}`);
+        
+        // Restart loop
+        this.start();
+    }
+
+    public async disable() {
+        ConfigLoader.save({
+            heartbeatEnabled: false,
+        });
+        this.stop();
+        logger.info('[HeartbeatService] Heartbeat disabled.');
+    }
+
+    public async sendHeartbeat() {
+        if (!this.client || !this.bridge) {
+            logger.warn('[HeartbeatService] Cannot send heartbeat: client or bridge not initialized.');
+            return;
+        }
+
+        const config = ConfigLoader.load();
+        const channelId = config.heartbeatChannelId;
+        if (!channelId) return;
+
+        try {
+            const channel = await this.client.channels.fetch(channelId);
+            if (!channel || !channel.isTextBased()) {
+                logger.warn(`[HeartbeatService] Channel ${channelId} not found or is not a text channel.`);
+                return;
+            }
+
+            const embed = this.buildHeartbeatEmbed();
+            const lastMessageId = config.heartbeatLastMessageId;
+
+            if (lastMessageId) {
+                try {
+                    const message = await (channel as TextChannel).messages.fetch(lastMessageId);
+                    if (message && message.author.id === this.client.user?.id) {
+                        await message.edit({ embeds: [embed] });
+                        logger.debug(`[HeartbeatService] Updated heartbeat message in-place: ${lastMessageId}`);
+                        return;
+                    }
+                } catch (fetchErr) {
+                    logger.debug(`[HeartbeatService] Failed to fetch or edit message ${lastMessageId}, sending new one.`);
+                }
+            }
+
+            // Send new message
+            const newMsg = await (channel as TextChannel).send({ embeds: [embed] });
+            ConfigLoader.save({ heartbeatLastMessageId: newMsg.id });
+            logger.info(`[HeartbeatService] Sent new heartbeat message: ${newMsg.id}`);
+        } catch (error) {
+            logger.error('[HeartbeatService] Error in sendHeartbeat:', error);
+        }
+    }
+
+    private buildHeartbeatEmbed(): EmbedBuilder {
+        const uptimeMs = Date.now() - this.botStartTime;
+        const uptimeStr = formatDuration(uptimeMs);
+        
+        const activeWorkspaces = this.bridge?.pool.getActiveWorkspaceNames() || [];
+        const activeCount = activeWorkspaces.length;
+        const activeList = activeCount > 0 ? activeWorkspaces.join(', ') : 'None';
+
+        const lastActivityStr = formatRelativeTime(this.lastActivityTimestamp);
+
+        return new EmbedBuilder()
+            .setTitle('💓 LazyGravity Heartbeat')
+            .setColor(0x00CC88)
+            .addFields(
+                { name: 'Status', value: '🟢 Running', inline: true },
+                { name: 'Uptime', value: uptimeStr, inline: true },
+                { name: 'Active Sessions', value: `${activeCount} (${activeList})`, inline: true },
+                { name: 'Last Activity', value: lastActivityStr, inline: true },
+            )
+            .setFooter({ text: `Last updated: ${new Date().toLocaleString()}` })
+            .setTimestamp();
+    }
+}
+
+/**
+ * Parse a duration string like "1h", "6h", "30m", or pure numbers to milliseconds
+ */
+export function parseInterval(str: string): number | null {
+    const match = str.trim().toLowerCase().match(/^(\d+)(ms|s|m|h|d)?$/);
+    if (!match) return null;
+    const value = parseInt(match[1], 10);
+    const unit = match[2] || 'h'; // default to hours
+
+    switch (unit) {
+        case 'ms': return value;
+        case 's': return value * 1000;
+        case 'm': return value * 60 * 1000;
+        case 'h': return value * 60 * 60 * 1000;
+        case 'd': return value * 24 * 60 * 60 * 1000;
+        default: return value * 60 * 60 * 1000;
+    }
+}
+
+/**
+ * Format milliseconds to a human-readable duration (e.g. "2h 15m")
+ */
+export function formatDuration(ms: number): string {
+    const seconds = Math.floor((ms / 1000) % 60);
+    const minutes = Math.floor((ms / (1000 * 60)) % 60);
+    const hours = Math.floor((ms / (1000 * 60 * 60)) % 24);
+    const days = Math.floor(ms / (1000 * 60 * 60 * 24));
+
+    const parts = [];
+    if (days > 0) parts.push(`${days}d`);
+    if (hours > 0) parts.push(`${hours}h`);
+    if (minutes > 0) parts.push(`${minutes}m`);
+    if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`);
+    return parts.join(' ');
+}
+
+/**
+ * Format a past timestamp to a relative string (e.g. "5m ago")
+ */
+export function formatRelativeTime(timestamp: number): string {
+    const diff = Date.now() - timestamp;
+    if (diff < 5000) return 'just now';
+    const seconds = Math.floor(diff / 1000);
+    if (seconds < 60) return `${seconds}s ago`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ${minutes % 60}m ago`;
+    const days = Math.floor(hours / 24);
+    return `${days}d ago`;
+}

--- a/src/services/heartbeatService.ts
+++ b/src/services/heartbeatService.ts
@@ -39,7 +39,7 @@ export class HeartbeatService {
             return;
         }
 
-        const interval = config.heartbeatIntervalMs || 3600000;
+        const interval = config.heartbeatIntervalMs ?? 3600000;
         logger.info(`[HeartbeatService] Starting periodic heartbeat every ${interval}ms to channel ${channelId}`);
 
         // Run immediately on start

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -27,6 +27,10 @@ export interface AppConfig {
     platforms: PlatformType[];
     /** Response monitor inactivity timeout in ms. 0 = disabled. Default: 900000 (15 min). */
     responseTimeoutMs: number;
+    heartbeatEnabled: boolean;
+    heartbeatIntervalMs: number;
+    heartbeatChannelId?: string;
+    heartbeatLastMessageId?: string;
 }
 
 export type ResponseDeliveryMode = 'stream';

--- a/src/utils/configLoader.ts
+++ b/src/utils/configLoader.ts
@@ -169,7 +169,7 @@ function mergeConfig(persisted: PersistedConfig): AppConfig {
     );
 
     const heartbeatChannelId = process.env.HEARTBEAT_CHANNEL_ID ?? persisted.heartbeatChannelId ?? undefined;
-    const heartbeatLastMessageId = process.env.HEARTBEAT_LAST_MESSAGE_ID ?? persisted.heartbeatLastMessageId ?? undefined;
+    const heartbeatLastMessageId = persisted.heartbeatLastMessageId ?? undefined;
 
     return {
         discordToken,

--- a/src/utils/configLoader.ts
+++ b/src/utils/configLoader.ts
@@ -37,6 +37,10 @@ export interface PersistedConfig {
     responseTimeoutMs?: number;
     antigravityAccounts?: string | AntigravityAccountConfig[];
     cdpHost?: string;
+    heartbeatEnabled?: boolean;
+    heartbeatIntervalMs?: number;
+    heartbeatChannelId?: string;
+    heartbeatLastMessageId?: string;
 }
 
 export interface AntigravityAccountConfig {
@@ -152,6 +156,21 @@ function mergeConfig(persisted: PersistedConfig): AppConfig {
         );
     }
 
+    const heartbeatEnabled = resolveBoolean(
+        process.env.HEARTBEAT_ENABLED,
+        persisted.heartbeatEnabled,
+        false,
+    );
+
+    const heartbeatIntervalMs = resolvePositiveInt(
+        process.env.HEARTBEAT_INTERVAL_MS,
+        persisted.heartbeatIntervalMs,
+        3600000,
+    );
+
+    const heartbeatChannelId = process.env.HEARTBEAT_CHANNEL_ID ?? persisted.heartbeatChannelId ?? undefined;
+    const heartbeatLastMessageId = process.env.HEARTBEAT_LAST_MESSAGE_ID ?? persisted.heartbeatLastMessageId ?? undefined;
+
     return {
         discordToken,
         clientId,
@@ -167,6 +186,10 @@ function mergeConfig(persisted: PersistedConfig): AppConfig {
         telegramAllowedUserIds,
         platforms,
         cdpHost,
+        heartbeatEnabled,
+        heartbeatIntervalMs,
+        heartbeatChannelId,
+        heartbeatLastMessageId,
     };
 }
 

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -51,6 +51,14 @@ jest.mock('discord.js', () => {
                     optFn(opt);
                     return sub;
                 });
+                sub.addChannelOption = jest.fn().mockImplementation((optFn: any) => {
+                    const opt: any = {};
+                    opt.setName = jest.fn().mockReturnValue(opt);
+                    opt.setDescription = jest.fn().mockReturnValue(opt);
+                    opt.setRequired = jest.fn().mockReturnValue(opt);
+                    optFn(opt);
+                    return sub;
+                });
                 fn(sub);
                 return builder;
             });

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -228,6 +228,8 @@ describe('Bot Startup', () => {
         let mockTargetChannel: any;
         let mockPermissions: any;
 
+        const { HeartbeatService } = require('../src/services/heartbeatService');
+
         beforeEach(() => {
             interactionCallback = clientInstance.on.mock.calls.find((call: any) => call[0] === Events.InteractionCreate)[1];
             mockPermissions = {
@@ -240,26 +242,42 @@ describe('Bot Startup', () => {
             };
         });
 
-        it('handles heartbeat on command successfully', async () => {
-            const editReplySpy = jest.fn().mockResolvedValue(true);
-            const mockInteraction = {
+        const makeMockInteraction = (overrides: {
+            subcommand: string;
+            interval?: string | null;
+            targetChannel?: any;
+            editReply?: jest.Mock;
+            user?: { id: string };
+        }) => {
+            const editReplySpy = overrides.editReply || jest.fn().mockResolvedValue(true);
+            const channel = overrides.hasOwnProperty('targetChannel') ? overrides.targetChannel : mockTargetChannel;
+            return {
                 isAutocomplete: () => false,
                 isButton: () => false,
                 isStringSelectMenu: () => false,
                 isChatInputCommand: () => true,
                 commandName: 'heartbeat',
                 options: {
-                    getSubcommand: () => 'on',
-                    getString: (name: string) => name === 'interval' ? '30m' : null,
-                    getChannel: (name: string) => name === 'channel' ? mockTargetChannel : null,
+                    getSubcommand: () => overrides.subcommand,
+                    getString: (name: string) => name === 'interval' ? (overrides.hasOwnProperty('interval') ? overrides.interval : '30m') : null,
+                    getChannel: (name: string) => name === 'channel' ? channel : null,
                 },
                 client: clientInstance,
-                channel: mockTargetChannel,
+                channel,
                 channelId: 'heartbeat-channel-id',
-                user: { id: '123' }, // allowed user in mocked config
+                user: overrides.user || { id: '123' }, // allowed user in mocked config
                 deferReply: jest.fn().mockResolvedValue(true),
                 editReply: editReplySpy,
             } as any;
+        };
+
+        it('handles heartbeat on command successfully', async () => {
+            const editReplySpy = jest.fn().mockResolvedValue(true);
+            const mockInteraction = makeMockInteraction({
+                subcommand: 'on',
+                interval: '30m',
+                editReply: editReplySpy,
+            });
 
             await interactionCallback(mockInteraction);
 
@@ -272,24 +290,11 @@ describe('Bot Startup', () => {
         it('fails heartbeat on if bot lacks send permissions', async () => {
             mockPermissions.has.mockReturnValue(false);
             const editReplySpy = jest.fn().mockResolvedValue(true);
-            const mockInteraction = {
-                isAutocomplete: () => false,
-                isButton: () => false,
-                isStringSelectMenu: () => false,
-                isChatInputCommand: () => true,
-                commandName: 'heartbeat',
-                options: {
-                    getSubcommand: () => 'on',
-                    getString: (name: string) => name === 'interval' ? '30m' : null,
-                    getChannel: (name: string) => name === 'channel' ? mockTargetChannel : null,
-                },
-                client: clientInstance,
-                channel: mockTargetChannel,
-                channelId: 'heartbeat-channel-id',
-                user: { id: '123' },
-                deferReply: jest.fn().mockResolvedValue(true),
+            const mockInteraction = makeMockInteraction({
+                subcommand: 'on',
+                interval: '30m',
                 editReply: editReplySpy,
-            } as any;
+            });
 
             await interactionCallback(mockInteraction);
 
@@ -298,24 +303,83 @@ describe('Bot Startup', () => {
             }));
         });
 
+        it('fails heartbeat on if channel is not text-based', async () => {
+            const nonTextChannel = {
+                id: 'non-text-id',
+                isTextBased: () => false,
+            };
+            const editReplySpy = jest.fn().mockResolvedValue(true);
+            const mockInteraction = makeMockInteraction({
+                subcommand: 'on',
+                targetChannel: nonTextChannel,
+                editReply: editReplySpy,
+            });
+
+            await interactionCallback(mockInteraction);
+
+            expect(editReplySpy).toHaveBeenCalledWith(expect.objectContaining({
+                content: expect.stringContaining('Please select a valid text channel'),
+            }));
+        });
+
+        it('fails heartbeat on if interval format is invalid', async () => {
+            const { parseInterval } = require('../src/services/heartbeatService');
+            parseInterval.mockReturnValueOnce(null);
+
+            const editReplySpy = jest.fn().mockResolvedValue(true);
+            const mockInteraction = makeMockInteraction({
+                subcommand: 'on',
+                interval: 'invalid-val',
+                editReply: editReplySpy,
+            });
+
+            await interactionCallback(mockInteraction);
+
+            expect(editReplySpy).toHaveBeenCalledWith(expect.objectContaining({
+                content: expect.stringContaining('Invalid interval format'),
+            }));
+        });
+
+        it('fails heartbeat on if interval is below 10 seconds', async () => {
+            const { parseInterval } = require('../src/services/heartbeatService');
+            parseInterval.mockReturnValueOnce(5000);
+
+            const editReplySpy = jest.fn().mockResolvedValue(true);
+            const mockInteraction = makeMockInteraction({
+                subcommand: 'on',
+                interval: '5s',
+                editReply: editReplySpy,
+            });
+
+            await interactionCallback(mockInteraction);
+
+            expect(editReplySpy).toHaveBeenCalledWith(expect.objectContaining({
+                content: expect.stringContaining('Interval must be at least 10 seconds'),
+            }));
+        });
+
+        it('handles heartbeat off command successfully', async () => {
+            const editReplySpy = jest.fn().mockResolvedValue(true);
+            const mockInteraction = makeMockInteraction({
+                subcommand: 'off',
+                editReply: editReplySpy,
+            });
+
+            await interactionCallback(mockInteraction);
+
+            const mockServiceInstance = (HeartbeatService as jest.Mock).mock.results[0].value;
+            expect(mockServiceInstance.disable).toHaveBeenCalled();
+            expect(editReplySpy).toHaveBeenCalledWith(expect.objectContaining({
+                content: expect.stringContaining('Heartbeat disabled'),
+            }));
+        });
+
         it('handles heartbeat status command and returns status embed', async () => {
             const editReplySpy = jest.fn().mockResolvedValue(true);
-            const mockInteraction = {
-                isAutocomplete: () => false,
-                isButton: () => false,
-                isStringSelectMenu: () => false,
-                isChatInputCommand: () => true,
-                commandName: 'heartbeat',
-                options: {
-                    getSubcommand: () => 'status',
-                },
-                client: clientInstance,
-                channel: mockTargetChannel,
-                channelId: 'heartbeat-channel-id',
-                user: { id: '123' },
-                deferReply: jest.fn().mockResolvedValue(true),
+            const mockInteraction = makeMockInteraction({
+                subcommand: 'status',
                 editReply: editReplySpy,
-            } as any;
+            });
 
             await interactionCallback(mockInteraction);
 

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -410,23 +410,25 @@ describe('Bot Startup', () => {
             const originalEnv = process.env.HEARTBEAT_ENABLED;
             process.env.HEARTBEAT_ENABLED = 'false';
 
-            const editReplySpy = jest.fn().mockResolvedValue(true);
-            const mockInteraction = makeMockInteraction({
-                subcommand: 'on',
-                interval: '30m',
-                editReply: editReplySpy,
-            });
+            try {
+                const editReplySpy = jest.fn().mockResolvedValue(true);
+                const mockInteraction = makeMockInteraction({
+                    subcommand: 'on',
+                    interval: '30m',
+                    editReply: editReplySpy,
+                });
 
-            await interactionCallback(mockInteraction);
+                await interactionCallback(mockInteraction);
 
-            expect(editReplySpy).toHaveBeenCalledWith(expect.objectContaining({
-                content: expect.stringContaining('Environment override(s) active: HEARTBEAT_ENABLED'),
-            }));
-
-            if (originalEnv === undefined) {
-                delete process.env.HEARTBEAT_ENABLED;
-            } else {
-                process.env.HEARTBEAT_ENABLED = originalEnv;
+                expect(editReplySpy).toHaveBeenCalledWith(expect.objectContaining({
+                    content: expect.stringContaining('Environment override(s) active: HEARTBEAT_ENABLED'),
+                }));
+            } finally {
+                if (originalEnv === undefined) {
+                    delete process.env.HEARTBEAT_ENABLED;
+                } else {
+                    process.env.HEARTBEAT_ENABLED = originalEnv;
+                }
             }
         });
 

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -11,6 +11,7 @@ jest.mock('discord.js', () => {
                 on: jest.fn(),
                 login: jest.fn().mockResolvedValue('test_token'),
                 guilds: { cache: new Map() },
+                user: { id: 'bot-id' },
             };
         }),
         GatewayIntentBits: {
@@ -22,6 +23,13 @@ jest.mock('discord.js', () => {
             ClientReady: 'ready',
             MessageCreate: 'messageCreate',
             InteractionCreate: 'interactionCreate',
+        },
+        MessageFlags: {
+            Ephemeral: 64,
+        },
+        ChannelType: {
+            GuildText: 0,
+            GuildAnnouncement: 5,
         },
         // Mock for slash commands
         SlashCommandBuilder: jest.fn().mockImplementation(() => {
@@ -56,6 +64,7 @@ jest.mock('discord.js', () => {
                     opt.setName = jest.fn().mockReturnValue(opt);
                     opt.setDescription = jest.fn().mockReturnValue(opt);
                     opt.setRequired = jest.fn().mockReturnValue(opt);
+                    opt.addChannelTypes = jest.fn().mockReturnValue(opt);
                     optFn(opt);
                     return sub;
                 });
@@ -154,6 +163,26 @@ jest.mock('../src/services/screenshotService', () => ({
     })),
 }));
 
+jest.mock('../src/services/heartbeatService', () => {
+    return {
+        HeartbeatService: jest.fn().mockImplementation(() => {
+            return {
+                init: jest.fn(),
+                start: jest.fn(),
+                stop: jest.fn(),
+                disable: jest.fn(),
+                recordActivity: jest.fn(),
+                updateConfig: jest.fn().mockResolvedValue(true),
+                botStartTime: Date.now() - 5000,
+                lastActivityTimestamp: Date.now() - 1000,
+            };
+        }),
+        parseInterval: jest.fn().mockReturnValue(1800000),
+        formatDuration: jest.fn().mockReturnValue('30m'),
+        formatRelativeTime: jest.fn().mockReturnValue('1m ago'),
+    };
+});
+
 describe('Bot Startup', () => {
     let clientInstance: any;
 
@@ -192,5 +221,107 @@ describe('Bot Startup', () => {
     it('forces response delivery mode to stream even when final-only is configured', () => {
         process.env.LAZYGRAVITY_RESPONSE_DELIVERY = 'final-only';
         expect(getResponseDeliveryModeForTest()).toBe('stream');
+    });
+
+    describe('heartbeat command interaction', () => {
+        let interactionCallback: (interaction: any) => Promise<void>;
+        let mockTargetChannel: any;
+        let mockPermissions: any;
+
+        beforeEach(() => {
+            interactionCallback = clientInstance.on.mock.calls.find((call: any) => call[0] === Events.InteractionCreate)[1];
+            mockPermissions = {
+                has: jest.fn().mockReturnValue(true),
+            };
+            mockTargetChannel = {
+                id: 'heartbeat-channel-id',
+                isTextBased: () => true,
+                permissionsFor: jest.fn().mockReturnValue(mockPermissions),
+            };
+        });
+
+        it('handles heartbeat on command successfully', async () => {
+            const editReplySpy = jest.fn().mockResolvedValue(true);
+            const mockInteraction = {
+                isAutocomplete: () => false,
+                isButton: () => false,
+                isStringSelectMenu: () => false,
+                isChatInputCommand: () => true,
+                commandName: 'heartbeat',
+                options: {
+                    getSubcommand: () => 'on',
+                    getString: (name: string) => name === 'interval' ? '30m' : null,
+                    getChannel: (name: string) => name === 'channel' ? mockTargetChannel : null,
+                },
+                client: clientInstance,
+                channel: mockTargetChannel,
+                channelId: 'heartbeat-channel-id',
+                user: { id: '123' }, // allowed user in mocked config
+                deferReply: jest.fn().mockResolvedValue(true),
+                editReply: editReplySpy,
+            } as any;
+
+            await interactionCallback(mockInteraction);
+
+            expect(mockTargetChannel.permissionsFor).toHaveBeenCalledWith(clientInstance.user);
+            expect(editReplySpy).toHaveBeenCalledWith(expect.objectContaining({
+                content: expect.stringContaining('Heartbeat enabled'),
+            }));
+        });
+
+        it('fails heartbeat on if bot lacks send permissions', async () => {
+            mockPermissions.has.mockReturnValue(false);
+            const editReplySpy = jest.fn().mockResolvedValue(true);
+            const mockInteraction = {
+                isAutocomplete: () => false,
+                isButton: () => false,
+                isStringSelectMenu: () => false,
+                isChatInputCommand: () => true,
+                commandName: 'heartbeat',
+                options: {
+                    getSubcommand: () => 'on',
+                    getString: (name: string) => name === 'interval' ? '30m' : null,
+                    getChannel: (name: string) => name === 'channel' ? mockTargetChannel : null,
+                },
+                client: clientInstance,
+                channel: mockTargetChannel,
+                channelId: 'heartbeat-channel-id',
+                user: { id: '123' },
+                deferReply: jest.fn().mockResolvedValue(true),
+                editReply: editReplySpy,
+            } as any;
+
+            await interactionCallback(mockInteraction);
+
+            expect(editReplySpy).toHaveBeenCalledWith(expect.objectContaining({
+                content: expect.stringContaining('Bot does not have permission'),
+            }));
+        });
+
+        it('handles heartbeat status command and returns status embed', async () => {
+            const editReplySpy = jest.fn().mockResolvedValue(true);
+            const mockInteraction = {
+                isAutocomplete: () => false,
+                isButton: () => false,
+                isStringSelectMenu: () => false,
+                isChatInputCommand: () => true,
+                commandName: 'heartbeat',
+                options: {
+                    getSubcommand: () => 'status',
+                },
+                client: clientInstance,
+                channel: mockTargetChannel,
+                channelId: 'heartbeat-channel-id',
+                user: { id: '123' },
+                deferReply: jest.fn().mockResolvedValue(true),
+                editReply: editReplySpy,
+            } as any;
+
+            await interactionCallback(mockInteraction);
+
+            expect(editReplySpy).toHaveBeenCalledWith(expect.objectContaining({
+                embeds: expect.any(Array),
+            }));
+        });
     });
 });

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -387,5 +387,60 @@ describe('Bot Startup', () => {
                 embeds: expect.any(Array),
             }));
         });
+
+        it('fails heartbeat on if interval is above 24.8 days', async () => {
+            const { parseInterval } = require('../src/services/heartbeatService');
+            parseInterval.mockReturnValueOnce(3000000000);
+
+            const editReplySpy = jest.fn().mockResolvedValue(true);
+            const mockInteraction = makeMockInteraction({
+                subcommand: 'on',
+                interval: '30d',
+                editReply: editReplySpy,
+            });
+
+            await interactionCallback(mockInteraction);
+
+            expect(editReplySpy).toHaveBeenCalledWith(expect.objectContaining({
+                content: expect.stringContaining('Interval cannot be greater than 24.8 days'),
+            }));
+        });
+
+        it('warns user of environment variables override if present', async () => {
+            const originalEnv = process.env.HEARTBEAT_ENABLED;
+            process.env.HEARTBEAT_ENABLED = 'false';
+
+            const editReplySpy = jest.fn().mockResolvedValue(true);
+            const mockInteraction = makeMockInteraction({
+                subcommand: 'on',
+                interval: '30m',
+                editReply: editReplySpy,
+            });
+
+            await interactionCallback(mockInteraction);
+
+            expect(editReplySpy).toHaveBeenCalledWith(expect.objectContaining({
+                content: expect.stringContaining('Environment override(s) active: HEARTBEAT_ENABLED'),
+            }));
+
+            if (originalEnv === undefined) {
+                delete process.env.HEARTBEAT_ENABLED;
+            } else {
+                process.env.HEARTBEAT_ENABLED = originalEnv;
+            }
+        });
+
+        it('excludes heartbeat commands from recording activity', async () => {
+            const mockServiceInstance = (HeartbeatService as jest.Mock).mock.results[0].value;
+            mockServiceInstance.recordActivity.mockClear();
+
+            const mockInteraction = makeMockInteraction({
+                subcommand: 'status',
+            });
+
+            await interactionCallback(mockInteraction);
+
+            expect(mockServiceInstance.recordActivity).not.toHaveBeenCalled();
+        });
     });
 });

--- a/tests/commands/registerSlashCommands.test.ts
+++ b/tests/commands/registerSlashCommands.test.ts
@@ -54,6 +54,15 @@ jest.mock('discord.js', () => {
                     optFn(option);
                     return sub;
                 }),
+                addChannelOption: jest.fn().mockImplementation((optFn: (option: any) => void) => {
+                    const option = {
+                        setName: jest.fn().mockReturnThis(),
+                        setDescription: jest.fn().mockReturnThis(),
+                        setRequired: jest.fn().mockReturnThis(),
+                    };
+                    optFn(option);
+                    return sub;
+                }),
             };
             fn(sub);
             return this;

--- a/tests/commands/registerSlashCommands.test.ts
+++ b/tests/commands/registerSlashCommands.test.ts
@@ -59,6 +59,7 @@ jest.mock('discord.js', () => {
                         setName: jest.fn().mockReturnThis(),
                         setDescription: jest.fn().mockReturnThis(),
                         setRequired: jest.fn().mockReturnThis(),
+                        addChannelTypes: jest.fn().mockReturnThis(),
                     };
                     optFn(option);
                     return sub;
@@ -84,6 +85,10 @@ jest.mock('discord.js', () => {
             applicationGuildCommands: jest.fn().mockReturnValue('/guild-commands'),
         },
         PermissionFlagsBits: { Administrator: 8n },
+        ChannelType: {
+            GuildText: 0,
+            GuildAnnouncement: 5,
+        },
     };
 });
 

--- a/tests/events/interactionCreateHandler.question.test.ts
+++ b/tests/events/interactionCreateHandler.question.test.ts
@@ -11,6 +11,10 @@ jest.mock('../../src/handlers/questionSkipAction', () => ({
     createQuestionSkipAction: jest.fn(),
 }));
 
+jest.mock('child_process', () => ({
+    execFile: jest.fn(),
+}));
+
 describe('interactionCreateHandler - question select and skip', () => {
     function createBaseDeps(overrides: Record<string, any> = {}) {
         return {

--- a/tests/services/heartbeatService.test.ts
+++ b/tests/services/heartbeatService.test.ts
@@ -27,8 +27,8 @@ describe('Heartbeat Utility Functions', () => {
             expect(parseInterval('2d')).toBe(172800000);
         });
 
-        it('defaults to hours for pure numbers', () => {
-            expect(parseInterval('3')).toBe(10800000);
+        it('returns null for pure numbers (unit required)', () => {
+            expect(parseInterval('3')).toBeNull();
         });
 
         it('returns null for invalid format', () => {
@@ -133,7 +133,7 @@ describe('HeartbeatService', () => {
         (ConfigLoader.load as jest.Mock).mockReturnValue({
             heartbeatEnabled: true,
             heartbeatChannelId: 'channel-123',
-            heartbeatIntervalMs: 5000,
+            heartbeatIntervalMs: 15000,
         });
 
         service.init(mockClient, mockBridge);
@@ -144,11 +144,11 @@ describe('HeartbeatService', () => {
         expect(sendSpy).toHaveBeenCalledTimes(1); // Immediate call
         expect(jest.getTimerCount()).toBe(1);
 
-        jest.advanceTimersByTime(5000);
+        jest.advanceTimersByTime(15000);
         expect(sendSpy).toHaveBeenCalledTimes(2);
     });
 
-    it('uses configured interval of 0 if explicitly provided', () => {
+    it('clamps interval to 10000ms if configured interval is below 10000ms', () => {
         (ConfigLoader.load as jest.Mock).mockReturnValue({
             heartbeatEnabled: true,
             heartbeatChannelId: 'channel-123',
@@ -161,14 +161,30 @@ describe('HeartbeatService', () => {
         const logSpy = jest.spyOn(require('../../src/utils/logger').logger, 'info');
         service.start();
 
-        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('every 0ms'));
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('every 10000ms'));
+    });
+
+    it('clamps interval to 2147483647ms if configured interval is above 2147483647ms', () => {
+        (ConfigLoader.load as jest.Mock).mockReturnValue({
+            heartbeatEnabled: true,
+            heartbeatChannelId: 'channel-123',
+            heartbeatIntervalMs: 3000000000,
+        });
+
+        service.init(mockClient, mockBridge);
+        jest.spyOn(service, 'sendHeartbeat').mockResolvedValue(undefined);
+
+        const logSpy = jest.spyOn(require('../../src/utils/logger').logger, 'info');
+        service.start();
+
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('every 2147483647ms'));
     });
 
     it('stops interval on stop()', () => {
         (ConfigLoader.load as jest.Mock).mockReturnValue({
             heartbeatEnabled: true,
             heartbeatChannelId: 'channel-123',
-            heartbeatIntervalMs: 5000,
+            heartbeatIntervalMs: 15000,
         });
 
         service.init(mockClient, mockBridge);
@@ -181,14 +197,77 @@ describe('HeartbeatService', () => {
         expect(jest.getTimerCount()).toBe(0);
     });
 
-    it('disables heartbeat on disable()', async () => {
+    it('disables heartbeat on disable() and deletes old message', async () => {
+        const mockDelete = jest.fn().mockResolvedValue(true);
+        const mockMessage = {
+            id: 'msg-abc',
+            author: { id: 'bot-id' },
+            delete: mockDelete,
+        };
+        const mockChannel = {
+            isTextBased: () => true,
+            messages: {
+                fetch: jest.fn().mockResolvedValue(mockMessage),
+            },
+        };
+        mockClient.channels.fetch.mockResolvedValue(mockChannel);
+
+        (ConfigLoader.load as jest.Mock).mockReturnValue({
+            heartbeatEnabled: true,
+            heartbeatChannelId: 'channel-123',
+            heartbeatLastMessageId: 'msg-abc',
+        });
+
         service.init(mockClient, mockBridge);
         await service.disable();
 
+        expect(mockClient.channels.fetch).toHaveBeenCalledWith('channel-123');
+        expect(mockChannel.messages.fetch).toHaveBeenCalledWith('msg-abc');
+        expect(mockDelete).toHaveBeenCalled();
+
         expect(ConfigLoader.save).toHaveBeenCalledWith({
             heartbeatEnabled: false,
+            heartbeatLastMessageId: undefined,
         });
         expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it('deletes old message when channel changes on updateConfig()', async () => {
+        const mockDelete = jest.fn().mockResolvedValue(true);
+        const mockMessage = {
+            id: 'msg-abc',
+            author: { id: 'bot-id' },
+            delete: mockDelete,
+        };
+        const mockChannel = {
+            isTextBased: () => true,
+            messages: {
+                fetch: jest.fn().mockResolvedValue(mockMessage),
+            },
+        };
+        mockClient.channels.fetch.mockResolvedValue(mockChannel);
+
+        (ConfigLoader.load as jest.Mock).mockReturnValue({
+            heartbeatEnabled: true,
+            heartbeatChannelId: 'channel-old',
+            heartbeatLastMessageId: 'msg-abc',
+        });
+
+        service.init(mockClient, mockBridge);
+        await service.updateConfig(true, 30000, 'channel-new');
+
+        expect(mockClient.channels.fetch).toHaveBeenCalledWith('channel-old');
+        expect(mockChannel.messages.fetch).toHaveBeenCalledWith('msg-abc');
+        expect(mockDelete).toHaveBeenCalled();
+
+        expect(ConfigLoader.save).toHaveBeenCalledWith({
+            heartbeatLastMessageId: undefined,
+        });
+        expect(ConfigLoader.save).toHaveBeenCalledWith({
+            heartbeatEnabled: true,
+            heartbeatIntervalMs: 30000,
+            heartbeatChannelId: 'channel-new',
+        });
     });
 
     describe('sendHeartbeat', () => {

--- a/tests/services/heartbeatService.test.ts
+++ b/tests/services/heartbeatService.test.ts
@@ -1,0 +1,246 @@
+import { HeartbeatService, parseInterval, formatDuration, formatRelativeTime } from '../../src/services/heartbeatService';
+import { ConfigLoader } from '../../src/utils/configLoader';
+
+jest.mock('../../src/utils/configLoader');
+
+describe('Heartbeat Utility Functions', () => {
+    describe('parseInterval', () => {
+        it('parses hours correctly', () => {
+            expect(parseInterval('1h')).toBe(3600000);
+            expect(parseInterval('6h')).toBe(21600000);
+        });
+
+        it('parses minutes correctly', () => {
+            expect(parseInterval('30m')).toBe(1800000);
+            expect(parseInterval('5m')).toBe(300000);
+        });
+
+        it('parses seconds correctly', () => {
+            expect(parseInterval('10s')).toBe(10000);
+        });
+
+        it('parses milliseconds correctly', () => {
+            expect(parseInterval('500ms')).toBe(500);
+        });
+
+        it('parses days correctly', () => {
+            expect(parseInterval('2d')).toBe(172800000);
+        });
+
+        it('defaults to hours for pure numbers', () => {
+            expect(parseInterval('3')).toBe(10800000);
+        });
+
+        it('returns null for invalid format', () => {
+            expect(parseInterval('abc')).toBeNull();
+            expect(parseInterval('')).toBeNull();
+        });
+    });
+
+    describe('formatDuration', () => {
+        it('formats seconds correctly', () => {
+            expect(formatDuration(5000)).toBe('5s');
+        });
+
+        it('formats minutes and seconds correctly', () => {
+            expect(formatDuration(65000)).toBe('1m 5s');
+        });
+
+        it('formats hours, minutes and seconds correctly', () => {
+            expect(formatDuration(3665000)).toBe('1h 1m 5s');
+        });
+
+        it('formats days, hours, minutes and seconds correctly', () => {
+            expect(formatDuration(90065000)).toBe('1d 1h 1m 5s');
+        });
+    });
+
+    describe('formatRelativeTime', () => {
+        it('formats recent events as just now', () => {
+            expect(formatRelativeTime(Date.now() - 2000)).toBe('just now');
+        });
+
+        it('formats seconds ago correctly', () => {
+            expect(formatRelativeTime(Date.now() - 10000)).toBe('10s ago');
+        });
+
+        it('formats minutes ago correctly', () => {
+            expect(formatRelativeTime(Date.now() - 180000)).toBe('3m ago');
+        });
+
+        it('formats hours ago correctly', () => {
+            expect(formatRelativeTime(Date.now() - 7200000)).toBe('2h 0m ago');
+        });
+    });
+});
+
+describe('HeartbeatService', () => {
+    let service: HeartbeatService;
+    let mockClient: any;
+    let mockBridge: any;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        service = new HeartbeatService();
+        mockClient = {
+            user: { id: 'bot-id', tag: 'bot#1234' },
+            channels: {
+                fetch: jest.fn(),
+            },
+        };
+        mockBridge = {
+            pool: {
+                getActiveWorkspaceNames: jest.fn().mockReturnValue(['project-a']),
+            },
+        };
+    });
+
+    afterEach(() => {
+        service.stop();
+        jest.useRealTimers();
+        jest.resetAllMocks();
+    });
+
+    it('initializes times on init()', () => {
+        const now = Date.now();
+        service.init(mockClient, mockBridge);
+        expect(service.botStartTime).toBeGreaterThanOrEqual(now);
+        expect(service.lastActivityTimestamp).toBeGreaterThanOrEqual(now);
+    });
+
+    it('updates last activity on recordActivity()', () => {
+        service.init(mockClient, mockBridge);
+        const originalTime = service.lastActivityTimestamp;
+        
+        jest.advanceTimersByTime(5000);
+        service.recordActivity();
+        
+        expect(service.lastActivityTimestamp).toBeGreaterThan(originalTime);
+    });
+
+    it('does not start heartbeat if disabled in config', () => {
+        (ConfigLoader.load as jest.Mock).mockReturnValue({
+            heartbeatEnabled: false,
+        });
+
+        service.init(mockClient, mockBridge);
+        service.start();
+
+        expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it('starts heartbeat if enabled in config', () => {
+        (ConfigLoader.load as jest.Mock).mockReturnValue({
+            heartbeatEnabled: true,
+            heartbeatChannelId: 'channel-123',
+            heartbeatIntervalMs: 5000,
+        });
+
+        service.init(mockClient, mockBridge);
+        const sendSpy = jest.spyOn(service, 'sendHeartbeat').mockResolvedValue(undefined);
+
+        service.start();
+
+        expect(sendSpy).toHaveBeenCalledTimes(1); // Immediate call
+        expect(jest.getTimerCount()).toBe(1);
+
+        jest.advanceTimersByTime(5000);
+        expect(sendSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('stops interval on stop()', () => {
+        (ConfigLoader.load as jest.Mock).mockReturnValue({
+            heartbeatEnabled: true,
+            heartbeatChannelId: 'channel-123',
+            heartbeatIntervalMs: 5000,
+        });
+
+        service.init(mockClient, mockBridge);
+        jest.spyOn(service, 'sendHeartbeat').mockResolvedValue(undefined);
+
+        service.start();
+        expect(jest.getTimerCount()).toBe(1);
+
+        service.stop();
+        expect(jest.getTimerCount()).toBe(0);
+    });
+
+    it('disables heartbeat on disable()', () => {
+        service.init(mockClient, mockBridge);
+        service.disable();
+
+        expect(ConfigLoader.save).toHaveBeenCalledWith({
+            heartbeatEnabled: false,
+        });
+        expect(jest.getTimerCount()).toBe(0);
+    });
+
+    describe('sendHeartbeat', () => {
+        let mockChannel: any;
+        let mockMessage: any;
+
+        beforeEach(() => {
+            mockMessage = {
+                id: 'msg-abc',
+                author: { id: 'bot-id' },
+                edit: jest.fn().mockResolvedValue(true),
+            };
+            mockChannel = {
+                isTextBased: jest.fn().mockReturnValue(true),
+                send: jest.fn().mockResolvedValue(mockMessage),
+                messages: {
+                    fetch: jest.fn().mockResolvedValue(mockMessage),
+                },
+            };
+            mockClient.channels.fetch.mockResolvedValue(mockChannel);
+        });
+
+        it('sends a new message if no lastMessageId is configured', async () => {
+            (ConfigLoader.load as jest.Mock).mockReturnValue({
+                heartbeatEnabled: true,
+                heartbeatChannelId: 'channel-123',
+            });
+
+            service.init(mockClient, mockBridge);
+            await service.sendHeartbeat();
+
+            expect(mockChannel.send).toHaveBeenCalled();
+            expect(ConfigLoader.save).toHaveBeenCalledWith({
+                heartbeatLastMessageId: 'msg-abc',
+            });
+        });
+
+        it('edits existing message in-place if lastMessageId is configured and message matches author', async () => {
+            (ConfigLoader.load as jest.Mock).mockReturnValue({
+                heartbeatEnabled: true,
+                heartbeatChannelId: 'channel-123',
+                heartbeatLastMessageId: 'msg-abc',
+            });
+
+            service.init(mockClient, mockBridge);
+            await service.sendHeartbeat();
+
+            expect(mockChannel.messages.fetch).toHaveBeenCalledWith('msg-abc');
+            expect(mockMessage.edit).toHaveBeenCalled();
+            expect(mockChannel.send).not.toHaveBeenCalled();
+        });
+
+        it('sends new message if lastMessageId fails to fetch', async () => {
+            (ConfigLoader.load as jest.Mock).mockReturnValue({
+                heartbeatEnabled: true,
+                heartbeatChannelId: 'channel-123',
+                heartbeatLastMessageId: 'msg-abc',
+            });
+            mockChannel.messages.fetch.mockRejectedValue(new Error('not found'));
+
+            service.init(mockClient, mockBridge);
+            await service.sendHeartbeat();
+
+            expect(mockChannel.messages.fetch).toHaveBeenCalledWith('msg-abc');
+            expect(mockChannel.send).toHaveBeenCalled();
+            expect(ConfigLoader.save).toHaveBeenCalledWith({
+                heartbeatLastMessageId: 'msg-abc',
+            });
+        });
+    });
+});

--- a/tests/services/heartbeatService.test.ts
+++ b/tests/services/heartbeatService.test.ts
@@ -148,6 +148,22 @@ describe('HeartbeatService', () => {
         expect(sendSpy).toHaveBeenCalledTimes(2);
     });
 
+    it('uses configured interval of 0 if explicitly provided', () => {
+        (ConfigLoader.load as jest.Mock).mockReturnValue({
+            heartbeatEnabled: true,
+            heartbeatChannelId: 'channel-123',
+            heartbeatIntervalMs: 0,
+        });
+
+        service.init(mockClient, mockBridge);
+        jest.spyOn(service, 'sendHeartbeat').mockResolvedValue(undefined);
+
+        const logSpy = jest.spyOn(require('../../src/utils/logger').logger, 'info');
+        service.start();
+
+        expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('every 0ms'));
+    });
+
     it('stops interval on stop()', () => {
         (ConfigLoader.load as jest.Mock).mockReturnValue({
             heartbeatEnabled: true,
@@ -165,9 +181,9 @@ describe('HeartbeatService', () => {
         expect(jest.getTimerCount()).toBe(0);
     });
 
-    it('disables heartbeat on disable()', () => {
+    it('disables heartbeat on disable()', async () => {
         service.init(mockClient, mockBridge);
-        service.disable();
+        await service.disable();
 
         expect(ConfigLoader.save).toHaveBeenCalledWith({
             heartbeatEnabled: false,


### PR DESCRIPTION
### Summary
Resolves https://github.com/tokyoweb3/LazyGravity/issues/6 by introducing an optional, periodic keep-alive heartbeat notification. This allows operators to passively monitor the health, connectivity, and status of their local IDE control plane from their mobile device or remote Discord channel. When running LazyGravity remotely, users have no way of knowing if the local PC went to sleep, the home internet disconnected, or the bot crashed without sending active commands (which can generate unwanted side-effects or connection updates). A quiet, periodic heartbeat offers passive confirmation of health. By updating a single Discord status message **in-place** (editing it rather than spamming), the channel remains clean.

## Changelog

### Heartbeat Service Implementation
- **`src/services/heartbeatService.ts`**: Created a new `HeartbeatService` that tracks:
  - Uptime (duration since bot start)
  - Active workspaces/projects count
  - Last activity relative time (updated when message/slash commands occur)
  - Updates the heartbeat message in-place in Discord using `heartbeatLastMessageId` if possible to avoid cluttering the channel.
  - Implemented helpers: `parseInterval` (e.g. `1h` -> `3600000`), `formatDuration`, and `formatRelativeTime`.
### Slash Command Registration
- **`src/commands/registerSlashCommands.ts`**: Registered the new `/heartbeat` command with three subcommands:
  - `on [interval] [channel]`
  - `off`
  - `status`
### Submodule Configuration Updates
- **`src/utils/config.ts`**: Added `heartbeatEnabled`, `heartbeatIntervalMs`, `heartbeatChannelId`, and `heartbeatLastMessageId` properties to the `AppConfig` interface.
- **`src/utils/configLoader.ts`**: Added the new settings to the JSON-serializable `PersistedConfig` interface and resolved them in `mergeConfig` from environment variables, persistent settings, or defaults.
### Activity Hooking & Lifecycle Integration
- **`src/events/messageCreateHandler.ts`**: Added the `heartbeatService` to dependencies, called `recordActivity` on incoming authorized operator messages, and added `'heartbeat'` to `slashOnlyCommands` to redirect chat prefix usages.
- **`src/events/interactionCreateHandler.ts`**: Added the `heartbeatService` to dependencies, called `recordActivity` on incoming slash interactions, and forwarded the service to `handleSlashInteraction`.
- **`src/bot/index.ts`**:
  - Instantiated `HeartbeatService` in `startBot`.
  - Initialized and started it in the `Events.ClientReady` callback.
  - Handled the `/heartbeat` command interactions.
### PR Feedback & Safety Updates
- **`src/utils/configLoader.ts`**: Removed `process.env.HEARTBEAT_LAST_MESSAGE_ID` environment resolution, ensuring `heartbeatLastMessageId` is treated as persistent runtime state only.
- **`src/services/heartbeatService.ts`**:
  - Enforced unit descriptors in `parseInterval()` (pure numbers are now rejected during validation to avoid ambiguity).
  - Added safety interval clamping (`10000` ms lower limit, `2147483647` ms upper limit) inside `start()` to prevent timer overflow and 1ms send loops.
  - Added previous message cleanup upon disabling the heartbeat or changing target channels.
- **`src/events/interactionCreateHandler.ts`**: Excluded `heartbeat` command interactions from calling `recordActivity()` so `/heartbeat status` does not measure its own invocation.
- **`src/commands/registerSlashCommands.ts`**: Updated interval option description to clarify that units are required, featuring day, hour, and minute examples (e.g. `1d`, `1h`, `30m`).
- **`src/bot/index.ts`**:
  - Added upper-bound validation checks (`intervalMs > 2147483647`).
  - Added warnings when configuration changes might be overridden by active environment variables.
  - Provided descriptive unit examples (including `1d`, `1h`, and `30m`) in the invalid interval validation error message.
---
## Test & Validation Results
### Mocking Updates
- Added `addChannelOption` support to mocks of `SlashCommandBuilder.addSubcommand` in:
  - **`tests/bot.test.ts`**
  - **`tests/commands/registerSlashCommands.test.ts`**
- Mocked `MessageFlags` and `ChannelType` in the `discord.js` mock in **`tests/bot.test.ts`**.
- Configured a mock `user` object on the mocked client instance and injected `channelId: 'heartbeat-channel-id'` to prevent `inferParentScopeChannelId` runtime errors during test interaction execution.
### Unit Tests
- Updated **`tests/services/heartbeatService.test.ts`**, verifying:
  - human-readable interval strings parse correctly, while pure numbers return null.
  - interval clamping behaves correctly on lower/upper limits.
  - previous message cleanup is executed successfully on channel changes and disable events.
- Updated **`tests/bot.test.ts`**, verifying:
  - Upper-bound validation is checked correctly on command handling.
  - Environment overrides warning banners are returned when overrides are active (safely wrapped in a `try...finally` block to ensure environment state is cleanly restored).
  - Heartbeat commands do not record activity.
- Updated **`tests/events/interactionCreateHandler.question.test.ts`**:
  - Mocked `child_process` globally to prevent the real `execFile` CLI utility from executing during relative file open tests, fixing a background process leak that caused Jest workers to stall indefinitely.
### Test Run
- Compiled and built TypeScript successfully (`npm run build`).
- Executed local tests: All 115 test suites and 1,530 tests passed cleanly, including the new heartbeat unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `/heartbeat` slash command to enable/disable and view heartbeat status.
  * Heartbeats show uptime and last activity, and can be configured with an interval and target text channel.
* **Bug Fixes**
  * Heartbeat “last activity” now updates based on messages from allowed users.
  * Heartbeat updates edit the existing message when possible, otherwise send a new one.
* **Documentation**
  * Updated README with `/heartbeat` usage and options.
* **Tests**
  * Expanded tests for the `/heartbeat` command and heartbeat service lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->