### PR TITLE
feat: Increase JSDoc/Docstring Coverage and Other Improvements

### DIFF
--- a/src/bin/commands/doctor.ts
+++ b/src/bin/commands/doctor.ts
@@ -13,11 +13,21 @@ const warn = (msg: string) => console.log(`  ${COLORS.yellow}[--]${COLORS.reset}
 const fail = (msg: string) => console.log(`  ${COLORS.red}[!!]${COLORS.reset} ${msg}`);
 const hint = (msg: string) => console.log(`       ${COLORS.dim}${msg}${COLORS.reset}`);
 
+/**
+ * Result structure of a single CDP port live check.
+ */
 interface PortCheckResult {
+    /** Whether the target port is listening and active. */
     alive: boolean;
+    /** List of target connections parsed from `/json/list`. */
     targets?: any[];
 }
 
+/**
+ * Check if the specified HTTP port is listening and responsive.
+ * @param port Target port number.
+ * @returns Port check status and optional targets list.
+ */
 function checkPort(port: number): Promise<PortCheckResult> {
     return new Promise((resolve) => {
         const req = http.get(`http://127.0.0.1:${port}/json/list`, (res) => {
@@ -44,6 +54,10 @@ function checkPort(port: number): Promise<PortCheckResult> {
     });
 }
 
+/**
+ * Checks for the presence of a local `.env` file in the current directory.
+ * @returns Object indicating status and absolute path.
+ */
 function checkEnvFile(): { exists: boolean; path: string } {
     const envPath = path.resolve(process.cwd(), '.env');
     return { exists: fs.existsSync(envPath), path: envPath };
@@ -51,6 +65,10 @@ function checkEnvFile(): { exists: boolean; path: string } {
 
 const VALID_PLATFORMS: readonly PlatformType[] = ['discord', 'telegram'];
 
+/**
+ * Checks environment configuration to determine currently configured chat platforms.
+ * @returns Array of active platform types.
+ */
 function getActivePlatforms(): PlatformType[] {
     const raw = process.env.PLATFORMS || 'discord';
     return raw
@@ -59,6 +77,10 @@ function getActivePlatforms(): PlatformType[] {
         .filter((p): p is PlatformType => VALID_PLATFORMS.includes(p as PlatformType));
 }
 
+/**
+ * Validates whether required variables are configured based on active platforms.
+ * @returns List of variable check status items.
+ */
 function checkRequiredEnvVars(): { name: string; set: boolean }[] {
     const platforms = getActivePlatforms();
     const required: string[] = [];
@@ -76,6 +98,9 @@ function checkRequiredEnvVars(): { name: string; set: boolean }[] {
     }));
 }
 
+/**
+ * Executes a diagnosis check suite to analyze local system health, configuration, and connectivity.
+ */
 export async function doctorAction(): Promise<void> {
     console.log(`\n${COLORS.cyan}lazy-gravity doctor${COLORS.reset}\n`);
     let allOk = true;

--- a/src/bin/commands/open.ts
+++ b/src/bin/commands/open.ts
@@ -18,6 +18,8 @@ const C = {
 
 /**
  * Check whether a TCP port is available (not in use) by attempting to listen on it.
+ * @param port Target port number.
+ * @returns Whether the port is available.
  */
 function isPortAvailable(port: number): Promise<boolean> {
     return new Promise((resolve) => {
@@ -30,6 +32,10 @@ function isPortAvailable(port: number): Promise<boolean> {
     });
 }
 
+/**
+ * Iterates over standard candidate ports to find the first unused TCP port.
+ * @returns Available port number, or null if none are available.
+ */
 async function findAvailablePort(): Promise<number | null> {
     for (const port of CDP_PORTS) {
         if (await isPortAvailable(port)) {
@@ -39,6 +45,11 @@ async function findAvailablePort(): Promise<number | null> {
     return null;
 }
 
+/**
+ * Spawns Antigravity with debugging port enabled on macOS.
+ * @param port Debugging target port.
+ * @returns Promise resolving on spawn completion.
+ */
 function openMacOS(port: number): Promise<void> {
     return new Promise((resolve, reject) => {
         execFile('open', ['-a', APP_NAME, '--args', `--remote-debugging-port=${port}`], (err) => {
@@ -51,6 +62,11 @@ function openMacOS(port: number): Promise<void> {
     });
 }
 
+/**
+ * Spawns Antigravity with debugging port enabled on Windows.
+ * @param port Debugging target port.
+ * @returns Promise resolving on spawn completion.
+ */
 function openWindows(port: number): Promise<void> {
     return new Promise((resolve, reject) => {
         execFile(APP_NAME, [`--remote-debugging-port=${port}`], { shell: true }, (err) => {
@@ -63,6 +79,11 @@ function openWindows(port: number): Promise<void> {
     });
 }
 
+/**
+ * Spawns Antigravity with debugging port enabled on Linux.
+ * @param port Debugging target port.
+ * @returns Promise resolving on spawn completion.
+ */
 function openLinux(port: number): Promise<void> {
     return new Promise((resolve, reject) => {
         try {
@@ -85,6 +106,10 @@ function openLinux(port: number): Promise<void> {
 
 /**
  * Poll CDP endpoint until it responds or timeout is reached.
+ * @param port Debugging port to poll.
+ * @param timeoutMs Maximum duration to poll.
+ * @param intervalMs Time between checks.
+ * @returns Whether the port responded before timeout.
  */
 function waitForCdp(port: number, timeoutMs: number = 15000, intervalMs: number = 1000): Promise<boolean> {
     const start = Date.now();
@@ -123,6 +148,9 @@ function waitForCdp(port: number, timeoutMs: number = 15000, intervalMs: number 
     });
 }
 
+/**
+ * Command action to open/launch the Antigravity application with CDP enabled on a free port.
+ */
 export async function openAction(): Promise<void> {
     const platform = os.platform();
 

--- a/src/bin/commands/setup.ts
+++ b/src/bin/commands/setup.ts
@@ -3,6 +3,7 @@ import * as https from 'https';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+
 // @inquirer/select is ESM-only — use native import() that tsc won't rewrite to require()
 // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
 const dynamicImport = new Function('specifier', 'return import(specifier)') as (specifier: string) => Promise<any>;
@@ -10,6 +11,10 @@ const dynamicImport = new Function('specifier', 'return import(specifier)') as (
 type SelectFn = typeof import('@inquirer/select')['default'];
 let _select: SelectFn | undefined;
 
+/**
+ * Lazily loads the inquirer select function dynamically to support ES Module format.
+ * @returns Inquirer select prompt function.
+ */
 async function getSelect(): Promise<SelectFn> {
     if (_select === undefined) {
         const mod = await dynamicImport('@inquirer/select');
@@ -52,14 +57,29 @@ ${C.cyan}                \\__)      \\__)${C.reset}
 // Pure validators
 // ---------------------------------------------------------------------------
 
+/**
+ * Validates if the input string is not empty.
+ * @param value String candidate.
+ * @returns True if not empty.
+ */
 function isNonEmpty(value: string): boolean {
     return value.trim().length > 0;
 }
 
+/**
+ * Validates if the input string represents only digits.
+ * @param value String candidate.
+ * @returns True if numeric digits.
+ */
 function isNumericString(value: string): boolean {
     return /^\d+$/.test(value.trim());
 }
 
+/**
+ * Parses comma-separated user ID values from terminal inputs.
+ * @param raw Raw input string.
+ * @returns Clean parsed list array.
+ */
 function parseAllowedUserIds(raw: string): string[] {
     return raw
         .split(',')
@@ -67,6 +87,11 @@ function parseAllowedUserIds(raw: string): string[] {
         .filter((id) => id.length > 0);
 }
 
+/**
+ * Validates raw user IDs string format for terminal prompts.
+ * @param raw Input string.
+ * @returns Error description string, or null if valid.
+ */
 function validateAllowedUserIds(raw: string): string | null {
     const ids = parseAllowedUserIds(raw);
     if (ids.length === 0) {
@@ -79,6 +104,11 @@ function validateAllowedUserIds(raw: string): string | null {
     return null;
 }
 
+/**
+ * Expands home tilde characters into the user's home directory.
+ * @param raw Input path string.
+ * @returns Expanded absolute path string.
+ */
 function expandTilde(raw: string): string {
     if (raw === '~') return os.homedir();
     if (raw.startsWith('~/')) return path.join(os.homedir(), raw.slice(2));
@@ -89,14 +119,21 @@ function expandTilde(raw: string): string {
 // Discord API helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Representation of Discord API bot info.
+ */
 interface BotInfo {
+    /** Bot application ID. */
     id: string;
+    /** Bot username string. */
     username: string;
 }
 
 /**
  * Extract Bot ID from a Discord token.
  * Token format: base64(bot_id).timestamp.hmac
+ * @param token Raw Discord bot token.
+ * @returns Extracted bot/client ID or null.
  */
 function extractBotIdFromToken(token: string): string | null {
     const parts = token.split('.');
@@ -111,6 +148,8 @@ function extractBotIdFromToken(token: string): string | null {
 
 /**
  * Verify a Discord bot token via GET /users/@me and return bot info.
+ * @param token Bot token to verify.
+ * @returns BotInfo metadata object or null.
  */
 function verifyToken(token: string): Promise<BotInfo | null> {
     return new Promise((resolve) => {
@@ -144,6 +183,10 @@ function verifyToken(token: string): Promise<BotInfo | null> {
 // Readline helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Factory creating readline interface.
+ * @returns Readline interface instance.
+ */
 function createInterface(): readline.Interface {
     return readline.createInterface({
         input: process.stdin,
@@ -151,6 +194,12 @@ function createInterface(): readline.Interface {
     });
 }
 
+/**
+ * Helper to prompt the user with a question.
+ * @param rl Readline interface.
+ * @param prompt Prompt message.
+ * @returns Answer string.
+ */
 function ask(rl: readline.Interface, prompt: string): Promise<string> {
     return new Promise((resolve) => {
         rl.question(prompt, (answer) => {
@@ -162,6 +211,9 @@ function ask(rl: readline.Interface, prompt: string): Promise<string> {
 /**
  * Read a secret value without echoing to the terminal.
  * Falls back to normal readline if raw mode is unavailable (e.g. piped stdin).
+ * @param rl Readline interface.
+ * @param prompt Prompt message.
+ * @returns Secret input string.
  */
 function askSecret(rl: readline.Interface, prompt: string): Promise<string> {
     return new Promise((resolve) => {
@@ -212,22 +264,42 @@ function askSecret(rl: readline.Interface, prompt: string): Promise<string> {
 // Output helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Output helper logging section header.
+ * @param title Header title.
+ */
 function sectionHeader(title: string): void {
     console.log(`\n  ${C.cyan}—${C.reset} ${C.bold}${title}${C.reset}\n`);
 }
 
+/**
+ * Output helper logging hint information.
+ * @param text Hint text.
+ */
 function hint(text: string): void {
     console.log(`  ${C.dim}${text}${C.reset}`);
 }
 
+/**
+ * Prints a blank hint line.
+ */
 function hintBlank(): void {
     console.log('');
 }
 
+/**
+ * Output helper logging error messages.
+ * @param text Error text.
+ */
 function errMsg(text: string): void {
     console.log(`  ${C.red}${text}${C.reset}\n`);
 }
 
+/**
+ * Helper building Discord bot OAuth invite URL.
+ * @param clientId Bot application client ID.
+ * @returns OAuth invite URL.
+ */
 function buildInviteUrl(clientId: string): string {
     const permissions = '2147485696';
     return `https://discord.com/api/oauth2/authorize?client_id=${clientId}&permissions=${permissions}&scope=bot%20applications.commands`;
@@ -237,18 +309,38 @@ function buildInviteUrl(clientId: string): string {
 // Status detection (pure functions)
 // ---------------------------------------------------------------------------
 
+/**
+ * Checks if Discord is fully configured.
+ * @param p Current configurations.
+ * @returns True if configured.
+ */
 function isDiscordConfigured(p: PersistedConfig): boolean {
     return !!(p.discordToken && p.clientId && p.allowedUserIds && p.allowedUserIds.length > 0);
 }
 
+/**
+ * Checks if Telegram is fully configured.
+ * @param p Current configurations.
+ * @returns True if configured.
+ */
 function isTelegramConfigured(p: PersistedConfig): boolean {
     return !!(p.telegramToken && p.telegramAllowedUserIds && p.telegramAllowedUserIds.length > 0);
 }
 
+/**
+ * Formats directory path label for displays.
+ * @param p Current configurations.
+ * @returns Display workspace directory path.
+ */
 function workspaceLabel(p: PersistedConfig): string {
     return p.workspaceBaseDir ?? (path.join(os.homedir(), 'Code') + ' (default)');
 }
 
+/**
+ * Validates raw Telegram bot token format.
+ * @param token Candidate token.
+ * @returns True if format matches telegram credentials regex.
+ */
 function isValidTelegramTokenFormat(token: string): boolean {
     return /^\d+:[A-Za-z0-9_-]+$/.test(token);
 }
@@ -268,6 +360,7 @@ function savePlatformsFromState(): void {
 
 /**
  * Add a platform to the persisted platforms list (idempotent).
+ * @param platform Target platform.
  */
 function addPlatform(platform: PlatformType): void {
     const current = ConfigLoader.readPersisted();
@@ -280,6 +373,7 @@ function addPlatform(platform: PlatformType): void {
 /**
  * Remove a platform from the persisted platforms list (idempotent).
  * Credentials are preserved — only the enabled flag changes.
+ * @param platform Target platform.
  */
 function removePlatform(platform: PlatformType): void {
     const current = ConfigLoader.readPersisted();
@@ -289,6 +383,13 @@ function removePlatform(platform: PlatformType): void {
 
 type PlatformStatus = 'enabled' | 'disabled' | 'not_configured';
 
+/**
+ * Determines current platform setup status.
+ * @param hasCredentials Credentials configured state.
+ * @param platforms Enabled platforms list.
+ * @param platform Target platform.
+ * @returns Platform status.
+ */
 function platformStatus(
     hasCredentials: boolean,
     platforms: PlatformType[] | undefined,
@@ -299,6 +400,11 @@ function platformStatus(
     return 'disabled';
 }
 
+/**
+ * Formats a stylized status badge string for choices.
+ * @param status Target status string.
+ * @returns Stylized badge.
+ */
 function statusBadge(status: PlatformStatus): string {
     switch (status) {
         case 'enabled':
@@ -314,6 +420,11 @@ function statusBadge(status: PlatformStatus): string {
 // Input prompt helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Prompts user for Discord bot token and performs online validation.
+ * @param rl Readline interface.
+ * @returns Token parameters object.
+ */
 async function promptToken(rl: readline.Interface): Promise<{ token: string; clientId: string; botName: string | null }> {
     while (true) {
         const token = await askSecret(rl, `  ${C.yellow}>${C.reset} `);
@@ -343,6 +454,11 @@ async function promptToken(rl: readline.Interface): Promise<{ token: string; cli
     }
 }
 
+/**
+ * Prompts user for Discord Guild (Server) ID.
+ * @param rl Readline interface.
+ * @returns Guild ID or undefined.
+ */
 async function promptGuildId(rl: readline.Interface): Promise<string | undefined> {
     const raw = await ask(rl, `  ${C.yellow}>${C.reset} `);
     const trimmed = raw.trim();
@@ -352,6 +468,11 @@ async function promptGuildId(rl: readline.Interface): Promise<string | undefined
     return undefined;
 }
 
+/**
+ * Prompts user for allowed Discord operator user IDs.
+ * @param rl Readline interface.
+ * @returns Parsed user IDs.
+ */
 async function promptAllowedUserIds(rl: readline.Interface): Promise<string[]> {
     while (true) {
         const raw = await ask(rl, `  ${C.yellow}>${C.reset} `);
@@ -363,6 +484,11 @@ async function promptAllowedUserIds(rl: readline.Interface): Promise<string[]> {
     }
 }
 
+/**
+ * Prompts user for Workspace base directory path.
+ * @param rl Readline interface.
+ * @returns Absolute workspace directory path.
+ */
 async function promptWorkspaceDir(rl: readline.Interface): Promise<string> {
     const defaultDir = path.join(os.homedir(), 'Code');
 
@@ -390,6 +516,13 @@ async function promptWorkspaceDir(rl: readline.Interface): Promise<string> {
 
 type PlatformAction = 'enable' | 'reconfigure' | 'disable' | 'back';
 
+/**
+ * Platform sub-menu wizard.
+ * @param rl Readline interface.
+ * @param platformName Target platform name.
+ * @param status Current status.
+ * @returns Target action.
+ */
 async function platformSubMenu(
     rl: readline.Interface,
     platformName: string,
@@ -425,6 +558,10 @@ async function platformSubMenu(
 // Individual setup flows (each saves immediately)
 // ---------------------------------------------------------------------------
 
+/**
+ * Runs Discord configuration setup questions sequence.
+ * @param rl Readline interface.
+ */
 async function runDiscordSetup(rl: readline.Interface): Promise<void> {
     sectionHeader('Discord Bot Token');
     hint('1. Go to https://discord.com/developers/applications and log in');
@@ -466,6 +603,10 @@ async function runDiscordSetup(rl: readline.Interface): Promise<void> {
     console.log(`  ${C.dim}Invite URL:${C.reset} ${inviteUrl}\n`);
 }
 
+/**
+ * Runs Telegram configuration setup questions sequence.
+ * @param rl Readline interface.
+ */
 async function runTelegramSetup(rl: readline.Interface): Promise<void> {
     sectionHeader('Telegram Bot Token');
     hint('1. Open Telegram and message @BotFather');
@@ -503,6 +644,10 @@ async function runTelegramSetup(rl: readline.Interface): Promise<void> {
     console.log(`  ${C.green}Telegram saved!${C.reset}\n`);
 }
 
+/**
+ * Runs Workspace directory configuration setup questions sequence.
+ * @param rl Readline interface.
+ */
 async function runWorkspaceSetup(rl: readline.Interface): Promise<void> {
     sectionHeader('Workspace Base Directory');
     hint('The parent directory where your coding projects live.');
@@ -519,6 +664,9 @@ async function runWorkspaceSetup(rl: readline.Interface): Promise<void> {
 // Public action
 // ---------------------------------------------------------------------------
 
+/**
+ * Primary command runner function launched during setup interactive prompts loop.
+ */
 export async function setupAction(): Promise<void> {
     const rl = createInterface();
 

--- a/src/bin/commands/start.ts
+++ b/src/bin/commands/start.ts
@@ -10,6 +10,8 @@ import { checkForUpdates } from '../../services/updateCheckService';
 /**
  * Resolve log level from CLI flags on the root program.
  * Priority: --verbose > --quiet > undefined (fall through to env/config)
+ * @param cmd Active commander Command.
+ * @returns Resolved LogLevel.
  */
 function resolveCliLogLevel(cmd: Command | undefined): LogLevel | undefined {
     if (!cmd) return undefined;
@@ -20,6 +22,11 @@ function resolveCliLogLevel(cmd: Command | undefined): LogLevel | undefined {
     return undefined;
 }
 
+/**
+ * Command action to start/run the LazyGravity bot backend.
+ * @param _opts Unused command options map.
+ * @param cmd Active commander Command.
+ */
 export async function startAction(
     _opts?: Record<string, unknown>,
     cmd?: Command,

--- a/src/bot/eventRouter.ts
+++ b/src/bot/eventRouter.ts
@@ -8,15 +8,25 @@ import type {
 } from '../platform/types';
 import { logger } from '../utils/logger';
 
+/**
+ * Configuration options dictionary for the EventRouter.
+ */
 export interface EventRouterConfig {
     /** Map of platform type to allowed user IDs on that platform. */
     readonly allowedUsers: ReadonlyMap<PlatformType, ReadonlySet<string>>;
 }
 
+/**
+ * Event callbacks mappings object.
+ */
 export interface EventHandlers {
+    /** Triggered on new inbound messages. */
     readonly onMessage?: (message: PlatformMessage) => Promise<void>;
+    /** Triggered on button click interactions. */
     readonly onButtonInteraction?: (interaction: PlatformButtonInteraction) => Promise<void>;
+    /** Triggered on dropdown select menu interactions. */
     readonly onSelectInteraction?: (interaction: PlatformSelectInteraction) => Promise<void>;
+    /** Triggered on slash command invocations. */
     readonly onCommandInteraction?: (interaction: PlatformCommandInteraction) => Promise<void>;
 }
 
@@ -29,6 +39,10 @@ export class EventRouter {
     private readonly handlers: EventHandlers;
     private readonly adapters: PlatformAdapter[] = [];
 
+    /**
+     * @param config EventRouter configurations.
+     * @param handlers Handlers registry object.
+     */
     constructor(config: EventRouterConfig, handlers: EventHandlers) {
         this.config = config;
         this.handlers = handlers;
@@ -60,6 +74,11 @@ export class EventRouter {
         return allowed ? allowed.has(userId) : false;
     }
 
+    /**
+     * Internal factory constructing platform events listener callbacks.
+     * @param adapter Target PlatformAdapter instance.
+     * @returns AdapterEvents configuration callbacks.
+     */
     private createAdapterEvents(adapter: PlatformAdapter): PlatformAdapterEvents {
         return {
             onReady: () => {

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -176,8 +176,18 @@ const RESPONSE_DELIVERY_MODE = resolveResponseDeliveryMode();
 
 /** Tracks channel IDs where /stop was explicitly invoked by the user */
 const userStopRequestedChannels = new Set<string>();
+/**
+ * Test helper to retrieve the response delivery mode.
+ * @returns Response delivery mode string.
+ */
 export const getResponseDeliveryModeForTest = (): string => RESPONSE_DELIVERY_MODE;
 
+/**
+ * Test helper to instantiate a serial task queue executor.
+ * @param queueName Target queue identifier label.
+ * @param traceId Diagnostic correlation trace ID.
+ * @returns Queue runner executor function.
+ */
 export function createSerialTaskQueueForTest(queueName: string, traceId: string): (task: () => Promise<void>, label?: string) => Promise<void> {
     let queue: Promise<void> = Promise.resolve();
     let queueDepth = 0;

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -2317,6 +2317,8 @@ export async function handleSlashInteraction(
                         '`/account` — Show and switch Antigravity account',
                         '`/logs [lines] [level]` — View recent bot logs',
                         '`/cleanup [days]` — Clean up unused channels/categories',
+                        '`/heartbeat [on|off|status]` — Configure periodic bot heartbeat notifications',
+                        '`/schedule [add|list|remove|clear|backup|restore]` — Manage scheduled tasks',
                         '`/help` — Show this help',
                     ].join('\n')
                 },
@@ -3068,10 +3070,26 @@ export async function handleSlashInteraction(
                     break;
                 }
 
+                if (attachment.size > 1024 * 1024) {
+                    await interaction.editReply({ content: '❌ Attachment exceeds maximum size limit of 1MB.' });
+                    break;
+                }
+
                 try {
+                    const controller = new AbortController();
+                    const timeoutId = setTimeout(() => controller.abort(), 10000);
+
                     // Download file content using global fetch (available in Node 18+)
-                    const response = await fetch(attachment.url);
+                    const response = await fetch(attachment.url, { signal: controller.signal });
+                    clearTimeout(timeoutId);
+
                     if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+
+                    const contentLength = response.headers.get('content-length');
+                    if (contentLength && parseInt(contentLength, 10) > 1024 * 1024) {
+                        throw new Error('Response body exceeds maximum size limit of 1MB.');
+                    }
+
                     const jsonText = await response.text();
 
                     const jobCb = scheduleService.getJobCallback();

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -2853,10 +2853,8 @@ export async function handleSlashInteraction(
                     break;
                 }
 
-                // Check permissions
-                const botUser = interaction.client.user;
-                const permissions = (targetChannel as any).permissionsFor?.(botUser);
-                if (!permissions || !permissions.has('SendMessages') || !permissions.has('EmbedLinks')) {
+                const permissions = (targetChannel as any).permissionsFor?.(interaction.client.user);
+                if (permissions && (!permissions.has('SendMessages') || !permissions.has('EmbedLinks'))) {
                     await interaction.editReply({ content: '⚠️ Bot does not have permission to send messages and embed links in that channel.' });
                     break;
                 }
@@ -3085,22 +3083,28 @@ export async function handleSlashInteraction(
                     break;
                 }
 
+                let timeoutId: NodeJS.Timeout | undefined;
                 try {
                     const controller = new AbortController();
-                    const timeoutId = setTimeout(() => controller.abort(), 10000);
+                    timeoutId = setTimeout(() => controller.abort(), 10000);
 
-                    // Download file content using global fetch (available in Node 18+)
-                    const response = await fetch(attachment.url, { signal: controller.signal });
-                    clearTimeout(timeoutId);
+                    let jsonText: string;
+                    try {
+                        // Download file content using global fetch (available in Node 18+)
+                        const response = await fetch(attachment.url, { signal: controller.signal });
+                        if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
 
-                    if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+                        const contentLength = response.headers.get('content-length');
+                        if (contentLength && parseInt(contentLength, 10) > 1024 * 1024) {
+                            throw new Error('Response body exceeds maximum size limit of 1MB.');
+                        }
 
-                    const contentLength = response.headers.get('content-length');
-                    if (contentLength && parseInt(contentLength, 10) > 1024 * 1024) {
-                        throw new Error('Response body exceeds maximum size limit of 1MB.');
+                        jsonText = await response.text();
+                    } finally {
+                        if (timeoutId) {
+                            clearTimeout(timeoutId);
+                        }
                     }
-
-                    const jsonText = await response.text();
 
                     const jobCb = scheduleService.getJobCallback();
                     if (!jobCb) {

--- a/src/bot/telegramCommands.ts
+++ b/src/bot/telegramCommands.ts
@@ -1,23 +1,4 @@
 import { handleJoin, handleMirror } from './telegramJoinCommand';
-/**
- * Telegram command parser and handlers.
- *
- * Handles built-in bot commands that can be answered immediately
- * without routing through CDP/Antigravity:
- *   /start      — Welcome message
- *   /help       — List available commands
- *   /status     — Show bot connection status
- *   /stop       — Interrupt active LLM generation
- *   /ping       — Latency check
- *   /mode       — Switch execution mode
- *   /model      — Switch LLM model
- *   /screenshot — Capture Antigravity screenshot
- *   /autoaccept — Toggle auto-accept for approval dialogs
- *   /template   — List and execute prompt templates
- *   /logs       — Show recent log entries
- *   /new        — Start a new chat session
- */
-
 import fs from 'fs';
 import type { PlatformMessage, MessagePayload } from '../platform/types';
 import type { CdpBridge } from '../services/cdpBridgeManager';
@@ -55,8 +36,13 @@ type KnownCommand = typeof KNOWN_COMMANDS[number];
 // Parser
 // ---------------------------------------------------------------------------
 
+/**
+ * Representation of parsed Telegram command components.
+ */
 export interface ParsedTelegramCommand {
+    /** Target command name. */
     readonly command: string;
+    /** Command arguments string. */
     readonly args: string;
 }
 
@@ -71,6 +57,8 @@ export interface ParsedTelegramCommand {
  *
  * Returns null if the text is not a known command (unknown commands
  * are forwarded to Antigravity as normal messages).
+ * @param text Input message text.
+ * @returns Parsed command results, or null.
  */
 export function parseTelegramCommand(text: string): ParsedTelegramCommand | null {
     const trimmed = text.trim();
@@ -90,21 +78,35 @@ export function parseTelegramCommand(text: string): ParsedTelegramCommand | null
 // Dependencies
 // ---------------------------------------------------------------------------
 
+/**
+ * Dependencies injected into the Telegram commands dispatcher.
+ */
 export interface TelegramCommandDeps {
+    /** Target CDP bridge manager instance. */
     readonly bridge: CdpBridge;
+    /** Low-level bot API. */
     readonly botApi?: any;
+    /** Switch mode configurations service. */
     readonly modeService?: ModeService;
+    /** Model configurations service. */
     readonly modelService?: ModelService;
+    /** Bindings database repository store. */
     readonly telegramBindingRepo?: TelegramBindingRepository;
+    /** Templates database repository store. */
     readonly templateRepo?: TemplateRepository;
+    /** Workspace paths list builder. */
     readonly workspaceService?: WorkspaceService;
+    /** Chat sessions service manager. */
     readonly chatSessionService?: ChatSessionService;
+    /** Live quota fetcher callback. */
     readonly fetchQuota?: () => Promise<any[]>;
-    /** Shared map of active ResponseMonitors keyed by project name.
-     *  Used by /stop to halt monitoring and prevent stale re-sends. */
+    /** Primary active response monitors registry. */
     readonly activeMonitors?: Map<string, ResponseMonitor>;
+    /** Account preferences repository. */
     readonly accountPrefRepo?: AccountPreferenceRepository;
+    /** Channel preferences repository. */
     readonly channelPrefRepo?: ChannelPreferenceRepository;
+    /** Configured accounts lists configurations. */
     readonly antigravityAccounts?: AntigravityAccountConfig[];
 }
 
@@ -115,6 +117,9 @@ export interface TelegramCommandDeps {
 /**
  * Handle a parsed Telegram command.
  * Routes to the appropriate sub-handler based on command name.
+ * @param deps Injected dependencies.
+ * @param message Platform message trigger.
+ * @param parsed Parsed command metadata.
  */
 export async function handleTelegramCommand(
     deps: TelegramCommandDeps,
@@ -192,6 +197,10 @@ export async function handleTelegramCommand(
 // Sub-handlers
 // ---------------------------------------------------------------------------
 
+/**
+ * Handle /start command.
+ * @param message Platform message context.
+ */
 async function handleStart(message: PlatformMessage): Promise<void> {
     const text = [
         '<b>Welcome to LazyGravity!</b>',
@@ -208,6 +217,10 @@ async function handleStart(message: PlatformMessage): Promise<void> {
     await message.reply({ text }).catch(logger.error);
 }
 
+/**
+ * Handle /help command.
+ * @param message Platform message context.
+ */
 async function handleHelp(message: PlatformMessage): Promise<void> {
     const text = [
         '<b>Available Commands</b>',
@@ -238,6 +251,11 @@ async function handleHelp(message: PlatformMessage): Promise<void> {
     await message.reply({ text }).catch(logger.error);
 }
 
+/**
+ * Handle /status command.
+ * @param deps Injected dependencies.
+ * @param message Platform message context.
+ */
 async function handleStatus(deps: TelegramCommandDeps, message: PlatformMessage): Promise<void> {
     const chatId = message.channel.id;
 
@@ -269,6 +287,11 @@ async function handleStatus(deps: TelegramCommandDeps, message: PlatformMessage)
     await message.reply({ text: lines.join('\n') }).catch(logger.error);
 }
 
+/**
+ * Handle /stop command.
+ * @param deps Injected dependencies.
+ * @param message Platform message context.
+ */
 async function handleStop(deps: TelegramCommandDeps, message: PlatformMessage): Promise<void> {
     const workspace = deps.bridge.lastActiveWorkspace;
 
@@ -316,10 +339,19 @@ async function handleStop(deps: TelegramCommandDeps, message: PlatformMessage): 
     }
 }
 
+/**
+ * Handle /ping command.
+ * @param message Platform message context.
+ */
 async function handlePing(message: PlatformMessage): Promise<void> {
     await message.reply({ text: 'Pong!' }).catch(logger.error);
 }
 
+/**
+ * Handle /mode command.
+ * @param deps Injected dependencies.
+ * @param message Platform message context.
+ */
 async function handleMode(deps: TelegramCommandDeps, message: PlatformMessage): Promise<void> {
     if (!deps.modeService) {
         await message.reply({ text: 'Mode service not available.' }).catch(logger.error);
@@ -331,6 +363,11 @@ async function handleMode(deps: TelegramCommandDeps, message: PlatformMessage): 
     await message.reply(payload).catch(logger.error);
 }
 
+/**
+ * Handle /model command.
+ * @param deps Injected dependencies.
+ * @param message Platform message context.
+ */
 async function handleModel(deps: TelegramCommandDeps, message: PlatformMessage): Promise<void> {
     const cdp = getCurrentCdp(deps.bridge);
     if (!cdp) {
@@ -352,6 +389,11 @@ async function handleModel(deps: TelegramCommandDeps, message: PlatformMessage):
     await message.reply(payload).catch(logger.error);
 }
 
+/**
+ * Handle /screenshot command.
+ * @param deps Injected dependencies.
+ * @param message Platform message context.
+ */
 async function handleScreenshot(deps: TelegramCommandDeps, message: PlatformMessage): Promise<void> {
     const cdp = getCurrentCdp(deps.bridge);
     const payload = await buildScreenshotPayload(cdp);
@@ -365,6 +407,12 @@ async function handleScreenshot(deps: TelegramCommandDeps, message: PlatformMess
     }
 }
 
+/**
+ * Handle /autoaccept command.
+ * @param deps Injected dependencies.
+ * @param message Platform message context.
+ * @param args Command arguments.
+ */
 async function handleAutoAccept(deps: TelegramCommandDeps, message: PlatformMessage, args: string): Promise<void> {
     // If args are provided (e.g. /autoaccept on), handle directly
     if (args) {
@@ -378,6 +426,12 @@ async function handleAutoAccept(deps: TelegramCommandDeps, message: PlatformMess
     await message.reply(payload).catch(logger.error);
 }
 
+/**
+ * Handle /account command.
+ * @param deps Injected dependencies.
+ * @param message Platform message context.
+ * @param args Command arguments.
+ */
 async function handleAccount(deps: TelegramCommandDeps, message: PlatformMessage, args: string): Promise<void> {
     if (!deps.accountPrefRepo) {
         await message.reply({ text: 'Account preference service not available.' }).catch(logger.error);
@@ -435,6 +489,11 @@ async function handleAccount(deps: TelegramCommandDeps, message: PlatformMessage
     await message.reply(payload).catch(logger.error);
 }
 
+/**
+ * Handle /template command.
+ * @param deps Injected dependencies.
+ * @param message Platform message context.
+ */
 async function handleTemplate(deps: TelegramCommandDeps, message: PlatformMessage): Promise<void> {
     if (!deps.templateRepo) {
         await message.reply({ text: 'Template service not available.' }).catch(logger.error);
@@ -446,6 +505,12 @@ async function handleTemplate(deps: TelegramCommandDeps, message: PlatformMessag
     await message.reply(payload).catch(logger.error);
 }
 
+/**
+ * Handle /template_add command.
+ * @param deps Injected dependencies.
+ * @param message Platform message context.
+ * @param args Command arguments.
+ */
 async function handleTemplateAdd(deps: TelegramCommandDeps, message: PlatformMessage, args: string): Promise<void> {
     if (!deps.templateRepo) {
         await message.reply({ text: 'Template service not available.' }).catch(logger.error);
@@ -477,6 +542,12 @@ async function handleTemplateAdd(deps: TelegramCommandDeps, message: PlatformMes
     }
 }
 
+/**
+ * Handle /template_delete command.
+ * @param deps Injected dependencies.
+ * @param message Platform message context.
+ * @param args Command arguments.
+ */
 async function handleTemplateDelete(deps: TelegramCommandDeps, message: PlatformMessage, args: string): Promise<void> {
     if (!deps.templateRepo) {
         await message.reply({ text: 'Template service not available.' }).catch(logger.error);
@@ -499,6 +570,12 @@ async function handleTemplateDelete(deps: TelegramCommandDeps, message: Platform
     }
 }
 
+/**
+ * Handle /project_create command.
+ * @param deps Injected dependencies.
+ * @param message Platform message context.
+ * @param args Command arguments.
+ */
 async function handleProjectCreate(deps: TelegramCommandDeps, message: PlatformMessage, args: string): Promise<void> {
     if (!deps.workspaceService) {
         await message.reply({ text: 'Workspace service not available.' }).catch(logger.error);
@@ -529,6 +606,11 @@ async function handleProjectCreate(deps: TelegramCommandDeps, message: PlatformM
     }
 }
 
+/**
+ * Handle /logs command.
+ * @param message Platform message context.
+ * @param args Command arguments.
+ */
 async function handleLogs(message: PlatformMessage, args: string): Promise<void> {
     const countArg = args ? parseInt(args, 10) : 20;
     const count = isNaN(countArg) ? 20 : Math.min(Math.max(countArg, 1), 50);
@@ -550,6 +632,11 @@ async function handleLogs(message: PlatformMessage, args: string): Promise<void>
     await message.reply({ text: truncated }).catch(logger.error);
 }
 
+/**
+ * Handle /new command.
+ * @param deps Injected dependencies.
+ * @param message Platform message context.
+ */
 async function handleNew(deps: TelegramCommandDeps, message: PlatformMessage): Promise<void> {
     const originalChannelId = message.channel.id;
     const binding = deps.telegramBindingRepo?.findByChatIdWithParentFallback(originalChannelId);
@@ -617,6 +704,8 @@ async function handleNew(deps: TelegramCommandDeps, message: PlatformMessage): P
 /**
  * Send a MessagePayload that contains file attachments.
  * Falls back to a text reply if file sending is not supported.
+ * @param message Platform message destination.
+ * @param payload Payload context containing files.
  */
 async function sendFilePayload(message: PlatformMessage, payload: MessagePayload): Promise<void> {
     // Try sending with files — the Telegram adapter supports this if sendPhoto is available
@@ -628,7 +717,11 @@ async function sendFilePayload(message: PlatformMessage, payload: MessagePayload
     }
 }
 
-
+/**
+ * Handle /project_reopen command.
+ * @param deps Injected dependencies.
+ * @param message Platform message context.
+ */
 async function handleProjectReopen(deps: TelegramCommandDeps, message: PlatformMessage): Promise<void> {
     const chatId = message.channel.id;
     const channelBinding = deps.telegramBindingRepo?.findByChatIdWithParentFallback(chatId);

--- a/src/bot/telegramCommands.ts
+++ b/src/bot/telegramCommands.ts
@@ -74,7 +74,7 @@ export interface ParsedTelegramCommand {
  */
 export function parseTelegramCommand(text: string): ParsedTelegramCommand | null {
     const trimmed = text.trim();
-    const match = trimmed.match(/^\/(\w+)(?:@\S+)?(?:\s+(.*))?$/);
+    const match = trimmed.match(/^\/(\w+)(?:@\S+)?(?:\s+([\s\S]*))?$/);
     if (!match) return null;
 
     const command = match[1].toLowerCase();

--- a/src/bot/telegramCommands.ts
+++ b/src/bot/telegramCommands.ts
@@ -1,3 +1,22 @@
+/**
+ * Telegram command parser and handlers.
+ *
+ * Handles built-in bot commands that can be answered immediately
+ * without routing through CDP/Antigravity:
+ *   /start      — Welcome message
+ *   /help       — List available commands
+ *   /status     — Show bot connection status
+ *   /stop       — Interrupt active LLM generation
+ *   /ping       — Latency check
+ *   /mode       — Switch execution mode
+ *   /model      — Switch LLM model
+ *   /screenshot — Capture Antigravity screenshot
+ *   /autoaccept — Toggle auto-accept for approval dialogs
+ *   /template   — List and execute prompt templates
+ *   /logs       — Show recent log entries
+ *   /new        — Start a new chat session
+ */
+
 import { handleJoin, handleMirror } from './telegramJoinCommand';
 import fs from 'fs';
 import type { PlatformMessage, MessagePayload } from '../platform/types';

--- a/src/bot/telegramJoinCommand.ts
+++ b/src/bot/telegramJoinCommand.ts
@@ -14,23 +14,41 @@ import type { AccountPreferenceRepository } from '../database/accountPreferenceR
 import type { ChannelPreferenceRepository } from '../database/channelPreferenceRepository';
 import type { AntigravityAccountConfig } from '../utils/configLoader';
 
+/**
+ * Dependencies injected into Telegram join command handlers.
+ */
 export interface TelegramJoinCommandDeps {
+    /** Target CDP bridge manager instance. */
     readonly bridge: CdpBridge;
+    /** ChatSessionService managing active chats list. */
     readonly chatSessionService?: ChatSessionService;
+    /** Database repository containing Telegram chat binds. */
     readonly telegramBindingRepo?: TelegramBindingRepository;
+    /** Service mapping workspace name and directories. */
     readonly workspaceService?: WorkspaceService;
+    /** Low-level platform telegram client interface wrapper. */
     readonly botApi?: any;
+    /** Account preference configurations repository. */
     readonly accountPrefRepo?: AccountPreferenceRepository;
+    /** Channel preference configurations repository. */
     readonly channelPrefRepo?: ChannelPreferenceRepository;
+    /** Configured accounts lists database credentials. */
     readonly antigravityAccounts?: AntigravityAccountConfig[];
+    /** Extraction mode config preference. */
     readonly extractionMode?: import('../utils/config').ExtractionMode;
-    /** Primary active monitors from the main Telegram message handler (keyed by project name).
-     *  Used to skip passive mirror monitors when a primary monitor is already running. */
+    /** Primary active monitors from the main Telegram message handler (keyed by project name). */
     readonly activeMonitors?: Map<string, ResponseMonitor>;
 }
 
 const activeResponseMonitors = new Map<string, ResponseMonitor>();
 
+/**
+ * Resolves the account name for the interaction based on channel preferences.
+ * @param deps Injected dependencies.
+ * @param chatId Chat channel ID.
+ * @param userId Author user ID.
+ * @returns Resolved account name.
+ */
 function resolveAccount(deps: TelegramJoinCommandDeps, chatId: string, userId: string): string {
     return resolveScopedAccountName({
         channelId: chatId,
@@ -42,6 +60,11 @@ function resolveAccount(deps: TelegramJoinCommandDeps, chatId: string, userId: s
     });
 }
 
+/**
+ * Command handler function for the telegram /join command.
+ * @param deps Injected dependencies.
+ * @param message Platform message trigger.
+ */
 export async function handleJoin(deps: TelegramJoinCommandDeps, message: PlatformMessage): Promise<void> {
     const binding = deps.telegramBindingRepo?.findByChatIdWithParentFallback(message.channel.id);
     if (!binding) {
@@ -75,6 +98,11 @@ export async function handleJoin(deps: TelegramJoinCommandDeps, message: Platfor
     }
 }
 
+/**
+ * Event handler triggered when a session is selected inside Telegram dropdown UI.
+ * @param deps Injected dependencies.
+ * @param interaction Dropdown selection interaction.
+ */
 export async function handleTelegramJoinSelect(deps: TelegramJoinCommandDeps, interaction: PlatformSelectInteraction): Promise<void> {
     const selectedTitle = interaction.values[0];
     const originalChannelId = interaction.channel.id;
@@ -128,6 +156,11 @@ export async function handleTelegramJoinSelect(deps: TelegramJoinCommandDeps, in
     await interaction.update({ text: replyMsg }).catch(logger.error);
 }
 
+/**
+ * Command handler function for the /mirror command to toggle mirroring.
+ * @param deps Injected dependencies.
+ * @param message Platform command trigger.
+ */
 export async function handleMirror(deps: TelegramJoinCommandDeps, message: PlatformMessage): Promise<void> {
     const binding = deps.telegramBindingRepo?.findByChatIdWithParentFallback(message.channel.id);
     if (!binding) {
@@ -176,6 +209,14 @@ export async function handleMirror(deps: TelegramJoinCommandDeps, message: Platf
     }
 }
 
+/**
+ * Route a mirrored message to the appropriate Telegram channel.
+ * @param deps Injected dependencies.
+ * @param cdp Active CdpService.
+ * @param workspacePath Workspace root directory.
+ * @param info Input metadata containing text.
+ * @param channel Platform channel target.
+ */
 async function routeMirroredMessage(
     deps: TelegramJoinCommandDeps,
     cdp: CdpService,
@@ -192,6 +233,14 @@ async function routeMirroredMessage(
     startResponseMirror(deps, cdp, workspacePath, channel, chatTitle || 'Unknown');
 }
 
+/**
+ * Monitor and forward AI responses passively to Telegram channel.
+ * @param deps Injected dependencies.
+ * @param cdp Active CdpService.
+ * @param workspacePath Workspace directory path.
+ * @param channel Target channel.
+ * @param chatTitle Current session chat title.
+ */
 export function startResponseMirror(
     deps: TelegramJoinCommandDeps,
     cdp: CdpService,

--- a/src/bot/telegramMessageHandler.ts
+++ b/src/bot/telegramMessageHandler.ts
@@ -34,33 +34,49 @@ import type { ChannelPreferenceRepository } from '../database/channelPreferenceR
 import type { AntigravityAccountConfig } from '../utils/configLoader';
 import { resolveScopedAccountName } from '../utils/accountUtils';
 
+/**
+ * Dependencies injected into the Telegram message handler.
+ */
 export interface TelegramMessageHandlerDeps {
+    /** Target CDP bridge manager instance. */
     readonly bridge: CdpBridge;
+    /** Telegram binds repository store. */
     readonly telegramBindingRepo: TelegramBindingRepository;
+    /** Workspace paths list resolver. */
     readonly workspaceService?: WorkspaceService;
+    /** Mode service configurations. */
     readonly modeService?: ModeService;
+    /** Model service configurations. */
     readonly modelService?: ModelService;
+    /** Active extraction mode settings. */
     readonly extractionMode?: ExtractionMode;
+    /** Repository managing custom templates. */
     readonly templateRepo?: import('../database/templateRepository').TemplateRepository;
+    /** Callback fetching live quota data. */
     readonly fetchQuota?: () => Promise<any[]>;
-    /** Shared map of active ResponseMonitors keyed by project name.
-     *  Used by /stop to halt monitoring and prevent stale re-sends. */
+    /** Primary active monitors registry map. */
     readonly activeMonitors?: Map<string, ResponseMonitor>;
-    /** Bot token for downloading Telegram file attachments. */
+    /** Bot credentials token for downloads. */
     readonly botToken?: string;
-    /** Bot API object for getFile calls. */
+    /** Raw Telegram bot API helper interface. */
     readonly botApi?: import('../platform/telegram/wrappers').TelegramBotLike['api'];
+    /** Active chat sessions service manager. */
     readonly chatSessionService?: ChatSessionService;
-    /** Response monitor inactivity timeout in ms. Defaults to ResponseMonitor default (900000). */
+    /** Response monitoring timeout limit in ms. */
     readonly responseTimeoutMs?: number;
+    /** Account preferences data repository. */
     readonly accountPrefRepo?: AccountPreferenceRepository;
+    /** Channel preferences data repository. */
     readonly channelPrefRepo?: ChannelPreferenceRepository;
+    /** Active configured accounts configurations. */
     readonly antigravityAccounts?: AntigravityAccountConfig[];
 }
 
 /**
  * Create a handler for Telegram messages.
  * Returns an async function that processes a single PlatformMessage.
+ * @param deps Injected dependencies.
+ * @returns Message handler callback function.
  */
 export function createTelegramMessageHandler(deps: TelegramMessageHandlerDeps) {
     // Per-workspace prompt queue to serialize messages
@@ -402,7 +418,11 @@ export function createTelegramMessageHandler(deps: TelegramMessageHandlerDeps) {
     };
 }
 
-/** Split long text into Telegram-safe chunks (max 4096 chars). */
+/**
+ * Split long text into Telegram-safe chunks (max 4096 chars).
+ * @param channel Platform channel destination.
+ * @param text Log/response text content to send.
+ */
 async function sendTextChunked(
     channel: PlatformChannel,
     text: string,

--- a/src/bot/telegramProjectCommand.ts
+++ b/src/bot/telegramProjectCommand.ts
@@ -1,20 +1,7 @@
 import { logger } from '../utils/logger';
-/**
- * Telegram /project command handler.
- *
- * Allows users to bind a Telegram chat to an Antigravity workspace
- * via inline keyboard buttons, similar to Discord's /project slash command.
- *
- * User flow:
- *   /project        → show workspace list as buttons → user taps → chat bound
- *   /project list   → show workspace list (same as bare /project)
- *   /project unbind → remove current binding
- */
-
 import type { PlatformMessage, PlatformSelectInteraction, SelectMenuDef } from '../platform/types';
 import type { TelegramBindingRepository } from '../database/telegramBindingRepository';
 import type { WorkspaceService } from '../services/workspaceService';
-
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -28,7 +15,11 @@ export const TG_PROJECT_SELECT_ID = 'tg_project_select';
 
 export type TelegramProjectSubcommand = 'list' | 'unbind';
 
+/**
+ * Command arguments container for the telegram project settings command.
+ */
 export interface ParsedProjectCommand {
+    /** Target subcommand (e.g. list, unbind). */
     readonly subcommand: TelegramProjectSubcommand;
 }
 
@@ -42,6 +33,8 @@ export interface ParsedProjectCommand {
  *   /project unbind
  *   /project@BotName
  *   /project@BotName list
+ * @param text Raw command text.
+ * @returns Parsed command results or null.
  */
 export function parseTelegramProjectCommand(text: string): ParsedProjectCommand | null {
     const trimmed = text.trim();
@@ -66,11 +59,17 @@ export function parseTelegramProjectCommand(text: string): ParsedProjectCommand 
 import type { CdpBridge } from '../services/cdpBridgeManager';
 import { escapeHtml } from '../platform/telegram/telegramFormatter';
 
-
+/**
+ * Dependencies injected into telegram project command handlers.
+ */
 export interface TelegramProjectCommandDeps {
+    /** Low-level bot API. */
     readonly botApi?: any;
+    /** Active CDP bridge manager reference. */
     readonly bridge?: CdpBridge;
+    /** Scan workspaces path helper. */
     readonly workspaceService: WorkspaceService;
+    /** Telegram bindings database store repository. */
     readonly telegramBindingRepo: TelegramBindingRepository;
 }
 
@@ -80,6 +79,9 @@ export interface TelegramProjectCommandDeps {
 
 /**
  * Handle a /project command from Telegram.
+ * @param deps Injected dependencies.
+ * @param message Platform trigger message.
+ * @param parsed Parsed subcommand arguments.
  */
 export async function handleTelegramProjectCommand(
     deps: TelegramProjectCommandDeps,
@@ -135,9 +137,14 @@ export async function handleTelegramProjectCommand(
 // ---------------------------------------------------------------------------
 
 /**
- * Handle a workspace selection callback from inline keyboard.
+ * Attempts to automatically create a dedicated Telegram topic for the workspace and bind it.
+ * @param botApi Low-level telegram bot API.
+ * @param originalChannelId Original base group chat ID.
+ * @param workspacePath Workspace directory path.
+ * @param telegramBindingRepo Database repository store.
+ * @param pool CdpConnectionPool manager.
+ * @returns Resolved channel/topic ID string.
  */
-
 export async function tryCreateTopicAndBind(
     botApi: any,
     originalChannelId: string,
@@ -204,6 +211,11 @@ export async function tryCreateTopicAndBind(
     return originalChannelId;
 }
 
+/**
+ * Handle a workspace selection callback from inline keyboard.
+ * @param deps Injected dependencies.
+ * @param interaction Select menu interaction.
+ */
 export async function handleTelegramProjectSelect(
     deps: TelegramProjectCommandDeps,
     interaction: PlatformSelectInteraction,
@@ -258,6 +270,8 @@ export async function handleTelegramProjectSelect(
 /**
  * Create a select interaction handler that routes by customId.
  * Returns a function suitable for EventRouter's onSelectInteraction.
+ * @param deps Injected dependencies.
+ * @returns Event selection handler function.
  */
 export function createTelegramSelectHandler(
     deps: TelegramProjectCommandDeps,

--- a/src/bot/telegramProjectCommand.ts
+++ b/src/bot/telegramProjectCommand.ts
@@ -1,3 +1,15 @@
+/**
+ * Telegram /project command handler.
+ *
+ * Allows users to bind a Telegram chat to an Antigravity workspace
+ * via inline keyboard buttons, similar to Discord's /project slash command.
+ *
+ * User flow:
+ *   /project        → show workspace list as buttons → user taps → chat bound
+ *   /project list   → show workspace list (same as bare /project)
+ *   /project unbind → remove current binding
+ */
+
 import { logger } from '../utils/logger';
 import type { PlatformMessage, PlatformSelectInteraction, SelectMenuDef } from '../platform/types';
 import type { TelegramBindingRepository } from '../database/telegramBindingRepository';

--- a/src/bot/telegramStartupTarget.ts
+++ b/src/bot/telegramStartupTarget.ts
@@ -1,27 +1,56 @@
 import type { TelegramBindingRecord } from '../database/telegramBindingRepository';
 import type { TelegramBotLike } from '../platform/telegram/wrappers';
 
+/**
+ * Candidate structure for determining Telegram startup channels/chats.
+ */
 interface StartupChatCandidate {
+    /** Raw binding chat identifier. */
     bindingChatId: string;
+    /** Resolved base chat identifier. */
     resolvedChatId: string;
+    /** Chat type (e.g. group, supergroup, private). */
     type: string;
+    /** Friendly display title or name. */
     title: string;
+    /** Whether it corresponds directly to a top-level binding. */
     isDirectBinding: boolean;
 }
 
+/**
+ * Strips sub-channel qualifiers from a compound chat ID.
+ * @param chatId Target chat ID.
+ * @returns Base chat ID.
+ */
 function getBaseChatId(chatId: string): string {
     const sepIdx = chatId.indexOf('_');
     return sepIdx > 0 ? chatId.slice(0, sepIdx) : chatId;
 }
 
+/**
+ * Normalizes chat titles for consistency.
+ * @param title Chat title.
+ * @returns Normalized title string.
+ */
 function normalizeTitle(title: string): string {
     return title.trim().replace(/^#/, '').toLowerCase();
 }
 
+/**
+ * Evaluates whether a chat title represents a general chat.
+ * @param title Chat title.
+ * @returns True if title matches 'general'.
+ */
 function isGeneralChat(title: string): boolean {
     return normalizeTitle(title) === 'general';
 }
 
+/**
+ * Resolves the primary chat ID target to emit initial startup greeting message options.
+ * @param api Telegram bot api client instance.
+ * @param bindings Registered Telegram bindings lists.
+ * @returns Selected chat ID string, or null if none resolved.
+ */
 export async function selectTelegramStartupChatId(
     api: TelegramBotLike['api'],
     bindings: TelegramBindingRecord[],

--- a/src/commands/messageParser.ts
+++ b/src/commands/messageParser.ts
@@ -1,10 +1,22 @@
+/**
+ * Structured details of a parsed text message.
+ */
 export interface ParsedMessage {
+    /** True if the message represents a slash/bot command. */
     isCommand: boolean;
+    /** Command name, if parsed. */
     commandName?: string;
+    /** Arguments array, if parsed. */
     args?: string[];
+    /** Original message text, if not a command. */
     text?: string;
 }
 
+/**
+ * Parses user input message text to extract potential bot command name and arguments.
+ * @param content Raw input content string.
+ * @returns Parsed message properties.
+ */
 export function parseMessageContent(content: string): ParsedMessage {
     const trimmed = content.trim();
 

--- a/src/commands/slashCommandHandler.ts
+++ b/src/commands/slashCommandHandler.ts
@@ -13,15 +13,24 @@ export interface CommandResult {
     prompt?: string;
 }
 
+/**
+ * Handler parsing and processing slash commands.
+ */
 export class SlashCommandHandler {
     private templateRepo: TemplateRepository;
 
+    /**
+     * @param templateRepo The templates database repository.
+     */
     constructor(templateRepo: TemplateRepository) {
         this.templateRepo = templateRepo;
     }
 
     /**
-     * Parse the slash command name and arguments, then route to the appropriate handler
+     * Parse the slash command name and arguments, then route to the appropriate handler.
+     * @param commandName Trigger slash command name.
+     * @param args Array of parsed parameters/arguments.
+     * @returns Command execution result metadata.
      */
     public async handleCommand(commandName: string, args: string[]): Promise<CommandResult> {
         switch (commandName.toLowerCase()) {
@@ -35,6 +44,11 @@ export class SlashCommandHandler {
         }
     }
 
+    /**
+     * Internal template command handler logic.
+     * @param args Parameter arguments list.
+     * @returns Command execution result.
+     */
     private handleTemplateCommand(args: string[]): CommandResult {
         if (args.length === 0) {
             const templates = this.templateRepo.findAll();

--- a/src/database/accountPreferenceRepository.ts
+++ b/src/database/accountPreferenceRepository.ts
@@ -1,6 +1,14 @@
 import Database from 'better-sqlite3';
 
+/**
+ * Repository for managing user account preference mappings.
+ * Maps user IDs to their selected account names.
+ */
 export class AccountPreferenceRepository {
+    /**
+     * Initializes the account preferences repository and ensures the database table exists.
+     * @param db The database connection instance.
+     */
     constructor(private readonly db: Database.Database) {
         this.db.exec(`
             CREATE TABLE IF NOT EXISTS account_preferences (
@@ -11,6 +19,11 @@ export class AccountPreferenceRepository {
         `);
     }
 
+    /**
+     * Retrieves the saved account name for a specific user.
+     * @param userId The ID of the user.
+     * @returns The associated account name, or null if none is set.
+     */
     getAccountName(userId: string): string | null {
         const row = this.db.prepare(
             'SELECT account_name FROM account_preferences WHERE user_id = ?',
@@ -18,6 +31,11 @@ export class AccountPreferenceRepository {
         return row?.account_name ?? null;
     }
 
+    /**
+     * Sets or updates the account name associated with a user.
+     * @param userId The ID of the user.
+     * @param accountName The account name to associate with the user.
+     */
     setAccountName(userId: string, accountName: string): void {
         this.db.prepare(`
             INSERT INTO account_preferences (user_id, account_name)
@@ -27,3 +45,4 @@ export class AccountPreferenceRepository {
         `).run(userId, accountName);
     }
 }
+

--- a/src/database/artifactThreadRepository.ts
+++ b/src/database/artifactThreadRepository.ts
@@ -7,11 +7,18 @@ import Database from 'better-sqlite3';
 export class ArtifactThreadRepository {
     private readonly db: Database.Database;
 
+    /**
+     * Initializes the artifact thread repository and schema.
+     * @param db SQLite database connection.
+     */
     constructor(db: Database.Database) {
         this.db = db;
         this.initialize();
     }
 
+    /**
+     * Creates table and runs migration checks for artifact thread mapping.
+     */
     private initialize(): void {
         const tableInfo = this.db.prepare("PRAGMA table_info('artifact_threads')").all() as any[];
         

--- a/src/database/channelPreferenceRepository.ts
+++ b/src/database/channelPreferenceRepository.ts
@@ -1,6 +1,14 @@
 import Database from 'better-sqlite3';
 
+/**
+ * Repository for managing channel-specific account preference mappings.
+ * Maps a Discord/Telegram channel ID to a configured account name.
+ */
 export class ChannelPreferenceRepository {
+    /**
+     * Initializes the channel preferences repository and ensures the database table exists.
+     * @param db The database connection instance.
+     */
     constructor(private readonly db: Database.Database) {
         this.db.exec(`
             CREATE TABLE IF NOT EXISTS channel_preferences (
@@ -11,6 +19,11 @@ export class ChannelPreferenceRepository {
         `);
     }
 
+    /**
+     * Retrieves the saved account name for a specific channel.
+     * @param channelId The ID of the channel.
+     * @returns The associated account name, or null if none is set.
+     */
     getAccountName(channelId: string): string | null {
         const row = this.db.prepare(
             'SELECT account_name FROM channel_preferences WHERE channel_id = ?',
@@ -18,6 +31,11 @@ export class ChannelPreferenceRepository {
         return row?.account_name ?? null;
     }
 
+    /**
+     * Sets or updates the account name associated with a channel.
+     * @param channelId The ID of the channel.
+     * @param accountName The account name to associate with the channel.
+     */
     setAccountName(channelId: string, accountName: string): void {
         this.db.prepare(`
             INSERT INTO channel_preferences (channel_id, account_name)
@@ -27,3 +45,4 @@ export class ChannelPreferenceRepository {
         `).run(channelId, accountName);
     }
 }
+

--- a/src/database/chatSessionRepository.ts
+++ b/src/database/chatSessionRepository.ts
@@ -37,11 +37,18 @@ export interface CreateChatSessionInput {
 export class ChatSessionRepository {
     private readonly db: Database.Database;
 
+    /**
+     * Initializes the repository and triggers schema updates.
+     * @param db SQLite database connection.
+     */
     constructor(db: Database.Database) {
         this.db = db;
         this.initialize();
     }
 
+    /**
+     * Creates the table schema and updates it for newer migrations/columns.
+     */
     private initialize(): void {
         this.db.exec(`
             CREATE TABLE IF NOT EXISTS chat_sessions (
@@ -95,6 +102,11 @@ export class ChatSessionRepository {
         }
     }
 
+    /**
+     * Persists a new chat session database entry.
+     * @param input Data required to register the chat session.
+     * @returns The fully constructed ChatSessionRecord.
+     */
     public create(input: CreateChatSessionInput): ChatSessionRecord {
         const activeAccountName = input.activeAccountName ?? null;
         const stmt = this.db.prepare(`
@@ -126,6 +138,11 @@ export class ChatSessionRepository {
         };
     }
 
+    /**
+     * Finds a chat session by its Discord channel ID.
+     * @param channelId The channel ID to search by.
+     * @returns The ChatSessionRecord if found, otherwise undefined.
+     */
     public findByChannelId(channelId: string): ChatSessionRecord | undefined {
         const row = this.db.prepare(
             'SELECT * FROM chat_sessions WHERE channel_id = ?'
@@ -134,6 +151,11 @@ export class ChatSessionRepository {
         return this.mapRow(row);
     }
 
+    /**
+     * Retrieves all chat sessions associated with a specific channel category.
+     * @param categoryId The category ID to query by.
+     * @returns Array of matching ChatSessionRecord, ordered by session number.
+     */
     public findByCategoryId(categoryId: string): ChatSessionRecord[] {
         const rows = this.db.prepare(
             'SELECT * FROM chat_sessions WHERE category_id = ? ORDER BY session_number ASC'
@@ -162,6 +184,12 @@ export class ChatSessionRepository {
         return result.changes > 0;
     }
 
+    /**
+     * Updates the active account name linked with a chat session.
+     * @param channelId The target channel ID.
+     * @param accountName The new active account name.
+     * @returns True if updated successfully, false otherwise.
+     */
     public setActiveAccountName(channelId: string, accountName: string): boolean {
         const result = this.db.prepare(
             'UPDATE chat_sessions SET active_account_name = ? WHERE channel_id = ?'
@@ -169,6 +197,12 @@ export class ChatSessionRepository {
         return result.changes > 0;
     }
 
+    /**
+     * Updates the original account name linked with a chat session.
+     * @param channelId The target channel ID.
+     * @param accountName The origin account name.
+     * @returns True if updated successfully, false otherwise.
+     */
     public setOriginAccountName(channelId: string, accountName: string): boolean {
         const result = this.db.prepare(
             'UPDATE chat_sessions SET origin_account_name = ? WHERE channel_id = ?'
@@ -176,6 +210,12 @@ export class ChatSessionRepository {
         return result.changes > 0;
     }
 
+    /**
+     * Associates a specific conversation ID with a chat session.
+     * @param channelId The target channel ID.
+     * @param conversationId The IDE conversation ID.
+     * @returns True if updated successfully, false otherwise.
+     */
     public setConversationId(channelId: string, conversationId: string): boolean {
         const result = this.db.prepare(
             'UPDATE chat_sessions SET conversation_id = ? WHERE channel_id = ?'
@@ -183,6 +223,12 @@ export class ChatSessionRepository {
         return result.changes > 0;
     }
 
+    /**
+     * Initializes the conversation ID if it is currently unset (null).
+     * @param channelId The target channel ID.
+     * @param conversationId The initial conversation ID.
+     * @returns True if updated successfully, false otherwise.
+     */
     public initializeConversationId(channelId: string, conversationId: string): boolean {
         const result = this.db.prepare(
             'UPDATE chat_sessions SET conversation_id = ? WHERE channel_id = ? AND conversation_id IS NULL'
@@ -190,6 +236,12 @@ export class ChatSessionRepository {
         return result.changes > 0;
     }
 
+    /**
+     * Initializes the original account name if it is currently unset (null).
+     * @param channelId The target channel ID.
+     * @param accountName The default origin account name.
+     * @returns True if updated successfully, false otherwise.
+     */
     public initializeOriginAccountName(channelId: string, accountName: string): boolean {
         const result = this.db.prepare(
             'UPDATE chat_sessions SET origin_account_name = ? WHERE channel_id = ? AND origin_account_name IS NULL'
@@ -209,6 +261,11 @@ export class ChatSessionRepository {
         return this.mapRow(row);
     }
 
+    /**
+     * Removes a chat session from database storage.
+     * @param channelId The target channel ID.
+     * @returns True if deleted successfully, false otherwise.
+     */
     public deleteByChannelId(channelId: string): boolean {
         const result = this.db.prepare(
             'DELETE FROM chat_sessions WHERE channel_id = ?'
@@ -216,6 +273,11 @@ export class ChatSessionRepository {
         return result.changes > 0;
     }
 
+    /**
+     * Maps database row columns to a structured ChatSessionRecord object.
+     * @param row Database row object.
+     * @returns Fully parsed ChatSessionRecord.
+     */
     private mapRow(row: any): ChatSessionRecord {
         return {
             id: row.id,
@@ -233,3 +295,4 @@ export class ChatSessionRepository {
         };
     }
 }
+

--- a/src/database/scheduleRepository.ts
+++ b/src/database/scheduleRepository.ts
@@ -49,11 +49,17 @@ export interface UpdateScheduleInput {
 export class ScheduleRepository {
     private db: Database.Database;
 
+    /**
+     * @param db SQLite database connection.
+     */
     constructor(db: Database.Database) {
         this.db = db;
         this.initialize();
     }
 
+    /**
+     * Initializes the schedules table and schema migrations.
+     */
     private initialize(): void {
         this.db.exec(`
             CREATE TABLE IF NOT EXISTS schedules (
@@ -217,6 +223,8 @@ export class ScheduleRepository {
 
     /**
      * Map a DB row to ScheduleRecord
+     * @param row SQLite database row.
+     * @returns Mapped ScheduleRecord payload.
      */
     private mapRow(row: any): ScheduleRecord {
         return {

--- a/src/events/interactionCreateHandler.ts
+++ b/src/events/interactionCreateHandler.ts
@@ -70,32 +70,55 @@ import type { AntigravityAccountConfig } from '../utils/configLoader';
 import { inferParentScopeChannelId, listAccountNames, resolveScopedAccountName } from '../utils/accountUtils';
 import { ACCOUNT_SELECT_ID, sendAccountUI } from '../ui/accountUi';
 
+/**
+ * Dependencies injected into interaction create handler factory.
+ */
 export interface InteractionCreateHandlerDeps {
+    /** Configuration options including allowed user lists and workspace directories. */
     config: { allowedUserIds: string[]; workspaceBaseDir?: string };
+    /** Active CDP bridge manager reference. */
     bridge: CdpBridge;
+    /** Command handler for cleanup actions. */
     cleanupHandler: CleanupCommandHandler;
+    /** Current ModeService instance. */
     modeService: ModeService;
+    /** Current ModelService instance. */
     modelService: ModelService;
+    /** Helper dispatching slash commands. */
     slashCommandHandler: SlashCommandHandler;
+    /** Handler coordinating workspace directories. */
     wsHandler: WorkspaceCommandHandler;
+    /** Handler executing chat interactions. */
     chatHandler: ChatCommandHandler;
+    /** Discord client handle reference. */
     client: any;
+    /** Helper function displaying mode selection interface. */
     sendModeUI: (target: { editReply: (opts: any) => Promise<any> }, modeService: ModeService, deps?: import('../ui/modeUi').ModeUiDeps) => Promise<void>;
+    /** Helper function displaying models selection interface. */
     sendModelsUI: (
         target: { editReply: (opts: any) => Promise<any> },
         deps: { getCurrentCdp: () => CdpService | null; fetchQuota: () => Promise<any[]> },
     ) => Promise<void>;
+    /** Helper function displaying auto-accept config interface. */
     sendAutoAcceptUI: (
         target: { editReply: (opts: any) => Promise<any> },
         autoAcceptService: AutoAcceptService,
     ) => Promise<void>;
+    /** Optional handler capture helper for screenshots. */
     handleScreenshot?: (...args: any[]) => Promise<void>;
+    /** Resolve active CdpService connection. */
     getCurrentCdp: (bridge: CdpBridge) => CdpService | null;
+    /** Parser for approval button identifiers. */
     parseApprovalCustomId: (customId: string) => { action: 'approve' | 'always_allow' | 'deny'; projectName: string | null; channelId: string | null } | null;
+    /** Parser for planning button identifiers. */
     parsePlanningCustomId: (customId: string) => { action: 'open' | 'proceed' | 'reject'; projectName: string | null; channelId: string | null } | null;
+    /** Parser for file change button identifiers. */
     parseFileChangeCustomId: (customId: string) => { action: 'accept' | 'reject'; projectName: string | null; channelId: string | null } | null;
+    /** Parser for error popup button identifiers. */
     parseErrorPopupCustomId: (customId: string) => { action: 'dismiss' | 'copy_debug' | 'retry'; projectName: string | null; channelId: string | null } | null;
+    /** Parser for run command button identifiers. */
     parseRunCommandCustomId: (customId: string) => { action: 'run' | 'reject'; projectName: string | null; channelId: string | null } | null;
+    /** Custom handler router execution function for slash commands. */
     handleSlashInteraction: (
         interaction: ChatInputCommandInteraction,
         handler: SlashCommandHandler,
@@ -114,23 +137,43 @@ export interface InteractionCreateHandlerDeps {
         scheduleService?: ScheduleService,
         heartbeatService?: HeartbeatService,
     ) => Promise<void>;
+    /** Optional button interaction handler trigger for template files. */
     handleTemplateUse?: (interaction: ButtonInteraction, templateId: number) => Promise<void>;
+    /** Join command handler helper. */
     joinHandler?: JoinCommandHandler;
+    /** User preferences repository database accessor. */
     userPrefRepo?: UserPreferenceRepository;
+    /** Account preferences repository database accessor. */
     accountPrefRepo?: AccountPreferenceRepository;
+    /** Channel preferences repository database accessor. */
     channelPrefRepo?: ChannelPreferenceRepository;
+    /** Artifact threads mappings store. */
     artifactThreadRepo?: ArtifactThreadRepository;
+    /** Configurations array of active accounts. */
     antigravityAccounts?: AntigravityAccountConfig[];
+    /** Chat sessions store. */
     chatSessionRepo?: ChatSessionRepository;
+    /** Chat sessions service manager. */
     chatSessionService?: ChatSessionService;
+    /** Artifacts list service loader. */
     artifactService?: ArtifactService;
+    /** Scheduling manager service context. */
     scheduleService?: ScheduleService;
+    /** Stream dispatcher service connection. */
     promptDispatcher?: import('../services/promptDispatcher').PromptDispatcher;
+    /** Bound channels tracker. */
     channelManager?: import('../services/channelManager').ChannelManager;
+    /** Channel titles AI generator helper. */
     titleGenerator?: import('../services/titleGeneratorService').TitleGeneratorService;
+    /** Heartbeat emitter tracker service. */
     heartbeatService?: HeartbeatService;
 }
 
+/**
+ * Factory creating Discord event listener callback on new interactions.
+ * @param deps Injected dependencies.
+ * @returns Event listener callback function.
+ */
 export function createInteractionCreateHandler(deps: InteractionCreateHandlerDeps) {
     const getParentChannelId = (interaction: Interaction): string | null => {
         const channelId = interaction.channelId;

--- a/src/events/messageCreateHandler.ts
+++ b/src/events/messageCreateHandler.ts
@@ -39,19 +39,35 @@ import { logger } from '../utils/logger';
 import { HeartbeatService } from '../services/heartbeatService';
 import { WorkspaceQueue } from '../bot/workspaceQueue';
 
+/**
+ * Dependencies injected into message create handler factory.
+ */
 export interface MessageCreateHandlerDeps {
+    /** Configuration options including allowed user lists and timeout values. */
     config: { allowedUserIds: string[]; extractionMode?: import('../utils/config').ExtractionMode; responseTimeoutMs?: number };
+    /** Active CDP bridge manager reference. */
     bridge: CdpBridge;
+    /** Current ModeService instance. */
     modeService: ModeService;
+    /** Current ModelService instance. */
     modelService: ModelService;
+    /** Registered slash commands handler helper. */
     slashCommandHandler: SlashCommandHandler;
+    /** Workspace binding and directory configurations handler. */
     wsHandler: WorkspaceCommandHandler;
+    /** Sessions service interface. */
     chatSessionService: ChatSessionService;
+    /** Sessions local repository store. */
     chatSessionRepo: ChatSessionRepository;
+    /** Bound channels tracker manager. */
     channelManager: ChannelManager;
+    /** Channel titles AI generator service. */
     titleGenerator: TitleGeneratorService;
+    /** Optional Artifacts storage/retrieval service. */
     artifactService?: ArtifactService;
+    /** Discord client reference. */
     client: any;
+    /** Handler helper function sending prompts to the active Antigravity workspace. */
     sendPromptToAntigravity: (
         bridge: CdpBridge,
         message: Message,
@@ -62,6 +78,7 @@ export interface MessageCreateHandlerDeps {
         inboundImages?: InboundImageAttachment[],
         options?: any,
     ) => Promise<void>;
+    /** Handler helper function running channel auto-rename routine. */
     autoRenameChannel: (
         message: Message,
         chatSessionRepo: ChatSessionRepository,
@@ -69,26 +86,49 @@ export interface MessageCreateHandlerDeps {
         channelManager: ChannelManager,
         cdp?: CdpService,
     ) => Promise<void>;
+    /** Handler helper function generating/sending workspace screenshots. */
     handleScreenshot: (target: Message, cdp: CdpService | null) => Promise<void>;
+    /** Optional getter returning currently connected CdpService. */
     getCurrentCdp?: (bridge: CdpBridge) => CdpService | null;
+    /** Optional listener registers for approvals detector. */
     ensureApprovalDetector?: (bridge: CdpBridge, cdp: CdpService, projectName: string) => void;
+    /** Optional listener registers for error popup detector. */
     ensureErrorPopupDetector?: (bridge: CdpBridge, cdp: CdpService, projectName: string) => void;
+    /** Optional listener registers for planning detector. */
     ensurePlanningDetector?: (bridge: CdpBridge, cdp: CdpService, projectName: string) => void;
+    /** Optional listener registers for run commands detector. */
     ensureRunCommandDetector?: (bridge: CdpBridge, cdp: CdpService, projectName: string) => void;
+    /** Optional listener registers for questions detector. */
     ensureQuestionDetector?: (bridge: CdpBridge, cdp: CdpService, projectName: string, accountName?: string) => void;
+    /** Optional workspace approvals channel registrar callback. */
     registerApprovalWorkspaceChannel?: (bridge: CdpBridge, projectName: string, channel: PlatformChannel) => void;
+    /** Optional session approvals channel registrar callback. */
     registerApprovalSessionChannel?: (bridge: CdpBridge, projectName: string, sessionTitle: string, channel: PlatformChannel) => void;
+    /** Helper downloading image attachments to local disk temporarily. */
     downloadInboundImageAttachments?: (message: Message) => Promise<InboundImageAttachment[]>;
+    /** Helper cleaning up temporarily downloaded images. */
     cleanupInboundImageAttachments?: (attachments: InboundImageAttachment[]) => Promise<void>;
+    /** Helper validating if attachment mimetype corresponds to images. */
     isImageAttachment?: (contentType: string | null | undefined, fileName: string | null | undefined) => boolean;
+    /** User preferences repository database accessor. */
     userPrefRepo?: UserPreferenceRepository;
+    /** Account preferences repository database accessor. */
     accountPrefRepo?: AccountPreferenceRepository;
+    /** Channel preferences repository database accessor. */
     channelPrefRepo?: ChannelPreferenceRepository;
+    /** Mappings list of configured accounts. */
     antigravityAccounts?: { name: string; cdpPort: number }[];
+    /** Heartbeat tracker service emitter. */
     heartbeatService?: HeartbeatService;
+    /** Workspace execution request coordinator queue. */
     workspaceQueue?: WorkspaceQueue;
 }
 
+/**
+ * Factory creating Discord event listener callback on new messages.
+ * @param deps Injected dependencies.
+ * @returns Event listener callback function.
+ */
 export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
     const workspaceQueue = deps.workspaceQueue ?? new WorkspaceQueue();
     const getCurrentCdp = deps.getCurrentCdp ?? getCurrentCdpFn;

--- a/src/events/messageCreateHandler.ts
+++ b/src/events/messageCreateHandler.ts
@@ -398,7 +398,7 @@ export function createMessageCreateHandler(deps: MessageCreateHandlerDeps) {
                         logger.info(
                             `[Queue:${projectLabel}] Enqueued (depth: ${newDepth}, channel: ${message.channelId})`,
                         );
-                        await message.react('⏳').catch(() => { });
+                        message.react('⏳').catch(() => { });
                     } else {
                         logger.info(
                             `[Queue:${projectLabel}] Processing immediately (depth: ${newDepth}, channel: ${message.channelId})`,

--- a/src/handlers/accountSelectAction.ts
+++ b/src/handlers/accountSelectAction.ts
@@ -9,15 +9,29 @@ import { listAccountNames } from '../utils/accountUtils';
 import { ACCOUNT_SELECT_ID, buildAccountPayload } from '../ui/accountUi';
 import { logger } from '../utils/logger';
 
+/**
+ * Dependencies injected into account selection action creator.
+ */
 export interface AccountSelectActionDeps {
+    /** Target CDP bridge manager instance. */
     readonly bridge: CdpBridge;
+    /** User account configuration preferences repository. */
     readonly accountPrefRepo: AccountPreferenceRepository;
+    /** Channel preferences repository. */
     readonly channelPrefRepo?: ChannelPreferenceRepository;
+    /** Chat session binding repository. */
     readonly chatSessionRepo?: ChatSessionRepository;
+    /** Resolve bound workspace directory for target channel. */
     readonly getWorkspacePathForChannel?: (channelId: string) => string | null | undefined;
+    /** Registered account credentials mappings configurations. */
     readonly antigravityAccounts: AntigravityAccountConfig[];
 }
 
+/**
+ * Factory creating SelectAction for account selection dropdown changes.
+ * @param deps Injected dependencies.
+ * @returns SelectAction implementation.
+ */
 export function createAccountSelectAction(deps: AccountSelectActionDeps): SelectAction {
     return {
         match(customId: string): boolean {

--- a/src/handlers/approvalButtonAction.ts
+++ b/src/handlers/approvalButtonAction.ts
@@ -13,11 +13,21 @@ import { resolveProjectName } from '../utils/projectResolver';
 import type { WorkspaceCommandHandler } from '../commands/workspaceCommandHandler';
 import { logger } from '../utils/logger';
 
+/**
+ * Dependencies injected into approval button action creator.
+ */
 export interface ApprovalButtonActionDeps {
+    /** Target CDP bridge manager instance. */
     readonly bridge: CdpBridge;
+    /** Workspace command handler instance. */
     readonly wsHandler: WorkspaceCommandHandler;
 }
 
+/**
+ * Factory creating ButtonAction for handling platform approvals.
+ * @param deps Injected dependencies.
+ * @returns ButtonAction implementation.
+ */
 export function createApprovalButtonAction(
     deps: ApprovalButtonActionDeps,
 ): ButtonAction {

--- a/src/handlers/autoAcceptButtonAction.ts
+++ b/src/handlers/autoAcceptButtonAction.ts
@@ -16,10 +16,19 @@ import {
     buildAutoAcceptPayload,
 } from '../ui/autoAcceptUi';
 
+/**
+ * Dependencies injected into auto-accept button action creator.
+ */
 export interface AutoAcceptButtonActionDeps {
+    /** AutoAcceptService managing current configuration state. */
     readonly autoAcceptService: AutoAcceptService;
 }
 
+/**
+ * Factory creating ButtonAction for auto-accept config toggling button clicks.
+ * @param deps Injected dependencies.
+ * @returns ButtonAction implementation.
+ */
 export function createAutoAcceptButtonAction(deps: AutoAcceptButtonActionDeps): ButtonAction {
     return {
         match(customId: string): Record<string, string> | null {

--- a/src/handlers/buttonHandler.ts
+++ b/src/handlers/buttonHandler.ts
@@ -12,6 +12,9 @@ import { logger } from '../utils/logger';
 // Action definition
 // ---------------------------------------------------------------------------
 
+/**
+ * Interface definition for button click action handlers.
+ */
 export interface ButtonAction {
     /** Parse a customId and return extracted parameters, or null if not matching. */
     match: (customId: string) => Record<string, string> | null;
@@ -26,6 +29,9 @@ export interface ButtonAction {
 // Dependency injection interface
 // ---------------------------------------------------------------------------
 
+/**
+ * Dependencies injected into button handler factory.
+ */
 export interface ButtonHandlerDeps {
     /** Registered button action handlers. */
     actions: readonly ButtonAction[];
@@ -38,6 +44,8 @@ export interface ButtonHandlerDeps {
 /**
  * Create a platform-agnostic button interaction handler.
  * Returns an async function that processes PlatformButtonInteraction events.
+ * @param deps Injected dependencies.
+ * @returns Button click handler dispatch function.
  */
 export function createPlatformButtonHandler(deps: ButtonHandlerDeps) {
     return async (interaction: PlatformButtonInteraction): Promise<void> => {

--- a/src/handlers/commandHandler.ts
+++ b/src/handlers/commandHandler.ts
@@ -11,10 +11,16 @@ import { logger } from '../utils/logger';
 // Command definition
 // ---------------------------------------------------------------------------
 
+/**
+ * Interface definition for slash commands.
+ */
 export interface CommandDef {
     /** Command name (e.g. "mode", "project", "model"). */
     readonly name: string;
-    /** Execute the command. */
+    /**
+     * Executes the command logic.
+     * @param interaction Trigger command interaction.
+     */
     execute: (interaction: PlatformCommandInteraction) => Promise<void>;
 }
 
@@ -22,6 +28,9 @@ export interface CommandDef {
 // Dependency injection interface
 // ---------------------------------------------------------------------------
 
+/**
+ * Dependencies injected into command handler factory.
+ */
 export interface CommandHandlerDeps {
     /** Registered command definitions. */
     commands: readonly CommandDef[];
@@ -34,6 +43,8 @@ export interface CommandHandlerDeps {
 /**
  * Create a platform-agnostic slash command handler.
  * Returns an async function that processes PlatformCommandInteraction events.
+ * @param deps Injected dependencies.
+ * @returns Command handler dispatch function.
  */
 export function createPlatformCommandHandler(deps: CommandHandlerDeps) {
     const commandMap = new Map<string, CommandDef>();

--- a/src/handlers/errorPopupButtonAction.ts
+++ b/src/handlers/errorPopupButtonAction.ts
@@ -13,13 +13,23 @@ import { parseErrorPopupCustomId } from '../services/cdpBridgeManager';
 import type { WorkspaceCommandHandler } from '../commands/workspaceCommandHandler';
 import { logger } from '../utils/logger';
 
+/**
+ * Dependencies injected into error popup button action creator.
+ */
 export interface ErrorPopupButtonActionDeps {
+    /** Target CDP bridge manager instance. */
     readonly bridge: CdpBridge;
+    /** Workspace command handler instance. */
     readonly wsHandler: WorkspaceCommandHandler;
 }
 
 const MAX_DEBUG_CONTENT = 4096;
 
+/**
+ * Factory creating ButtonAction for handling IDE error popups.
+ * @param deps Injected dependencies.
+ * @returns ButtonAction implementation.
+ */
 export function createErrorPopupButtonAction(
     deps: ErrorPopupButtonActionDeps,
 ): ButtonAction {

--- a/src/handlers/fileChangeButtonAction.ts
+++ b/src/handlers/fileChangeButtonAction.ts
@@ -7,11 +7,22 @@ import type { WorkspaceCommandHandler } from '../commands/workspaceCommandHandle
 import { logger } from '../utils/logger';
 
 import { executeBrowserClick } from '../utils/questionActionUtils';
+
+/**
+ * Dependencies injected into file change button action creator.
+ */
 export interface FileChangeButtonActionDeps {
+    /** Target CDP bridge manager instance. */
     readonly bridge: CdpBridge;
+    /** Workspace command handler instance. */
     readonly wsHandler: WorkspaceCommandHandler;
 }
 
+/**
+ * Factory creating ButtonAction for file change approval/reject button clicks.
+ * @param deps Injected dependencies.
+ * @returns ButtonAction implementation.
+ */
 export function createFileChangeButtonAction(
     deps: FileChangeButtonActionDeps,
 ): ButtonAction {

--- a/src/handlers/genericActionButtonAction.ts
+++ b/src/handlers/genericActionButtonAction.ts
@@ -1,29 +1,40 @@
 import type { ButtonAction } from './buttonHandler';
 import type { CdpBridge } from '../services/cdpBridgeManager';
-import { getCurrentCdp } from '../services/cdpBridgeManager';
-import { logger } from '../utils/logger';
 import { resolveProjectName } from '../utils/projectResolver';
 
 import type { WorkspaceCommandHandler } from '../commands/workspaceCommandHandler';
 import { executeBrowserClick } from '../utils/questionActionUtils';
+import { logger } from '../utils/logger';
+
+/**
+ * Dependencies injected into generic action button creator.
+ */
 export interface GenericActionButtonActionDeps {
+    /** Target CDP bridge manager instance. */
     readonly bridge: CdpBridge;
+    /** Workspace command handler instance. */
     readonly wsHandler: WorkspaceCommandHandler;
+}
+
+/**
+ * Structured details of parsed generic action button customIds.
+ */
+export interface ParsedGenericAction {
+    /** Label/Name of the action. */
+    actionName: string;
+    /** Associated project workspace name. */
+    projectName?: string;
+    /** Trigger channel ID. */
+    channelId?: string;
 }
 
 /**
  * Parses a generic action button customId into its components.
  * Format: action_btn_[action_name]:[project_name]:[channel_id]
  *
- * @param customId The customId to parse
- * @returns Parsed action details, or null if not an action button
+ * @param customId The customId to parse.
+ * @returns Parsed action details, or null if not an action button.
  */
-export interface ParsedGenericAction {
-    actionName: string;
-    projectName?: string;
-    channelId?: string;
-}
-
 export function parseGenericActionCustomId(customId: string): ParsedGenericAction | null {
     if (!customId.startsWith('action_btn_')) return null;
     const parts = customId.split(':');
@@ -45,6 +56,11 @@ export function parseGenericActionCustomId(customId: string): ParsedGenericActio
     };
 }
 
+/**
+ * Factory creating ButtonAction for generic workspace button click triggers.
+ * @param deps Injected dependencies.
+ * @returns ButtonAction implementation.
+ */
 export function createGenericActionButtonAction(deps: GenericActionButtonActionDeps): ButtonAction {
     return {
         match(customId: string): Record<string, string> | null {

--- a/src/handlers/messageHandler.ts
+++ b/src/handlers/messageHandler.ts
@@ -12,6 +12,9 @@ import { logger } from '../utils/logger';
 // Dependency injection interface
 // ---------------------------------------------------------------------------
 
+/**
+ * Dependencies injected into the platform message handler.
+ */
 export interface MessageHandlerDeps {
     /** Get workspace path for a channel. */
     getWorkspaceForChannel: (channelId: string) => string | undefined;
@@ -36,6 +39,8 @@ export interface MessageHandlerDeps {
 /**
  * Create a platform-agnostic message handler.
  * Returns an async function that processes PlatformMessage events.
+ * @param deps Injected dependencies.
+ * @returns Message handler function.
  */
 export function createPlatformMessageHandler(deps: MessageHandlerDeps) {
     return async (message: PlatformMessage): Promise<void> => {

--- a/src/handlers/modeSelectAction.ts
+++ b/src/handlers/modeSelectAction.ts
@@ -16,11 +16,21 @@ import { MODE_DISPLAY_NAMES } from '../services/modeService';
 import { buildModePayload } from '../ui/modeUi';
 import { logger } from '../utils/logger';
 
+/**
+ * Dependencies injected into mode selection select action creator.
+ */
 export interface ModeSelectActionDeps {
+    /** Target CDP bridge manager instance. */
     readonly bridge: CdpBridge;
+    /** Mode configuration state manager. */
     readonly modeService: ModeService;
 }
 
+/**
+ * Factory creating SelectAction for mode selection menu updates.
+ * @param deps Injected dependencies.
+ * @returns SelectAction implementation.
+ */
 export function createModeSelectAction(deps: ModeSelectActionDeps): SelectAction {
     return {
         match(customId: string): boolean {

--- a/src/handlers/modelButtonAction.ts
+++ b/src/handlers/modelButtonAction.ts
@@ -14,14 +14,27 @@ import type { ModelService } from '../services/modelService';
 import type { UserPreferenceRepository } from '../database/userPreferenceRepository';
 import { logger } from '../utils/logger';
 
+/**
+ * Dependencies injected into model button action creator.
+ */
 export interface ModelButtonActionDeps {
+    /** Target CDP bridge manager instance. */
     readonly bridge: CdpBridge;
+    /** Callback for fetching quota usage datasets. */
     readonly fetchQuota: () => Promise<any[]>;
+    /** Model configurations service. */
     readonly modelService?: ModelService;
+    /** User preferences repository. */
     readonly userPrefRepo?: UserPreferenceRepository;
+    /** Optional activation callback interface checker. */
     readonly ensureSessionActivated?: (channelId: string, userId: string, cdp: NonNullable<ReturnType<typeof getCurrentCdp>>) => Promise<{ ok: true } | { ok: false; error: string }>;
 }
 
+/**
+ * Factory creating ButtonAction for selecting active AI models.
+ * @param deps Injected dependencies.
+ * @returns ButtonAction implementation.
+ */
 export function createModelButtonAction(deps: ModelButtonActionDeps): ButtonAction {
     return {
         match(customId: string): Record<string, string> | null {
@@ -114,6 +127,12 @@ export function createModelButtonAction(deps: ModelButtonActionDeps): ButtonActi
     };
 }
 
+/**
+ * Refreshes the models selection interface layout by fetching fresh metrics.
+ * @param cdp Active CdpService connection.
+ * @param actionDeps Injected button deps options.
+ * @param interaction Platform button click interaction.
+ */
 async function refreshModelsUI(
     cdp: NonNullable<ReturnType<typeof getCurrentCdp>>,
     actionDeps: ModelButtonActionDeps,

--- a/src/handlers/planningButtonAction.ts
+++ b/src/handlers/planningButtonAction.ts
@@ -17,13 +17,23 @@ import * as path from 'path';
 import { execFile } from 'child_process';
 import { getAntigravityCliPath } from '../utils/pathUtils';
 
+/**
+ * Dependencies injected into planning button action creator.
+ */
 export interface PlanningButtonActionDeps {
+    /** Target CDP bridge manager instance. */
     readonly bridge: CdpBridge;
+    /** Workspace command handler instance. */
     readonly wsHandler: WorkspaceCommandHandler;
 }
 
 const MAX_PLAN_CONTENT = 4096;
 
+/**
+ * Factory creating ButtonAction for planning prompt modal and proceed actions.
+ * @param deps Injected dependencies.
+ * @returns ButtonAction implementation.
+ */
 export function createPlanningButtonAction(
     deps: PlanningButtonActionDeps,
 ): ButtonAction {

--- a/src/handlers/planningModalSubmitAction.ts
+++ b/src/handlers/planningModalSubmitAction.ts
@@ -3,6 +3,13 @@ import { CdpConnectionPool } from '../services/cdpConnectionPool';
 import { t } from '../utils/i18n';
 import { logger } from '../utils/logger';
 
+/**
+ * Executes the modal submission logic for custom comments injected into the workspace plan.
+ * @param interaction Platform modal submit interaction payload.
+ * @param projectName Active workspace project name.
+ * @param pool CDP connection pool service.
+ * @param accountName Active user account name.
+ */
 export async function execute(
     interaction: PlatformModalSubmitInteraction,
     projectName: string | null,

--- a/src/handlers/questionSelectAction.ts
+++ b/src/handlers/questionSelectAction.ts
@@ -4,15 +4,24 @@ import type { CdpBridge } from '../services/cdpBridgeManager';
 import type { WorkspaceCommandHandler } from '../commands/workspaceCommandHandler';
 import { logger } from '../utils/logger';
 import { QUESTION_SELECT_ACTION_PREFIX } from '../services/notificationSender';
-
-export interface QuestionSelectActionDeps {
-    readonly bridge: CdpBridge;
-    readonly wsHandler: WorkspaceCommandHandler;
-}
-
 import { parseQuestionCustomId } from '../utils/questionActionUtils';
 import { resolveProjectName } from '../utils/projectResolver';
 
+/**
+ * Dependencies injected into question selection action creator.
+ */
+export interface QuestionSelectActionDeps {
+    /** Target CDP bridge manager instance. */
+    readonly bridge: CdpBridge;
+    /** Workspace command handler instance. */
+    readonly wsHandler: WorkspaceCommandHandler;
+}
+
+/**
+ * Factory creating SelectAction for interactive question select menu changes.
+ * @param deps Injected dependencies.
+ * @returns SelectAction implementation.
+ */
 export function createQuestionSelectAction(deps: QuestionSelectActionDeps): SelectAction {
     return {
         match(customId: string): boolean {

--- a/src/handlers/questionSkipAction.ts
+++ b/src/handlers/questionSkipAction.ts
@@ -4,15 +4,24 @@ import type { CdpBridge } from '../services/cdpBridgeManager';
 import type { WorkspaceCommandHandler } from '../commands/workspaceCommandHandler';
 import { logger } from '../utils/logger';
 import { QUESTION_SKIP_ACTION_PREFIX } from '../services/notificationSender';
-
-export interface QuestionSkipActionDeps {
-    readonly bridge: CdpBridge;
-    readonly wsHandler: WorkspaceCommandHandler;
-}
-
 import { parseQuestionCustomId } from '../utils/questionActionUtils';
 import { resolveProjectName } from '../utils/projectResolver';
 
+/**
+ * Dependencies injected into question skip action creator.
+ */
+export interface QuestionSkipActionDeps {
+    /** Target CDP bridge manager instance. */
+    readonly bridge: CdpBridge;
+    /** Workspace command handler instance. */
+    readonly wsHandler: WorkspaceCommandHandler;
+}
+
+/**
+ * Factory creating ButtonAction for skipping interactive question inputs.
+ * @param deps Injected dependencies.
+ * @returns ButtonAction implementation.
+ */
 export function createQuestionSkipAction(deps: QuestionSkipActionDeps): ButtonAction {
     return {
         match(customId: string): Record<string, string> | null {

--- a/src/handlers/runCommandButtonAction.ts
+++ b/src/handlers/runCommandButtonAction.ts
@@ -13,11 +13,21 @@ import { resolveProjectName } from '../utils/projectResolver';
 import type { WorkspaceCommandHandler } from '../commands/workspaceCommandHandler';
 import { logger } from '../utils/logger';
 
+/**
+ * Dependencies injected into run command button action creator.
+ */
 export interface RunCommandButtonActionDeps {
+    /** Target CDP bridge manager instance. */
     readonly bridge: CdpBridge;
+    /** Workspace command handler instance. */
     readonly wsHandler: WorkspaceCommandHandler;
 }
 
+/**
+ * Factory creating ButtonAction for command execution/reject button clicks.
+ * @param deps Injected dependencies.
+ * @returns ButtonAction implementation.
+ */
 export function createRunCommandButtonAction(
     deps: RunCommandButtonActionDeps,
 ): ButtonAction {

--- a/src/handlers/selectHandler.ts
+++ b/src/handlers/selectHandler.ts
@@ -12,6 +12,9 @@ import { logger } from '../utils/logger';
 // Action definition
 // ---------------------------------------------------------------------------
 
+/**
+ * Single select action definition logic interface.
+ */
 export interface SelectAction {
     /** Match a select menu customId. Return true if this handler should process it. */
     match: (customId: string) => boolean;
@@ -26,6 +29,9 @@ export interface SelectAction {
 // Dependency injection interface
 // ---------------------------------------------------------------------------
 
+/**
+ * Dependencies injected into select handler factory.
+ */
 export interface SelectHandlerDeps {
     /** Registered select menu action handlers. */
     actions: readonly SelectAction[];
@@ -38,6 +44,8 @@ export interface SelectHandlerDeps {
 /**
  * Create a platform-agnostic select menu handler.
  * Returns an async function that processes PlatformSelectInteraction events.
+ * @param deps Injected dependencies.
+ * @returns Handler function.
  */
 export function createPlatformSelectHandler(deps: SelectHandlerDeps) {
     return async (interaction: PlatformSelectInteraction): Promise<void> => {

--- a/src/handlers/templateButtonAction.ts
+++ b/src/handlers/templateButtonAction.ts
@@ -14,11 +14,21 @@ import { TEMPLATE_BTN_PREFIX, parseTemplateButtonId } from '../ui/templateUi';
 import type { TemplateRepository } from '../database/templateRepository';
 import { logger } from '../utils/logger';
 
+/**
+ * Dependencies injected into template button action creator.
+ */
 export interface TemplateButtonActionDeps {
+    /** Target CDP bridge manager instance. */
     readonly bridge: CdpBridge;
+    /** Repository managing custom prompting templates. */
     readonly templateRepo: TemplateRepository;
 }
 
+/**
+ * Factory creating ButtonAction for template injection button clicks.
+ * @param deps Injected dependencies.
+ * @returns ButtonAction implementation.
+ */
 export function createTemplateButtonAction(deps: TemplateButtonActionDeps): ButtonAction {
     return {
         match(customId: string): Record<string, string> | null {

--- a/src/platform/adapter.ts
+++ b/src/platform/adapter.ts
@@ -18,12 +18,21 @@ import type {
 // Adapter events
 // ---------------------------------------------------------------------------
 
+/**
+ * Events emitted or handled by the platform adapter.
+ */
 export interface PlatformAdapterEvents {
+    /** Called when the adapter completes authentication and is ready. */
     onReady?: () => void;
+    /** Called when a user message is received. */
     onMessage?: (message: PlatformMessage) => Promise<void>;
+    /** Called when a user interacts with a button UI element. */
     onButtonInteraction?: (interaction: PlatformButtonInteraction) => Promise<void>;
+    /** Called when a user interacts with a dropdown/select menu UI element. */
     onSelectInteraction?: (interaction: PlatformSelectInteraction) => Promise<void>;
+    /** Called when a slash or chat command is triggered. */
     onCommandInteraction?: (interaction: PlatformCommandInteraction) => Promise<void>;
+    /** Called when a platform-level error occurs. */
     onError?: (error: Error) => void;
 }
 
@@ -31,19 +40,29 @@ export interface PlatformAdapterEvents {
 // Adapter interface
 // ---------------------------------------------------------------------------
 
+/**
+ * Interface that messaging platforms (Discord, Telegram) must implement.
+ */
 export interface PlatformAdapter {
     /** Which platform this adapter serves. */
     readonly platform: PlatformType;
 
-    /** Start the adapter (connect, login, begin polling/listening). */
+    /**
+     * Start the adapter (connect, login, begin polling/listening).
+     * @param events Event handler callbacks.
+     */
     start(events: PlatformAdapterEvents): Promise<void>;
 
     /** Stop the adapter (disconnect, cleanup). */
     stop(): Promise<void>;
 
-    /** Retrieve a channel by its platform-native ID. Returns null if not found. */
+    /**
+     * Retrieve a channel by its platform-native ID. Returns null if not found.
+     * @param channelId Native channel ID.
+     */
     getChannel(channelId: string): Promise<PlatformChannel | null>;
 
     /** Return the bot's own user ID on this platform. */
     getBotUserId(): string;
 }
+

--- a/src/platform/discord/discordAdapter.ts
+++ b/src/platform/discord/discordAdapter.ts
@@ -24,11 +24,17 @@ import type {
     ChatInputCommandInteraction,
 } from 'discord.js';
 
+/**
+ * Discord platform adapter implementation.
+ */
 export class DiscordAdapter implements PlatformAdapter {
     readonly platform = 'discord' as const;
     private readonly client: Client;
     private botUserId: string = '';
 
+    /**
+     * @param client Raw discord.js Client instance.
+     */
     constructor(client: Client) {
         this.client = client;
     }

--- a/src/platform/telegram/telegramAdapter.ts
+++ b/src/platform/telegram/telegramAdapter.ts
@@ -25,17 +25,31 @@ import { logger } from '../../utils/logger';
 // TelegramAdapter
 // ---------------------------------------------------------------------------
 
+/**
+ * Adapter implementing multi-platform interface for Telegram.
+ */
 export class TelegramAdapter implements PlatformAdapter {
+    /** The target messaging platform string. */
     readonly platform = 'telegram' as const;
 
+    /** Telegram bot client wrapper. */
     private readonly bot: TelegramBotLike;
+    /** The bot's own user ID. */
     private readonly botUserId: string;
+    /** Registered event handlers. */
     private events: PlatformAdapterEvents | null = null;
+    /** Polling loop status flag. */
     private started = false;
+    /** True if telegram event list handlers are bound. */
     private handlersRegistered = false;
     /** Timestamp when the adapter started — messages older than this are discarded. */
     private startedAt: number = 0;
 
+    /**
+     * Initializes the Telegram adapter.
+     * @param bot Bot library wrapper.
+     * @param botUserId Bot native user ID.
+     */
     constructor(bot: TelegramBotLike, botUserId: string) {
         this.bot = bot;
         this.botUserId = botUserId;
@@ -46,6 +60,7 @@ export class TelegramAdapter implements PlatformAdapter {
      *
      * Registers Telegram event handlers that translate incoming events to the
      * platform-agnostic event callbacks, then starts the bot polling loop.
+     * @param events Callbacks for handling received events.
      */
     async start(events: PlatformAdapterEvents): Promise<void> {
         if (this.started) {
@@ -90,6 +105,8 @@ export class TelegramAdapter implements PlatformAdapter {
     /**
      * Retrieve a channel (chat) by its platform-native ID.
      * Returns a PlatformChannel backed by the bot API.
+     * @param chatId Telegram Chat ID.
+     * @returns Fully mapped PlatformChannel, or null if retrieval failed.
      */
     async getChannel(chatId: string): Promise<PlatformChannel | null> {
         try {
@@ -109,6 +126,7 @@ export class TelegramAdapter implements PlatformAdapter {
 
     /**
      * Return the bot's own user ID.
+     * @returns Bot user ID string.
      */
     getBotUserId(): string {
         return this.botUserId;
@@ -121,6 +139,8 @@ export class TelegramAdapter implements PlatformAdapter {
     /**
      * Shared handler for both text and photo messages.
      * Wraps the Telegram message and fires onMessage.
+     * @param eventName Identifier event name for logging.
+     * @param ctx Event update context.
      */
     private handleIncomingMessage(eventName: string, ctx: any): void {
         if (!this.events?.onMessage) return;
@@ -162,6 +182,9 @@ export class TelegramAdapter implements PlatformAdapter {
         }
     }
 
+    /**
+     * Binds internal event listeners to the Telegram Bot client.
+     */
     private registerHandlers(): void {
         // Text messages
         this.bot.on('message:text', async (ctx: any) => {
@@ -217,6 +240,10 @@ export class TelegramAdapter implements PlatformAdapter {
         });
     }
 
+    /**
+     * Safely triggers the onError event handler callback.
+     * @param error The thrown error object.
+     */
     private emitError(error: unknown): void {
         if (!this.events?.onError) return;
 

--- a/src/platform/telegram/wrappers.ts
+++ b/src/platform/telegram/wrappers.ts
@@ -25,12 +25,19 @@ import { richContentToHtml, markdownToTelegramHtml } from './telegramFormatter';
 // grammy-compatible interfaces (no grammy import needed)
 // ---------------------------------------------------------------------------
 
+/**
+ * Interface mimicking a GrammY bot client for modular dependency injection.
+ */
 export interface TelegramBotLike {
     /** Bot token — needed to construct file download URLs. */
     token?: string;
+    /** Starts bot polling. */
     start(): void | Promise<void>;
+    /** Stops bot polling. */
     stop(): void;
+    /** Registers update event listeners. */
     on(event: string, handler: (...args: any[]) => any): void;
+    /** API client methods subset. */
     api: {
         sendMessage(chatId: number | string, text: string, options?: any): Promise<any>;
         editMessageText(chatId: number | string, messageId: number, text: string, options?: any): Promise<any>;
@@ -51,44 +58,81 @@ export interface TelegramBotLike {
     toInputFile?: (data: Buffer, filename?: string) => unknown;
 }
 
+/**
+ * Represents a Telegram sender structure.
+ */
 export interface TelegramFrom {
+    /** Native user ID. */
     id: number;
+    /** First name of the user. */
     first_name: string;
+    /** Optional last name of the user. */
     last_name?: string;
+    /** Optional username handle. */
     username?: string;
+    /** True if the user is a bot. */
     is_bot: boolean;
 }
 
+/**
+ * Represents a Telegram photo size detail.
+ */
 export interface TelegramPhotoSize {
+    /** Native file unique ID. */
     file_id: string;
+    /** Unique media ID. */
     file_unique_id: string;
+    /** Image pixel width. */
     width: number;
+    /** Image pixel height. */
     height: number;
+    /** File size in bytes. */
     file_size?: number;
 }
 
+/**
+ * Represents a Telegram message payload.
+ */
 export interface TelegramMessageLike {
+    /** Message ID. */
     message_id: number;
+    /** Sender user. */
     from?: TelegramFrom;
+    /** Chat destination info. */
     chat: { id: number; title?: string; type: string };
+    /** Optional raw message text. */
     text?: string;
     /** Photo messages store user text in caption, not text. */
     caption?: string;
     /** Array of photo sizes; last element is the largest. */
     photo?: TelegramPhotoSize[];
+    /** Unix timestamp. */
     date: number;
 }
 
+/**
+ * Represents a Telegram callback query update.
+ */
 export interface TelegramCallbackQueryLike {
+    /** Query identifier. */
     id: string;
+    /** Sender user. */
     from: TelegramFrom;
+    /** Original message, if any. */
     message?: TelegramMessageLike;
+    /** Callback payload data. */
     data?: string;
 }
 
+/**
+ * Options package for Telegram message deliveries.
+ */
 export interface TelegramSendOptions {
+    /** Outbound text markup. */
     text: string;
+    /** HTML formatting flag. */
     parse_mode: 'HTML';
+    /** Dynamic keyboard buttons. */
     reply_markup?: {
         inline_keyboard: ReadonlyArray<
             ReadonlyArray<{ text: string; callback_data: string }>
@@ -102,6 +146,11 @@ export interface TelegramSendOptions {
 
 type InlineButton = { text: string; callback_data: string };
 
+/**
+ * Converts a button definition to an inline button.
+ * @param btn The button definition.
+ * @returns InlineButton structure.
+ */
 function buttonDefToInline(btn: ButtonDef): InlineButton {
     return { text: btn.label, callback_data: btn.customId };
 }
@@ -113,12 +162,22 @@ function buttonDefToInline(btn: ButtonDef): InlineButton {
  */
 export const SELECT_CALLBACK_SEP = '\x1f';
 
+/**
+ * Converts select menu options to inline keyboard rows.
+ * @param menu Select menu definition.
+ * @returns Grid array of inline buttons.
+ */
 function selectMenuToInlineRows(menu: SelectMenuDef): ReadonlyArray<ReadonlyArray<InlineButton>> {
     return menu.options.map((opt) => [
         { text: opt.label, callback_data: `${menu.customId}${SELECT_CALLBACK_SEP}${opt.value}` },
     ]);
 }
 
+/**
+ * Transforms generic component rows to Telegram-compatible keyboard arrays.
+ * @param rows Input components grid.
+ * @returns Multi-dimensional inline button array.
+ */
 function componentRowsToInlineKeyboard(
     rows: readonly ComponentRow[],
 ): ReadonlyArray<ReadonlyArray<InlineButton>> {
@@ -163,6 +222,8 @@ function componentRowsToInlineKeyboard(
  * - RichContent is rendered to HTML via richContentToHtml
  * - ComponentRow[] become inline_keyboard
  * - text + richContent are combined into one HTML message
+ * @param payload Outbound payload.
+ * @returns Fully formatted TelegramSendOptions object.
  */
 export function toTelegramPayload(payload: MessagePayload): TelegramSendOptions {
     const parts: string[] = [];
@@ -206,7 +267,11 @@ export function toTelegramPayload(payload: MessagePayload): TelegramSendOptions 
 // Entity wrappers
 // ---------------------------------------------------------------------------
 
-/** Wrap a Telegram user object to a PlatformUser. */
+/**
+ * Wrap a Telegram user object to a PlatformUser.
+ * @param from Telegram source user.
+ * @returns Mapped PlatformUser.
+ */
 export function wrapTelegramUser(from: TelegramFrom): PlatformUser {
     const displayParts = [from.first_name];
     if (from.last_name) {
@@ -225,9 +290,13 @@ export function wrapTelegramUser(from: TelegramFrom): PlatformUser {
 /**
  * Try to send a file attachment via Telegram photo/document API.
  * Returns the sent message, or null if file sending is not available.
- *
- * @param toInputFile - Optional converter that wraps Buffer for the Telegram API.
- *   grammY requires Buffer wrapped in InputFile; pass `bot.toInputFile` here.
+ * @param api Bot API instance.
+ * @param chatId Destination chat ID.
+ * @param file Attachment payload.
+ * @param caption Custom caption text.
+ * @param extraOptions Optional additional options.
+ * @param toInputFile GrammY file formatter helper.
+ * @returns Resolves to sent message object, or null.
  */
 async function trySendFile(
     api: TelegramBotLike['api'],
@@ -260,7 +329,13 @@ async function trySendFile(
     return null;
 }
 
-/** Wrap a Telegram chat as a PlatformChannel. */
+/**
+ * Wrap a Telegram chat as a PlatformChannel.
+ * @param api Bot API reference.
+ * @param chatId Target chat ID.
+ * @param toInputFile Optional GrammY file formatter helper.
+ * @returns PlatformChannel abstraction interface.
+ */
 export function wrapTelegramChannel(
     api: TelegramBotLike['api'],
     chatId: number | string,
@@ -300,6 +375,9 @@ export function wrapTelegramChannel(
  * Build PlatformAttachment[] from a Telegram photo message.
  * Uses the largest photo size (last in the array) and constructs
  * the download URL from the bot token and file_id.
+ * @param photo Image sizes array.
+ * @param botToken Bot token to build uri.
+ * @returns Mapped PlatformAttachment array.
  */
 function buildPhotoAttachments(
     photo: TelegramPhotoSize[],
@@ -324,7 +402,14 @@ function buildPhotoAttachments(
     }];
 }
 
-/** Wrap a Telegram message as a PlatformMessage. */
+/**
+ * Wrap a Telegram message as a PlatformMessage.
+ * @param msg Original update message.
+ * @param api Bot API instance.
+ * @param toInputFile GrammY file formatter helper.
+ * @param botToken Bot connection token.
+ * @returns PlatformMessage interface.
+ */
 export function wrapTelegramMessage(
     msg: TelegramMessageLike,
     api: TelegramBotLike['api'],
@@ -405,6 +490,7 @@ export function wrapTelegramMessage(
 /**
  * Validate that a chatId is usable for sending messages.
  * Throws a descriptive error if the chatId is synthetic (0).
+ * @param chatId Target ID value.
  */
 function assertValidChatId(chatId: number | string): void {
     if (chatId === 0 || chatId === '0') {
@@ -415,7 +501,12 @@ function assertValidChatId(chatId: number | string): void {
     }
 }
 
-/** Wrap a Telegram callback query as a PlatformButtonInteraction. */
+/**
+ * Wrap a Telegram callback query as a PlatformButtonInteraction.
+ * @param query Native callback query event.
+ * @param api Bot API instance.
+ * @returns PlatformButtonInteraction interface wrapper.
+ */
 export function wrapTelegramCallbackQuery(
     query: TelegramCallbackQueryLike,
     api: TelegramBotLike['api'],
@@ -472,7 +563,13 @@ export function wrapTelegramCallbackQuery(
 // Sent message wrapper
 // ---------------------------------------------------------------------------
 
-/** Wrap a Telegram API send result as a PlatformSentMessage. */
+/**
+ * Wrap a Telegram API send result as a PlatformSentMessage.
+ * @param msg Return message from Telegram API.
+ * @param api Bot API instance.
+ * @param chatId Target destination ID.
+ * @returns Mapped PlatformSentMessage.
+ */
 export function wrapTelegramSentMessage(
     msg: any,
     api: TelegramBotLike['api'],

--- a/src/platform/telegram/wrappers.ts
+++ b/src/platform/telegram/wrappers.ts
@@ -295,7 +295,7 @@ export function wrapTelegramUser(from: TelegramFrom): PlatformUser {
  * @param file Attachment payload.
  * @param caption Custom caption text.
  * @param extraOptions Optional additional options.
- * @param toInputFile GrammY file formatter helper.
+ * @param toInputFile - Optional converter that wraps Buffer for the Telegram API. grammY requires Buffer wrapped in InputFile; pass `bot.toInputFile` here.
  * @returns Resolves to sent message object, or null.
  */
 async function trySendFile(

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -10,6 +10,9 @@
 // Platform identification
 // ---------------------------------------------------------------------------
 
+/**
+ * Supported messaging platform types.
+ */
 export type PlatformType = 'discord' | 'telegram';
 
 /**
@@ -17,16 +20,26 @@ export type PlatformType = 'discord' | 'telegram';
  * Encoded as "platform:id" string for use as map keys.
  */
 export interface PlatformId {
+    /** The target messaging platform. */
     readonly platform: PlatformType;
+    /** The platform-native ID of the entity. */
     readonly id: string;
 }
 
-/** Encode a PlatformId to a "platform:id" string key. */
+/**
+ * Encodes a PlatformId into a "platform:id" string key.
+ * @param pid The PlatformId object.
+ * @returns Serialized string key.
+ */
 export function toPlatformKey(pid: PlatformId): string {
     return `${pid.platform}:${pid.id}`;
 }
 
-/** Decode a "platform:id" string key to a PlatformId. Returns null on invalid input. */
+/**
+ * Decodes a "platform:id" string key back to a PlatformId.
+ * @param key Serialized key.
+ * @returns The deserialized PlatformId, or null if the key format is invalid.
+ */
 export function fromPlatformKey(key: string): PlatformId | null {
     const idx = key.indexOf(':');
     if (idx <= 0) return null;
@@ -41,40 +54,81 @@ export function fromPlatformKey(key: string): PlatformId | null {
 // Core platform entities
 // ---------------------------------------------------------------------------
 
+/**
+ * Represents a user across messaging platforms.
+ */
 export interface PlatformUser {
+    /** Native user ID. */
     readonly id: string;
+    /** Platform of the user. */
     readonly platform: PlatformType;
+    /** Handle/username. */
     readonly username: string;
+    /** Optional friendly display name. */
     readonly displayName?: string;
+    /** True if the user is an automated bot. */
     readonly isBot: boolean;
 }
 
+/**
+ * Represents a conversation channel or chat group.
+ */
 export interface PlatformChannel {
+    /** Native channel ID. */
     readonly id: string;
+    /** Platform of the channel. */
     readonly platform: PlatformType;
+    /** Optional friendly name of the channel. */
     readonly name?: string;
-    /** Send a message to this channel. */
+    /**
+     * Send a message to this channel.
+     * @param payload Message contents and components.
+     * @returns A promise resolving to the sent message wrapper.
+     */
     send(payload: MessagePayload): Promise<PlatformSentMessage>;
 }
 
+/**
+ * Represents a file attachment in a message.
+ */
 export interface PlatformAttachment {
+    /** Filename. */
     readonly name: string;
+    /** MIME content-type of the attachment. */
     readonly contentType: string | null;
+    /** Resource download URL. */
     readonly url: string;
+    /** Size of the attachment in bytes. */
     readonly size: number;
 }
 
+/**
+ * Represents a chat message received from a platform.
+ */
 export interface PlatformMessage {
+    /** Native message ID. */
     readonly id: string;
+    /** Platform of the message. */
     readonly platform: PlatformType;
+    /** Text content of the message. */
     readonly content: string;
+    /** The author user of the message. */
     readonly author: PlatformUser;
+    /** The channel the message was posted in. */
     readonly channel: PlatformChannel;
+    /** Attachments linked with the message. */
     readonly attachments: readonly PlatformAttachment[];
+    /** Creation timestamp. */
     readonly createdAt: Date;
-    /** Add a reaction (emoji) to this message. Platform-specific format. */
+    /**
+     * Add a reaction (emoji) to this message.
+     * @param emoji Reaction emoji symbol.
+     */
     react(emoji: string): Promise<void>;
-    /** Reply to this message. */
+    /**
+     * Reply to this message.
+     * @param payload Reply message content.
+     */
     reply(payload: MessagePayload): Promise<PlatformSentMessage>;
 }
 
@@ -82,20 +136,37 @@ export interface PlatformMessage {
 // Rich content (Embed abstraction)
 // ---------------------------------------------------------------------------
 
+/**
+ * Single field within a rich content embed.
+ */
 export interface RichContentField {
+    /** Field title/label. */
     readonly name: string;
+    /** Field body/value. */
     readonly value: string;
+    /** True to align inline. */
     readonly inline?: boolean;
 }
 
+/**
+ * Platform-independent rich text embed message card.
+ */
 export interface RichContent {
+    /** Embed title. */
     readonly title?: string;
+    /** Embed description. */
     readonly description?: string;
+    /** Hex color integer. */
     readonly color?: number;
+    /** Structured lists/fields. */
     readonly fields?: readonly RichContentField[];
+    /** Footer text string. */
     readonly footer?: string;
+    /** Optional timestamp. */
     readonly timestamp?: Date;
+    /** URL of the thumbnail preview. */
     readonly thumbnailUrl?: string;
+    /** URL of the main display image. */
     readonly imageUrl?: string;
 }
 
@@ -103,37 +174,65 @@ export interface RichContent {
 // UI Components (Button / Select Menu abstraction)
 // ---------------------------------------------------------------------------
 
+/**
+ * Styling styles for interface buttons.
+ */
 export type ButtonStyle = 'primary' | 'secondary' | 'success' | 'danger';
 
+/**
+ * Definition of an interactive interface button component.
+ */
 export interface ButtonDef {
+    /** Type identifier. */
     readonly type: 'button';
+    /** Unique developer identifier for handling clicks. */
     readonly customId: string;
+    /** Text label printed on the button. */
     readonly label: string;
+    /** Theme styling style. */
     readonly style: ButtonStyle;
+    /** True to disable clicking. */
     readonly disabled?: boolean;
 }
 
+/**
+ * Single selectable option in a dropdown/select menu.
+ */
 export interface SelectMenuOption {
+    /** User-visible label. */
     readonly label: string;
+    /** Internally returned value on selection. */
     readonly value: string;
+    /** Description helper. */
     readonly description?: string;
+    /** True if selected by default. */
     readonly isDefault?: boolean;
 }
 
+/**
+ * Definition of a dropdown/select menu component.
+ */
 export interface SelectMenuDef {
+    /** Type identifier. */
     readonly type: 'selectMenu';
+    /** Unique developer identifier for select changes. */
     readonly customId: string;
+    /** Placeholder message when empty. */
     readonly placeholder?: string;
+    /** Selectable menu options list. */
     readonly options: readonly SelectMenuOption[];
 }
 
+/**
+ * Supported component definitions.
+ */
 export type ComponentDef = ButtonDef | SelectMenuDef;
 
 /**
- * A row of components. Discord allows up to 5 buttons per row,
- * or 1 select menu per row. Telegram uses InlineKeyboard rows.
+ * A row of interactive components.
  */
 export interface ComponentRow {
+    /** Ordered list of components in the row. */
     readonly components: readonly ComponentDef[];
 }
 
@@ -141,22 +240,41 @@ export interface ComponentRow {
 // Modals (Dialog boxes)
 // ---------------------------------------------------------------------------
 
+/**
+ * Single text input field inside a modal popup.
+ */
 export interface ModalTextInput {
+    /** Type identifier. */
     readonly type: 'textInput';
+    /** Unique developer identifier. */
     readonly customId: string;
+    /** User-visible label. */
     readonly label: string;
+    /** Text layout style. */
     readonly style: 'short' | 'paragraph';
+    /** Optional placeholder string. */
     readonly placeholder?: string;
+    /** True if input is mandatory. */
     readonly required?: boolean;
 }
 
+/**
+ * Row layout containing text inputs inside a modal.
+ */
 export interface ModalRow {
+    /** Input elements within the row. */
     readonly components: readonly ModalTextInput[];
 }
 
+/**
+ * Modal form configuration definition.
+ */
 export interface ModalDef {
+    /** Form header title. */
     readonly title: string;
+    /** Unique modal ID. */
     readonly customId: string;
+    /** Ordered grid rows of inputs. */
     readonly components: readonly ModalRow[];
 }
 
@@ -164,18 +282,31 @@ export interface ModalDef {
 // Message payload (what gets sent)
 // ---------------------------------------------------------------------------
 
+/**
+ * Configuration of a file attachment payload.
+ */
 export interface FileAttachment {
+    /** Target file name. */
     readonly name: string;
+    /** Binary buffer. */
     readonly data: Buffer;
+    /** MIME content type. */
     readonly contentType?: string;
 }
 
+/**
+ * Payload contents sent to channels or used to update messages.
+ */
 export interface MessagePayload {
+    /** Raw text message. */
     readonly text?: string;
+    /** Optional rich content card. */
     readonly richContent?: RichContent;
+    /** Grid layout of components. */
     readonly components?: readonly ComponentRow[];
+    /** Files to attach. */
     readonly files?: readonly FileAttachment[];
-    /** Platform-specific: whether the message is ephemeral (only visible to the user). */
+    /** True if only visible to the trigger user. */
     readonly ephemeral?: boolean;
 }
 
@@ -183,13 +314,22 @@ export interface MessagePayload {
 // Sent message handle (for edit / delete)
 // ---------------------------------------------------------------------------
 
+/**
+ * Wrapper class representing a message successfully posted.
+ */
 export interface PlatformSentMessage {
+    /** Native message ID. */
     readonly id: string;
+    /** Target platform. */
     readonly platform: PlatformType;
+    /** Channel ID containing the message. */
     readonly channelId: string;
-    /** Edit the sent message content. */
+    /**
+     * Edit the contents of this message.
+     * @param payload Updated details.
+     */
     edit(payload: MessagePayload): Promise<PlatformSentMessage>;
-    /** Delete the sent message. */
+    /** Delete this message. */
     delete(): Promise<void>;
 }
 
@@ -197,66 +337,169 @@ export interface PlatformSentMessage {
 // Interaction types
 // ---------------------------------------------------------------------------
 
+/**
+ * Represents a button click interaction.
+ */
 export interface PlatformButtonInteraction {
+    /** Unique interaction ID. */
     readonly id: string;
+    /** Target platform. */
     readonly platform: PlatformType;
+    /** Component custom identifier. */
     readonly customId: string;
+    /** User who clicked the button. */
     readonly user: PlatformUser;
+    /** Channel containing the button message. */
     readonly channel: PlatformChannel;
+    /** Message containing the button. */
     readonly messageId: string;
-    /** Acknowledge the interaction (defer). */
+    /** Acknowledge the interaction without immediate updates. */
     deferUpdate(): Promise<void>;
-    /** Reply to the interaction. */
+    /**
+     * Reply to the interaction.
+     * @param payload Reply text/components.
+     */
     reply(payload: MessagePayload): Promise<void>;
-    /** Update the original message. */
+    /**
+     * Replace the message content.
+     * @param payload New contents.
+     */
     update(payload: MessagePayload): Promise<void>;
-    /** Edit the original reply. */
+    /**
+     * Edit the original interaction response.
+     * @param payload New reply contents.
+     */
     editReply(payload: MessagePayload): Promise<void>;
-    /** Send a follow-up message. */
+    /**
+     * Post a follow-up message linked to the interaction.
+     * @param payload Message parameters.
+     */
     followUp(payload: MessagePayload): Promise<PlatformSentMessage>;
-    /** Show a modal dialog box. Must be the first response. */
+    /**
+     * Show a popup form modal.
+     * @param modal Modal specifications.
+     */
     showModal?(modal: ModalDef): Promise<void>;
 }
 
+/**
+ * Represents a dropdown option change interaction.
+ */
 export interface PlatformSelectInteraction {
+    /** Unique interaction ID. */
     readonly id: string;
+    /** Target platform. */
     readonly platform: PlatformType;
+    /** Component custom identifier. */
     readonly customId: string;
+    /** User who made the selection. */
     readonly user: PlatformUser;
+    /** Channel containing the selection menu. */
     readonly channel: PlatformChannel;
+    /** Selected string values. */
     readonly values: readonly string[];
+    /** Message containing the selection. */
     readonly messageId: string;
+    /** Acknowledge the interaction. */
     deferUpdate(): Promise<void>;
+    /**
+     * Reply to the selection.
+     * @param payload Response contents.
+     */
     reply(payload: MessagePayload): Promise<void>;
+    /**
+     * Replace the selection message contents.
+     * @param payload Updated components/text.
+     */
     update(payload: MessagePayload): Promise<void>;
+    /**
+     * Edit the original response.
+     * @param payload Updated reply payload.
+     */
     editReply(payload: MessagePayload): Promise<void>;
+    /**
+     * Send a subsequent follow-up.
+     * @param payload Follow-up contents.
+     */
     followUp(payload: MessagePayload): Promise<PlatformSentMessage>;
 }
 
+/**
+ * Represents a slash command invocation.
+ */
 export interface PlatformCommandInteraction {
+    /** Unique interaction ID. */
     readonly id: string;
+    /** Target platform. */
     readonly platform: PlatformType;
+    /** Command name triggered. */
     readonly commandName: string;
+    /** User who invoked the command. */
     readonly user: PlatformUser;
+    /** Channel where command was run. */
     readonly channel: PlatformChannel;
+    /** Arguments map passed to the command. */
     readonly options: ReadonlyMap<string, string | number | boolean>;
+    /**
+     * Defer response rendering.
+     * @param opts Option flags.
+     */
     deferReply(opts?: { ephemeral?: boolean }): Promise<void>;
+    /**
+     * Post the response message.
+     * @param payload Response parameters.
+     */
     reply(payload: MessagePayload): Promise<void>;
+    /**
+     * Edit the deferred response message.
+     * @param payload Updated details.
+     */
     editReply(payload: MessagePayload): Promise<void>;
+    /**
+     * Post a subsequent follow-up response.
+     * @param payload Subsequent response details.
+     */
     followUp(payload: MessagePayload): Promise<PlatformSentMessage>;
 }
 
+/**
+ * Represents a modal form submit event.
+ */
 export interface PlatformModalSubmitInteraction {
+    /** Unique interaction ID. */
     readonly id: string;
+    /** Target platform. */
     readonly platform: PlatformType;
+    /** Modal custom identifier. */
     readonly customId: string;
+    /** User who submitted the form. */
     readonly user: PlatformUser;
+    /** Channel where modal was submitted. */
     readonly channel: PlatformChannel;
+    /** Message ID modal was opened from, if any. */
     readonly messageId: string | null;
+    /** Submitted input values mapped by customId. */
     readonly fields: ReadonlyMap<string, string>;
+    /** Acknowledge form submission. */
     deferUpdate(): Promise<void>;
+    /**
+     * Reply to the modal submission.
+     * @param payload Reply details.
+     */
     reply(payload: MessagePayload): Promise<void>;
+    /**
+     * Update the modal source message.
+     * @param payload Updated message layout.
+     */
     update(payload: MessagePayload): Promise<void>;
+    /**
+     * Edit the reply response.
+     * @param payload Updated contents.
+     */
     editReply(payload: MessagePayload): Promise<void>;
+    /**
+     * Send subsequent updates.
+     * @param payload Follow-up contents.
+     */
     followUp(payload: MessagePayload): Promise<PlatformSentMessage>;
 }

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -229,7 +229,8 @@ export interface SelectMenuDef {
 export type ComponentDef = ButtonDef | SelectMenuDef;
 
 /**
- * A row of interactive components.
+ * A row of components. Discord allows up to 5 buttons per row,
+ * or 1 select menu per row. Telegram uses InlineKeyboard rows.
  */
 export interface ComponentRow {
     /** Ordered list of components in the row. */
@@ -376,7 +377,7 @@ export interface PlatformButtonInteraction {
      */
     followUp(payload: MessagePayload): Promise<PlatformSentMessage>;
     /**
-     * Show a popup form modal.
+     * Show a popup form modal. Must be the first response.
      * @param modal Modal specifications.
      */
     showModal?(modal: ModalDef): Promise<void>;

--- a/src/services/approvalDetector.ts
+++ b/src/services/approvalDetector.ts
@@ -14,6 +14,7 @@ export interface ApprovalInfo {
     description: string;
 }
 
+/** Config options for ApprovalDetector. */
 export interface ApprovalDetectorOptions {
     /** CDP service instance */
     cdpService: CdpService;
@@ -491,6 +492,8 @@ export class ApprovalDetector {
 
     /**
      * Execute Runtime.evaluate with contextId and return result.value.
+     * @param expression Script string.
+     * @returns Evaluation result.
      */
     private async runEvaluateScript(expression: string): Promise<any> {
         const contextId = this.cdpService.getPrimaryContextId();

--- a/src/services/artifactService.ts
+++ b/src/services/artifactService.ts
@@ -18,6 +18,7 @@ import { logger } from '../utils/logger';
 // Types
 // ---------------------------------------------------------------------------
 
+/** Valid artifact markdown document types enum. */
 export type ArtifactType =
     | 'ARTIFACT_TYPE_IMPLEMENTATION_PLAN'
     | 'ARTIFACT_TYPE_TASK'
@@ -25,14 +26,25 @@ export type ArtifactType =
     | 'ARTIFACT_TYPE_OTHER'
     | string;
 
+/**
+ * Representation of the companion `.metadata.json` properties.
+ */
 export interface ArtifactMetadata {
+    /** Artifact category type. */
     artifactType: ArtifactType;
+    /** Summary description text. */
     summary?: string;
+    /** Last updated ISO timestamp string. */
     updatedAt?: string;
+    /** Current version of the artifact. */
     version?: string;
+    /** Feedback requests modal trigger check. */
     requestFeedback?: boolean;
 }
 
+/**
+ * Combined details mapping a located artifact's metadata and absolute path.
+ */
 export interface ArtifactInfo {
     /** The conversation UUID this artifact belongs to */
     conversationId: string;
@@ -61,6 +73,11 @@ const ARTIFACT_TYPE_LABELS: Record<string, string> = {
     ARTIFACT_TYPE_OTHER: '📄 Other',
 };
 
+/**
+ * Maps artifact type identifier keys to localized/emoji labels.
+ * @param type Target artifact type.
+ * @returns Human-readable label string.
+ */
 export function artifactTypeLabel(type: ArtifactType): string {
     return ARTIFACT_TYPE_LABELS[type] ?? '📄 Artifact';
 }
@@ -72,9 +89,15 @@ export function artifactTypeLabel(type: ArtifactType): string {
 /** Common words to ignore when scoring fuzzy title matches */
 const COMMON_WORDS = new Set(['the', 'and', 'for', 'with', 'from', 'this', 'that']);
 
+/**
+ * Local file reader service scanning Antigravity workspace artifact directories.
+ */
 export class ArtifactService {
     private readonly brainBasePath: string;
 
+    /**
+     * @param brainBasePath Optional base directory override.
+     */
     constructor(brainBasePath?: string) {
         if (brainBasePath) {
             this.brainBasePath = brainBasePath;
@@ -85,12 +108,17 @@ export class ArtifactService {
         }
     }
 
+    /**
+     * Gets the active base directory path.
+     * @returns Base path string.
+     */
     public getBrainBasePath(): string {
         return this.brainBasePath;
     }
 
     /**
      * List all conversations in the brain directory (UUIDs).
+     * @returns Array of conversation UUID strings.
      */
     private listConversationIds(): string[] {
         try {
@@ -110,6 +138,9 @@ export class ArtifactService {
 
     /**
      * Read the .metadata.json file for a given artifact in a conversation.
+     * @param conversationId Conversation UUID.
+     * @param mdFilename Artifact target markdown filename.
+     * @returns Loaded metadata details, or null.
      */
     private readMetadata(
         conversationId: string,
@@ -132,6 +163,8 @@ export class ArtifactService {
     /**
      * List all artifacts in a given conversation directory.
      * An artifact must be a .md file with a companion .metadata.json.
+     * @param conversationId Conversation UUID.
+     * @returns ArtifactInfo objects list.
      */
     listArtifacts(conversationId: string): ArtifactInfo[] {
         const convDir = path.join(this.brainBasePath, conversationId);
@@ -179,6 +212,9 @@ export class ArtifactService {
      * Uses an exact match first, falling back to keyword overlap scoring.
      * If workspaceFilter is provided, restricts matching exclusively to conversations belonging to that workspace.
      * Returns the UUID or null if not found.
+     * @param title Chat session title needle.
+     * @param workspaceFilter Optional workspace name filter.
+     * @returns Matching conversation ID or null.
      */
     findConversationByTitle(title: string, workspaceFilter?: string): string | null {
         if (!title || !title.trim()) return null;
@@ -284,6 +320,8 @@ export class ArtifactService {
      * Return the conversation ID of the most recently modified conversation
      * that has at least one artifact. Falls back to the most recent conversation
      * overall if none have artifacts.
+     * @param workspaceFilter Optional workspace directory name filter.
+     * @returns Conversation UUID, or null.
      */
     getLatestConversationWithArtifacts(workspaceFilter?: string): string | null {
         const ids = this.listConversationIds();
@@ -345,6 +383,9 @@ export class ArtifactService {
 
     /**
      * Build the filesystem path for a specific artifact file.
+     * @param conversationId Conversation UUID.
+     * @param filename Target filename.
+     * @returns Absolute path to target artifact file.
      */
     getArtifactPath(conversationId: string, filename: string): string {
         const safe = path.basename(filename);
@@ -354,6 +395,9 @@ export class ArtifactService {
     /**
      * Read the markdown content of a specific artifact file.
      * Returns null if the file cannot be read.
+     * @param conversationId Conversation UUID.
+     * @param filename Target filename.
+     * @returns Content string, or null.
      */
     getArtifactContent(conversationId: string, filename: string): string | null {
         // Sanitize: prevent path traversal
@@ -376,6 +420,9 @@ export class ArtifactService {
      * Encode conversationId and filename into a single string for Discord select menu values.
      * We use a prefix 'art_', followed by a short slice of the conv ID, and the filename.
      * Added a short hash of the filename to prevent collisions on long-filename truncation.
+     * @param conversationId Conversation UUID.
+     * @param filename Target filename.
+     * @returns Encoded select value string.
      */
     static encodeSelectValue(conversationId: string, filename: string): string {
         const shortConv = conversationId.replace(/-/g, '').slice(0, 12);
@@ -394,6 +441,9 @@ export class ArtifactService {
      * Decode a select menu value back into conversationId and filename.
      * Since we only have a slice of the conversationId, we must look it up
      * in the provided list of artifacts.
+     * @param value Encoded select value string.
+     * @param artifacts Current artifacts options.
+     * @returns Decoded conversationId and filename payload, or null.
      */
     decodeSelectValue(value: string, artifacts: ArtifactInfo[]): { conversationId: string; filename: string } | null {
         if (!value.startsWith('art_')) return null;

--- a/src/services/assistantDomExtractor.ts
+++ b/src/services/assistantDomExtractor.ts
@@ -42,21 +42,39 @@ export interface AssistantDomSegmentPayload {
     segments: AssistantDomSegment[];
 }
 
+/**
+ * Classified outcome result format from raw segment arrays.
+ */
 export interface ClassifyResult {
+    /** Extracted main assistant output text converted to markdown. */
     finalOutputText: string;
+    /** Extracted intermediate logs. */
     activityLines: string[];
+    /** Extracted feedback text snippets. */
     feedback: string[];
+    /** Extracted planning cards. */
     planCards: string[];
+    /** Extracted action buttons metadata. */
     actionButtons: string[];
+    /** Extracted file changes list path/type pairs. */
     fileChanges: { path: string; type: string }[];
+    /** Extracted raw citations string array. */
     citations: string[];
+    /** Extracted raw file changes text summaries. */
     fileChangesTexts: string[];
+    /** De-duplicated and validated cited files array. */
     citedFiles: string[];
+    /** Diagnostic metrics for telemetry. */
     diagnostics: {
+        /** Extraction engine source label. */
         source: 'dom-structured' | 'legacy-fallback';
+        /** Segment counts mapped by type labels. */
         segmentCounts: Record<string, number>;
+        /** Fingerprint string checksum. */
         allFingerprints: string[];
+        /** Total segments count. */
         totalSegments: number;
+        /** Diagnostic warning messages. */
         fallbackReason?: string;
     };
 }
@@ -70,6 +88,8 @@ export interface ClassifyResult {
  * feedback, and diagnostics.
  *
  * If the payload is invalid, returns a legacy-fallback result with empty fields.
+ * @param payload Raw payload parameter.
+ * @returns Classified outcome result wrapper.
  */
 export function classifyAssistantSegments(payload: unknown): ClassifyResult {
     if (!isValidPayload(payload)) {
@@ -218,6 +238,7 @@ export function classifyAssistantSegments(payload: unknown): ClassifyResult {
  * - thinking segments (from <details> summary text)
  * - tool-call / tool-result segments (from <details> content)
  * - feedback segments (Good/Bad buttons)
+ * @returns Evaluatable IIFE script string.
  */
 export function extractAssistantSegmentsPayloadScript(): string {
     // The IIFE is a plain string evaluated in the browser context via CDP.
@@ -627,6 +648,11 @@ export function extractAssistantSegmentsPayloadScript(): string {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Validates payload structures for Cdp response DOM structures.
+ * @param value Raw payload candidate.
+ * @returns True if valid structure.
+ */
 function isValidPayload(value: unknown): value is AssistantDomSegmentPayload {
     if (!value || typeof value !== 'object') return false;
     const obj = value as Record<string, unknown>;

--- a/src/services/autoAcceptService.ts
+++ b/src/services/autoAcceptService.ts
@@ -1,25 +1,56 @@
+/**
+ * Service to manage auto-accept configuration and operations.
+ */
+
 import { t } from "../utils/i18n";
 
+/**
+ * Normalized command action options.
+ */
 export type AutoAcceptAction = 'on' | 'off' | 'status';
 
+/**
+ * Return result mapping for executed commands.
+ */
 export interface AutoAcceptCommandResult {
+    /** True if command execution was valid. */
     success: boolean;
+    /** Current status flag state. */
     enabled: boolean;
+    /** True if state transitioned. */
     changed: boolean;
+    /** User status feedback message. */
     message: string;
 }
 
+/**
+ * Service that manages auto-accept switches for prompts and dialogs.
+ */
 export class AutoAcceptService {
+    /** Current state value. */
     private enabled: boolean;
 
+    /**
+     * Initializes the AutoAcceptService.
+     * @param initialEnabled Initial state (default: false).
+     */
     constructor(initialEnabled: boolean = false) {
         this.enabled = initialEnabled;
     }
 
+    /**
+     * Checks if auto-accept is active.
+     * @returns True if enabled, false otherwise.
+     */
     isEnabled(): boolean {
         return this.enabled;
     }
 
+    /**
+     * Processes state requests to toggle or query status.
+     * @param rawAction Command arguments.
+     * @returns AutoAcceptCommandResult object.
+     */
     handle(rawAction?: string): AutoAcceptCommandResult {
         const action = this.normalizeAction(rawAction);
         if (!action) {
@@ -76,6 +107,11 @@ export class AutoAcceptService {
         };
     }
 
+    /**
+     * Normalizes a raw input command string to a recognized AutoAcceptAction.
+     * @param rawAction Raw input string.
+     * @returns Mapped action, or null if invalid.
+     */
     private normalizeAction(rawAction?: string): AutoAcceptAction | null {
         if (!rawAction || rawAction.trim().length === 0) return 'status';
 

--- a/src/services/cdpBridgeManager.ts
+++ b/src/services/cdpBridgeManager.ts
@@ -23,8 +23,11 @@ import { QuestionDetector, QuestionInfo } from './questionDetector';
 
 /** CDP connection state management */
 export interface CdpBridge {
+    /** Connected workspaces/accounts pool manager. */
     pool: CdpConnectionPool;
+    /** Quota limit tracking service. */
     quota: QuotaService;
+    /** Auto accept configuration options settings. */
     autoAccept: AutoAcceptService;
     /** Directory name of the workspace that last sent a message */
     lastActiveWorkspace: string | null;
@@ -36,8 +39,11 @@ export interface CdpBridge {
     approvalChannelBySession: Map<string, PlatformChannel>;
     /** Channel-scoped preferred Antigravity account selection. */
     selectedAccountByChannel?: Map<string, string>;
+    /** Current CDP debugging host address. */
     cdpHost: string;
+    /** Chat sessions data repository reference. */
     chatSessionRepo?: any;
+    /** Active artifact generation files manager service. */
     artifactService?: any;
 }
 
@@ -56,10 +62,21 @@ export const QUESTION_SELECT_ACTION_PREFIX = 'question_select_action';
 export const FILE_CHANGE_ACCEPT_ACTION_PREFIX = 'ide_file_accept_all';
 export const FILE_CHANGE_REJECT_ACTION_PREFIX = 'ide_file_reject_all';
 
+/**
+ * Normalizes session title strings for matching.
+ * @param title Chat session title.
+ * @returns Clean normalized title.
+ */
 function normalizeSessionTitle(title: string): string {
     return title.trim().toLowerCase();
 }
 
+/**
+ * Constructs a unique session routing cache key.
+ * @param projectName Workspace project name.
+ * @param sessionTitle Active session title.
+ * @returns Formatted routing key.
+ */
 function buildSessionRouteKey(projectName: string, sessionTitle: string): string {
     return `${projectName}::${normalizeSessionTitle(sessionTitle)}`;
 }
@@ -75,6 +92,11 @@ const GET_CURRENT_CHAT_TITLE_SCRIPT = `(() => {
     return title;
 })()`;
 
+/**
+ * Queries the browser document evaluating the active conversation title name.
+ * @param cdp Active CdpService client.
+ * @returns Resolved chat title, or null.
+ */
 export async function getCurrentChatTitle(cdp: CdpService): Promise<string | null> {
     const contexts = cdp.getContexts();
     for (const ctx of contexts) {
@@ -95,6 +117,12 @@ export async function getCurrentChatTitle(cdp: CdpService): Promise<string | nul
     return null;
 }
 
+/**
+ * Registers target channel ID for a project workspace.
+ * @param bridge Target CdpBridge.
+ * @param projectName Workspace project name.
+ * @param channel Destination channel.
+ */
 export function registerApprovalWorkspaceChannel(
     bridge: CdpBridge,
     projectName: string,
@@ -103,6 +131,13 @@ export function registerApprovalWorkspaceChannel(
     bridge.approvalChannelByWorkspace.set(projectName, channel);
 }
 
+/**
+ * Registers target channel ID for a specific session title.
+ * @param bridge Target CdpBridge.
+ * @param projectName Workspace project name.
+ * @param sessionTitle Target session title.
+ * @param channel Destination channel.
+ */
 export function registerApprovalSessionChannel(
     bridge: CdpBridge,
     projectName: string,
@@ -114,6 +149,14 @@ export function registerApprovalSessionChannel(
     bridge.approvalChannelByWorkspace.set(projectName, channel);
 }
 
+/**
+ * Resolves the destination channel for routing approvals.
+ * Priority: session-level mapping -> workspace-level default.
+ * @param bridge Active CdpBridge.
+ * @param projectName Workspace project name.
+ * @param currentChatTitle Evaluated session title.
+ * @returns Resolved destination channel, or null.
+ */
 export function resolveApprovalChannelForCurrentChat(
     bridge: CdpBridge,
     projectName: string,
@@ -129,6 +172,14 @@ export function resolveApprovalChannelForCurrentChat(
     return bridge.approvalChannelByWorkspace.get(projectName) ?? null;
 }
 
+/**
+ * Builds customId string for approval buttons.
+ * Format: prefix:projectName[:channelId]
+ * @param action Approval action type.
+ * @param projectName Workspace project name.
+ * @param channelId Target channel ID.
+ * @returns Formatted customId.
+ */
 export function buildApprovalCustomId(
     action: 'approve' | 'always_allow' | 'deny',
     projectName: string,
@@ -145,6 +196,11 @@ export function buildApprovalCustomId(
     return `${prefix}:${projectName}`;
 }
 
+/**
+ * Parses customId string back to approval action details.
+ * @param customId Raw customId.
+ * @returns Parsed action details, or null.
+ */
 export function parseApprovalCustomId(customId: string): { action: 'approve' | 'always_allow' | 'deny'; projectName: string | null; channelId: string | null } | null {
     if (customId === APPROVE_ACTION_PREFIX) {
         return { action: 'approve', projectName: null, channelId: null };
@@ -173,6 +229,13 @@ export function parseApprovalCustomId(customId: string): { action: 'approve' | '
     return null;
 }
 
+/**
+ * Builds customId string for planning actions.
+ * @param action Planning action type.
+ * @param projectName Workspace project name.
+ * @param channelId Target channel ID.
+ * @returns Formatted customId.
+ */
 export function buildPlanningCustomId(
     action: 'open' | 'proceed' | 'reject',
     projectName: string,
@@ -189,6 +252,11 @@ export function buildPlanningCustomId(
     return `${prefix}:${projectName}`;
 }
 
+/**
+ * Parses customId string back to planning action details.
+ * @param customId Raw customId.
+ * @returns Parsed planning action details, or null.
+ */
 export function parsePlanningCustomId(customId: string): { action: 'open' | 'proceed' | 'reject'; projectName: string | null; channelId: string | null } | null {
     if (customId === PLANNING_OPEN_ACTION_PREFIX) {
         return { action: 'open', projectName: null, channelId: null };
@@ -217,6 +285,13 @@ export function parsePlanningCustomId(customId: string): { action: 'open' | 'pro
     return null;
 }
 
+/**
+ * Builds customId string for error popup actions.
+ * @param action Error action type.
+ * @param projectName Workspace project name.
+ * @param channelId Target channel ID.
+ * @returns Formatted customId.
+ */
 export function buildErrorPopupCustomId(
     action: 'dismiss' | 'copy_debug' | 'retry',
     projectName: string,
@@ -233,6 +308,11 @@ export function buildErrorPopupCustomId(
     return `${prefix}:${projectName}`;
 }
 
+/**
+ * Parses customId string back to error popup action details.
+ * @param customId Raw customId.
+ * @returns Parsed action details, or null.
+ */
 export function parseErrorPopupCustomId(customId: string): { action: 'dismiss' | 'copy_debug' | 'retry'; projectName: string | null; channelId: string | null } | null {
     if (customId === ERROR_POPUP_DISMISS_ACTION_PREFIX) {
         return { action: 'dismiss', projectName: null, channelId: null };
@@ -261,6 +341,13 @@ export function parseErrorPopupCustomId(customId: string): { action: 'dismiss' |
     return null;
 }
 
+/**
+ * Builds customId string for run command permission prompts.
+ * @param action Run action choice type.
+ * @param projectName Workspace project name.
+ * @param channelId Target channel ID.
+ * @returns Formatted customId.
+ */
 export function buildRunCommandCustomId(
     action: 'run' | 'reject',
     projectName: string,
@@ -275,6 +362,11 @@ export function buildRunCommandCustomId(
     return `${prefix}:${projectName}`;
 }
 
+/**
+ * Parses customId string back to run command action details.
+ * @param customId Raw customId.
+ * @returns Parsed action details, or null.
+ */
 export function parseRunCommandCustomId(customId: string): { action: 'run' | 'reject'; projectName: string | null; channelId: string | null } | null {
     if (customId === RUN_COMMAND_RUN_ACTION_PREFIX) {
         return { action: 'run', projectName: null, channelId: null };
@@ -295,6 +387,13 @@ export function parseRunCommandCustomId(customId: string): { action: 'run' | 're
     return null;
 }
 
+/**
+ * Builds customId string for file changes accept/reject actions.
+ * @param action File action type.
+ * @param projectName Workspace project name.
+ * @param channelId Target channel ID.
+ * @returns Formatted customId.
+ */
 export function buildFileChangeCustomId(
     action: 'accept' | 'reject',
     projectName: string,
@@ -309,6 +408,11 @@ export function buildFileChangeCustomId(
     return `${prefix}:${projectName}`;
 }
 
+/**
+ * Parses customId string back to file changes action details.
+ * @param customId Raw customId.
+ * @returns Parsed action details, or null.
+ */
 export function parseFileChangeCustomId(customId: string): { action: 'accept' | 'reject'; projectName: string | null; channelId: string | null } | null {
     if (customId === FILE_CHANGE_ACCEPT_ACTION_PREFIX) {
         return { action: 'accept', projectName: null, channelId: null };
@@ -329,7 +433,14 @@ export function parseFileChangeCustomId(customId: string): { action: 'accept' | 
     return null;
 }
 
-/** Initialize the CDP bridge (lazy connection: pool creation only) */
+/**
+ * Initialize the CDP bridge (lazy connection: pool creation only).
+ * @param autoApproveDefault Auto approve edits setting.
+ * @param accountPorts Port mappings.
+ * @param accountUserDataDirs User directories mapping.
+ * @param cdpHost CDP host name.
+ * @returns Constructed CdpBridge manager.
+ */
 export function initCdpBridge(
     autoApproveDefault: boolean,
     accountPorts: Record<string, number> = {},
@@ -367,6 +478,8 @@ export function initCdpBridge(
  * Helper to get the currently active CdpService from lastActiveWorkspace.
  * Used in contexts where the workspace path is not explicitly provided,
  * such as button interactions and model/mode switching.
+ * @param bridge Active CdpBridge.
+ * @returns Connected CdpService instance, or null.
  */
 export function getCurrentCdp(bridge: CdpBridge): CdpService | null {
     if (!bridge.lastActiveWorkspace) return null;
@@ -376,6 +489,10 @@ export function getCurrentCdp(bridge: CdpBridge): CdpService | null {
 /**
  * Helper to start an approval detector for each workspace.
  * Does nothing if a detector for the same workspace is already running.
+ * @param bridge Active CdpBridge.
+ * @param cdp Active CdpService client.
+ * @param projectName Workspace project name.
+ * @param accountName Scoped account name.
  */
 export function ensureApprovalDetector(
     bridge: CdpBridge,
@@ -501,6 +618,10 @@ export function ensureApprovalDetector(
 /**
  * Helper to start a planning detector for each workspace.
  * Does nothing if a detector for the same workspace is already running.
+ * @param bridge Active CdpBridge.
+ * @param cdp Active CdpService client.
+ * @param projectName Workspace project name.
+ * @param accountName Scoped account name.
  */
 export function ensurePlanningDetector(
     bridge: CdpBridge,
@@ -585,6 +706,10 @@ export function ensurePlanningDetector(
 /**
  * Helper to start an error popup detector for each workspace.
  * Does nothing if a detector for the same workspace is already running.
+ * @param bridge Active CdpBridge.
+ * @param cdp Active CdpService client.
+ * @param projectName Workspace project name.
+ * @param accountName Scoped account name.
  */
 export function ensureErrorPopupDetector(
     bridge: CdpBridge,
@@ -668,6 +793,10 @@ export function ensureErrorPopupDetector(
  * Helper to start a run command detector for each workspace.
  * Detects "Run command?" confirmation dialogs and forwards them to Discord.
  * Does nothing if a detector for the same workspace is already running.
+ * @param bridge Active CdpBridge.
+ * @param cdp Active CdpService client.
+ * @param projectName Workspace project name.
+ * @param accountName Scoped account name.
  */
 export function ensureRunCommandDetector(
     bridge: CdpBridge,
@@ -753,6 +882,11 @@ export function ensureRunCommandDetector(
  * Detects messages typed directly in the Antigravity UI (e.g., from a PC)
  * and mirrors them to a Discord channel.
  * Does nothing if a detector for the same workspace is already running.
+ * @param bridge Active CdpBridge.
+ * @param cdp Active CdpService client.
+ * @param projectName Workspace project name.
+ * @param onUserMessage Callback function when a message is detected.
+ * @param accountName Scoped account name.
  */
 export function ensureUserMessageDetector(
     bridge: CdpBridge,
@@ -788,6 +922,13 @@ export function ensureUserMessageDetector(
     logger.debug(`[UserMessageDetector:${projectName}] Started user message detection`);
 }
 
+/**
+ * Helper starting QuestionDetector monitoring for a workspace.
+ * @param bridge Active CdpBridge.
+ * @param cdp Active CdpService client.
+ * @param projectName Workspace project name.
+ * @param accountName Scoped account name.
+ */
 export function ensureQuestionDetector(
     bridge: CdpBridge,
     cdp: CdpService,

--- a/src/services/cdpConnectionPool.ts
+++ b/src/services/cdpConnectionPool.ts
@@ -8,10 +8,20 @@ import { RunCommandDetector } from './runCommandDetector';
 import { UserMessageDetector } from './userMessageDetector';
 import { QuestionDetector } from './questionDetector';
 
+/**
+ * Connection options detailing explicit target account names.
+ */
 export interface AccountSelection {
+    /** Target account name. */
     name?: string;
 }
 
+/**
+ * Builds unique caching map key representation for project/account pairs.
+ * @param projectName Workspace project name.
+ * @param accountName Scoped account name.
+ * @returns Unique connection cache key.
+ */
 function buildConnectionKey(projectName: string, accountName: string): string {
     return `${accountName}::${projectName}`;
 }
@@ -20,6 +30,7 @@ function buildConnectionKey(projectName: string, accountName: string): string {
  * Pool that manages independent CdpService instances per workspace/account pair.
  */
 export class CdpConnectionPool {
+    /** Cache of the last successfully active workspace name. */
     public lastActiveWorkspace: string | null = null;
     private readonly connections = new Map<string, CdpService>();
     private readonly workspaceToAccount = new Map<string, string>();
@@ -32,10 +43,20 @@ export class CdpConnectionPool {
     private readonly connectingPromises = new Map<string, Promise<CdpService>>();
     private readonly cdpOptions: CdpServiceOptions;
 
+    /**
+     * @param cdpOptions Options configuration passed to constructed CdpService client instances.
+     */
     constructor(cdpOptions: CdpServiceOptions = {}) {
         this.cdpOptions = cdpOptions;
     }
 
+    /**
+     * Resolves active account name according to override rules.
+     * @param projectName Workspace project name.
+     * @param accountName Scoped account name.
+     * @param explicitSelection Explicit selection indicator.
+     * @returns Resolved account name.
+     */
     private resolveAccountName(projectName: string, accountName: string, explicitSelection: boolean = false): string {
         if (explicitSelection) {
             return accountName;
@@ -44,6 +65,12 @@ export class CdpConnectionPool {
         return this.workspaceToAccount.get(projectName) || accountName;
     }
 
+    /**
+     * Retrieves or launches connection for a given workspace/account settings key.
+     * @param workspacePath Absolute workspace project directory path.
+     * @param selection Explicit account selection parameter.
+     * @returns Connected CdpService instance.
+     */
     async getOrConnect(workspacePath: string, selection?: AccountSelection): Promise<CdpService> {
         const projectName = this.extractProjectName(workspacePath);
         const explicitSelection = typeof selection?.name === 'string';
@@ -76,6 +103,12 @@ export class CdpConnectionPool {
         }
     }
 
+    /**
+     * Checks pool for active/cached connection by project/account parameters.
+     * @param projectName Target project name.
+     * @param accountName Target account name.
+     * @returns Connected CdpService if active, or null.
+     */
     getConnected(projectName: string, accountName: string = 'default'): CdpService | null {
         const effectiveAccount = this.resolveAccountName(projectName, accountName);
         const cdp = this.connections.get(buildConnectionKey(projectName, effectiveAccount)) || null;
@@ -86,6 +119,11 @@ export class CdpConnectionPool {
         return null;
     }
 
+    /**
+     * Disconnects a workspace from the CDP pool and stops all registered active detectors.
+     * @param projectName Workspace project name.
+     * @param accountName Target account name.
+     */
     disconnectWorkspace(projectName: string, accountName: string = 'default'): void {
         const effectiveAccount = this.resolveAccountName(projectName, accountName);
         const key = buildConnectionKey(projectName, effectiveAccount);
@@ -117,6 +155,9 @@ export class CdpConnectionPool {
         this.userMessageDetectors.delete(key);
     }
 
+    /**
+     * Disconnects all active workspaces.
+     */
     disconnectAll(): void {
         for (const key of [...this.connections.keys()]) {
             const [accountName, projectName] = key.split('::');
@@ -124,6 +165,12 @@ export class CdpConnectionPool {
         }
     }
 
+    /**
+     * Registers active ApprovalDetector for the workspace.
+     * @param projectName Workspace project name.
+     * @param detector Active detector implementation.
+     * @param accountName Scoped account name.
+     */
     registerApprovalDetector(projectName: string, detector: ApprovalDetector, accountName: string = 'default'): void {
         const effectiveAccount = this.resolveAccountName(projectName, accountName);
         const key = buildConnectionKey(projectName, effectiveAccount);
@@ -131,11 +178,23 @@ export class CdpConnectionPool {
         this.approvalDetectors.set(key, detector);
     }
 
+    /**
+     * Retrieves registered ApprovalDetector by workspace key.
+     * @param projectName Workspace project name.
+     * @param accountName Scoped account name.
+     * @returns Registered ApprovalDetector instance, or undefined.
+     */
     getApprovalDetector(projectName: string, accountName: string = 'default'): ApprovalDetector | undefined {
         const effectiveAccount = this.resolveAccountName(projectName, accountName);
         return this.approvalDetectors.get(buildConnectionKey(projectName, effectiveAccount));
     }
 
+    /**
+     * Registers active ErrorPopupDetector for the workspace.
+     * @param projectName Workspace project name.
+     * @param detector Active detector implementation.
+     * @param accountName Scoped account name.
+     */
     registerErrorPopupDetector(projectName: string, detector: ErrorPopupDetector, accountName: string = 'default'): void {
         const effectiveAccount = this.resolveAccountName(projectName, accountName);
         const key = buildConnectionKey(projectName, effectiveAccount);
@@ -143,11 +202,23 @@ export class CdpConnectionPool {
         this.errorPopupDetectors.set(key, detector);
     }
 
+    /**
+     * Retrieves registered ErrorPopupDetector by workspace key.
+     * @param projectName Workspace project name.
+     * @param accountName Scoped account name.
+     * @returns Registered ErrorPopupDetector instance, or undefined.
+     */
     getErrorPopupDetector(projectName: string, accountName: string = 'default'): ErrorPopupDetector | undefined {
         const effectiveAccount = this.resolveAccountName(projectName, accountName);
         return this.errorPopupDetectors.get(buildConnectionKey(projectName, effectiveAccount));
     }
 
+    /**
+     * Registers active PlanningDetector for the workspace.
+     * @param projectName Workspace project name.
+     * @param detector Active detector implementation.
+     * @param accountName Scoped account name.
+     */
     registerPlanningDetector(projectName: string, detector: PlanningDetector, accountName: string = 'default'): void {
         const effectiveAccount = this.resolveAccountName(projectName, accountName);
         const key = buildConnectionKey(projectName, effectiveAccount);
@@ -155,11 +226,23 @@ export class CdpConnectionPool {
         this.planningDetectors.set(key, detector);
     }
 
+    /**
+     * Retrieves registered QuestionDetector by workspace key.
+     * @param projectName Workspace project name.
+     * @param accountName Scoped account name.
+     * @returns Registered QuestionDetector instance, or undefined.
+     */
     getQuestionDetector(projectName: string, accountName: string = 'default'): QuestionDetector | undefined {
         const effectiveAccount = this.resolveAccountName(projectName, accountName);
         return this.questionDetectors.get(buildConnectionKey(projectName, effectiveAccount));
     }
 
+    /**
+     * Registers active QuestionDetector for the workspace.
+     * @param projectName Workspace project name.
+     * @param detector Active detector implementation.
+     * @param accountName Scoped account name.
+     */
     registerQuestionDetector(projectName: string, detector: QuestionDetector, accountName: string = 'default'): void {
         const effectiveAccount = this.resolveAccountName(projectName, accountName);
         const key = buildConnectionKey(projectName, effectiveAccount);
@@ -167,11 +250,23 @@ export class CdpConnectionPool {
         this.questionDetectors.set(key, detector);
     }
 
+    /**
+     * Retrieves registered PlanningDetector by workspace key.
+     * @param projectName Workspace project name.
+     * @param accountName Scoped account name.
+     * @returns Registered PlanningDetector instance, or undefined.
+     */
     getPlanningDetector(projectName: string, accountName: string = 'default'): PlanningDetector | undefined {
         const effectiveAccount = this.resolveAccountName(projectName, accountName);
         return this.planningDetectors.get(buildConnectionKey(projectName, effectiveAccount));
     }
 
+    /**
+     * Registers active RunCommandDetector for the workspace.
+     * @param projectName Workspace project name.
+     * @param detector Active detector implementation.
+     * @param accountName Scoped account name.
+     */
     registerRunCommandDetector(projectName: string, detector: RunCommandDetector, accountName: string = 'default'): void {
         const effectiveAccount = this.resolveAccountName(projectName, accountName);
         const key = buildConnectionKey(projectName, effectiveAccount);
@@ -179,11 +274,23 @@ export class CdpConnectionPool {
         this.runCommandDetectors.set(key, detector);
     }
 
+    /**
+     * Retrieves registered RunCommandDetector by workspace key.
+     * @param projectName Workspace project name.
+     * @param accountName Scoped account name.
+     * @returns Registered RunCommandDetector instance, or undefined.
+     */
     getRunCommandDetector(projectName: string, accountName: string = 'default'): RunCommandDetector | undefined {
         const effectiveAccount = this.resolveAccountName(projectName, accountName);
         return this.runCommandDetectors.get(buildConnectionKey(projectName, effectiveAccount));
     }
 
+    /**
+     * Registers active UserMessageDetector for the workspace.
+     * @param projectName Workspace project name.
+     * @param detector Active detector implementation.
+     * @param accountName Scoped account name.
+     */
     registerUserMessageDetector(projectName: string, detector: UserMessageDetector, accountName: string = 'default'): void {
         const effectiveAccount = this.resolveAccountName(projectName, accountName);
         const key = buildConnectionKey(projectName, effectiveAccount);
@@ -191,21 +298,41 @@ export class CdpConnectionPool {
         this.userMessageDetectors.set(key, detector);
     }
 
+    /**
+     * Retrieves registered UserMessageDetector by workspace key.
+     * @param projectName Workspace project name.
+     * @param accountName Scoped account name.
+     * @returns Registered UserMessageDetector instance, or undefined.
+     */
     getUserMessageDetector(projectName: string, accountName: string = 'default'): UserMessageDetector | undefined {
         const effectiveAccount = this.resolveAccountName(projectName, accountName);
         return this.userMessageDetectors.get(buildConnectionKey(projectName, effectiveAccount));
     }
 
+    /**
+     * Configures/overrides the preferred account settings for the workspace.
+     * @param workspacePath Target workspace directory path.
+     * @param accountName Assigned account name.
+     */
     setPreferredAccountForWorkspace(workspacePath: string, accountName: string): void {
         const projectName = this.extractProjectName(workspacePath);
         this.workspaceToAccount.set(projectName, accountName);
     }
 
+    /**
+     * Retrieves the preferred account settings for the workspace.
+     * @param workspacePath Target workspace directory path.
+     * @returns Preferred account name, or null.
+     */
     getPreferredAccountForWorkspace(workspacePath: string): string | null {
         const projectName = this.extractProjectName(workspacePath);
         return this.workspaceToAccount.get(projectName) ?? null;
     }
 
+    /**
+     * Lists active workspace names containing online connections.
+     * @returns Array of workspace name strings.
+     */
     getActiveWorkspaceNames(): string[] {
         const active = new Set<string>();
         for (const [key, cdp] of this.connections) {
@@ -216,10 +343,22 @@ export class CdpConnectionPool {
         return [...active];
     }
 
+    /**
+     * Extracts folder project name from path string.
+     * @param workspacePath Target workspace directory path.
+     * @returns Extracted project folder name string.
+     */
     extractProjectName(workspacePath: string): string {
         return extractProjectNameFromPath(workspacePath) || workspacePath;
     }
 
+    /**
+     * Core factory connecting and caching CdpService client instances.
+     * @param workspacePath Workspace directory path.
+     * @param projectName Workspace project name.
+     * @param accountName Scoped account name.
+     * @returns Active initialized CdpService client instance.
+     */
     private async createAndConnect(
         workspacePath: string,
         projectName: string,

--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -270,7 +270,7 @@ export class CdpService extends EventEmitter {
             this.targetId = typeof target.id === 'string' ? target.id : null;
             // Extract workspace name from title (e.g., "ProjectName — Antigravity")
             if (target.title && !this.currentWorkspaceName) {
-                const titleParts = target.title.split(/\\s[—–-]\\s/);
+                const titleParts = target.title.split(/\s[—–-]\s/);
                 if (titleParts.length > 0) {
                     this.currentWorkspaceName = titleParts[0].trim();
                 }

--- a/src/services/cdpService.ts
+++ b/src/services/cdpService.ts
@@ -6,43 +6,69 @@ import { execFile, spawn } from 'child_process';
 import { getAntigravityCliPath, extractProjectNameFromPath } from '../utils/pathUtils';
 import WebSocket from 'ws';
 
+/** Configuration options for the CDP service. */
 export interface CdpServiceOptions {
+    /** Target CDP ports to scan for active sessions. */
     portsToScan?: number[];
+    /** Request timeout duration in milliseconds. */
     cdpCallTimeout?: number;
     /** Number of auto-reconnect attempts on disconnect. 0 = no reconnect. Default: 3 */
     maxReconnectAttempts?: number;
     /** Delay between reconnect attempts (ms). Default: 2000 */
     reconnectDelayMs?: number;
+    /** Target instance profile configuration name. */
     accountName?: string;
+    /** Custom ports mapped per account name. */
     accountPorts?: Record<string, number>;
+    /** Custom profile storage paths mapped per account. */
     accountUserDataDirs?: Record<string, string>;
+    /** IP address or hostname of the CDP target. */
     cdpHost?: string;
 }
 
+/** Execution context payload metadata. */
 export interface CdpContext {
+    /** Target context unique ID identifier. */
     id: number;
+    /** Display name of target execution scope. */
     name: string;
+    /** Context location URL address. */
     url: string;
 }
 
+/** Output result payload for message injection. */
 export interface InjectResult {
+    /** Flag showing if message injection succeeded. */
     ok: boolean;
+    /** Injection trigger method key string. */
     method?: string;
+    /** Context identifier number target. */
     contextId?: number;
+    /** Error message string, if applicable. */
     error?: string;
 }
 
+/** Base64 metadata payload of extracted images. */
 export interface ExtractedResponseImage {
+    /** Base filename reference label. */
     name: string;
+    /** MIME type identifier. */
     mimeType: string;
+    /** Binary raw Base64 data payload. */
     base64Data?: string;
+    /** Source resource locator address. */
     url?: string;
 }
 
+/** Runtime telemetry metadata for workspace chats. */
 export interface WorkspaceRuntimeState {
+    /** Check showing if generation is actively processing. */
     isGenerating: boolean;
+    /** Active chat window session title. */
     sessionTitle: string;
+    /** Check showing if chat session is initialized. */
     hasActiveChat: boolean;
+    /** Active primary context identifier number. */
     contextId: number | null;
 }
 
@@ -148,6 +174,9 @@ const INJECT_RETRY_BACKOFF_MS = 500;
 const MODE_READY_TIMEOUT_MS = 4000;
 const MODE_RETRY_READY_TIMEOUT_MS = 2000;
 
+/**
+ * Service for communicating with Antigravity / Claude Code via Chrome DevTools Protocol (CDP).
+ */
 export class CdpService extends EventEmitter {
     private ports: number[];
     private isConnectedFlag: boolean = false;
@@ -177,6 +206,9 @@ export class CdpService extends EventEmitter {
     private accountPorts: Record<string, number>;
     private accountUserDataDirs: Record<string, string>;
 
+    /**
+     * @param options Service configuration options.
+     */
     constructor(options: CdpServiceOptions = {}) {
         super();
         this.accountName = options.accountName || 'default';
@@ -189,6 +221,11 @@ export class CdpService extends EventEmitter {
         this.cdpHost = options.cdpHost ?? '127.0.0.1';
     }
 
+    /**
+     * Resolves the scanning ports for the given account configuration.
+     * @param accountName Target account configuration name.
+     * @returns Array of ports.
+     */
     private resolveAccountPorts(accountName: string): number[] {
         const explicitPort = this.accountPorts[accountName];
         if (Number.isInteger(explicitPort) && explicitPort > 0) {
@@ -197,6 +234,11 @@ export class CdpService extends EventEmitter {
         return [...CDP_PORTS];
     }
 
+    /**
+     * Resolves the user data directory setting for the account.
+     * @param accountName Target account configuration name.
+     * @returns User data directory string path, or null.
+     */
     private resolveConfiguredUserDataDir(accountName: string): string | null {
         const configured = this.accountUserDataDirs[accountName];
         if (typeof configured === 'string' && configured.trim().length > 0) {
@@ -205,6 +247,11 @@ export class CdpService extends EventEmitter {
         return null;
     }
 
+    /**
+     * Fetch JSON payload from a HTTP endpoint.
+     * @param url Request target URL.
+     * @returns Parsed JSON array or object.
+     */
     private async getJson(url: string): Promise<any[]> {
         return new Promise((resolve, reject) => {
             http.get(url, (res) => {
@@ -217,6 +264,10 @@ export class CdpService extends EventEmitter {
         });
     }
 
+    /**
+     * Scans ports to find the active Antigravity/Claude Code workbench page and establishes target URL.
+     * @returns WebSocket debugger URL.
+     */
     async discoverTarget(): Promise<string> {
         let allPages: any[] = [];
         for (const port of this.ports) {
@@ -281,6 +332,9 @@ export class CdpService extends EventEmitter {
         throw new Error('CDP target not found on any port.');
     }
 
+    /**
+     * Connects to the target WebSocket debugger URL.
+     */
     async connect(): Promise<void> {
         if (!this.targetUrl) {
             await this.discoverTarget();
@@ -351,6 +405,12 @@ export class CdpService extends EventEmitter {
         }
     }
 
+    /**
+     * Sends a command payload directly via WebSocket.
+     * @param method CDP domain method name.
+     * @param params Method configuration parameters.
+     * @returns Command result promise.
+     */
     async call(method: string, params: any = {}): Promise<any> {
         if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
             throw new Error('WebSocket is not connected');
@@ -391,6 +451,9 @@ export class CdpService extends EventEmitter {
         }
     }
 
+    /**
+     * Disconnects the socket and resets session state properties.
+     */
     async disconnect(): Promise<void> {
         // Stop reconnection attempts
         this.maxReconnectAttempts = 0;
@@ -406,6 +469,13 @@ export class CdpService extends EventEmitter {
         this.clearPendingCalls(new Error('disconnect() was called'));
     }
 
+    /**
+     * Evaluates a script expression across all available execution contexts.
+     * @param expression Script string.
+     * @param accept Filtering logic callback.
+     * @param options Await promise setting.
+     * @returns Evaluation result and the context identifier.
+     */
     private async evaluateAcrossContexts<T = unknown>(
         expression: string,
         accept: (value: T) => boolean,
@@ -457,6 +527,10 @@ export class CdpService extends EventEmitter {
         return this.currentWorkspaceName;
     }
 
+    /**
+     * Gets the current workspace folder path.
+     * @returns Absolute path string, or null.
+     */
     getCurrentWorkspacePath(): string | null {
         return this.currentWorkspacePath;
     }
@@ -491,6 +565,11 @@ export class CdpService extends EventEmitter {
         }
     }
 
+    /**
+     * Connects to the workbench page or launches a new workbench for the workspace path.
+     * @param workspacePath Absolute workspace path.
+     * @returns True if workspace opened successfully.
+     */
     async openWorkspace(workspacePath: string): Promise<boolean> {
         const projectName = extractProjectNameFromPath(workspacePath);
         this.currentWorkspacePath = workspacePath;
@@ -533,6 +612,12 @@ export class CdpService extends EventEmitter {
         return this.probeWorkspaceFolderPath(projectName, workspacePath);
     }
 
+    /**
+     * Scan port configurations to locate and establish connection to target workspace page.
+     * @param workspacePath Absolute filepath to workspace.
+     * @param projectName Short workspace project name keyword.
+     * @returns True if target page connected successfully.
+     */
     private async _discoverAndConnectForWorkspaceImpl(
         workspacePath: string,
         projectName: string,
@@ -1017,6 +1102,11 @@ export class CdpService extends EventEmitter {
         }
     }
 
+    /**
+     * Spawns a CLI command process and awaits its completion.
+     * @param command Base binary executable command name.
+     * @param args Array of argument strings.
+     */
     private async runCommand(command: string, args: string[]): Promise<void> {
         await new Promise<void>((resolve, reject) => {
             const child = spawn(command, args, { stdio: 'ignore' });
@@ -1035,6 +1125,11 @@ export class CdpService extends EventEmitter {
         });
     }
 
+    /**
+     * Resolves the running user-data-dir configured for a specific port.
+     * @param port Target port number.
+     * @returns User data directory string path, or null.
+     */
     private async resolveRunningUserDataDirForPort(port: number): Promise<string | null> {
         const commandLines = await this.getProcessCommandLines();
         if (commandLines.length === 0) return null;
@@ -1058,6 +1153,10 @@ export class CdpService extends EventEmitter {
         return null;
     }
 
+    /**
+     * Queries active system processes command lines.
+     * @returns Command line strings list.
+     */
     private async getProcessCommandLines(): Promise<string[]> {
         const run = (command: string, args: string[]): Promise<string> =>
             new Promise((resolve, reject) => {
@@ -1121,6 +1220,10 @@ export class CdpService extends EventEmitter {
         }
     }
 
+    /**
+     * Closes the current CDP target page and disconnects the socket.
+     * @returns True if target closed successfully.
+     */
     async closeCurrentTarget(): Promise<boolean> {
         if (!this.targetId) {
             return false;
@@ -1134,6 +1237,10 @@ export class CdpService extends EventEmitter {
         }
     }
 
+    /**
+     * Inspects the current workspace UI runtime state.
+     * @returns WorkspaceRuntimeState object.
+     */
     async inspectWorkspaceRuntimeState(): Promise<WorkspaceRuntimeState> {
         const result = await this.evaluateAcrossContexts<WorkspaceRuntimeState>(
             WORKSPACE_STATE_SCRIPT,
@@ -1151,6 +1258,11 @@ export class CdpService extends EventEmitter {
         };
     }
 
+    /**
+     * Closes current target gracefully, using shortcut key sequences.
+     * @param timeoutMs Timeout duration.
+     * @returns True if gracefully closed target.
+     */
     async closeCurrentTargetGracefully(timeoutMs = 5000): Promise<boolean> {
         if (!this.targetId) {
             return false;
@@ -1338,10 +1450,18 @@ export class CdpService extends EventEmitter {
         }
     }
 
+    /**
+     * Checks if the WebSocket is currently connected.
+     * @returns True if connected.
+     */
     isConnected(): boolean {
         return this.isConnectedFlag;
     }
 
+    /**
+     * Retrieves the current list of execution contexts.
+     * @returns Array of CdpContext.
+     */
     getContexts(): CdpContext[] {
         return [...this.contexts];
     }
@@ -1369,6 +1489,10 @@ export class CdpService extends EventEmitter {
         return false;
     }
 
+    /**
+     * Resolves the primary cascade-panel context ID, fallback extension context or first context.
+     * @returns Resolved context ID or null.
+     */
     getPrimaryContextId(): number | null {
         // Find cascade-panel context
         const context = this.contexts.find(c => c.url && c.url.includes('cascade-panel'));
@@ -1412,6 +1536,11 @@ export class CdpService extends EventEmitter {
         return { ok: false, error: 'Chat input field not found' };
     }
 
+    /**
+     * Polls until the chat input is focused and ready.
+     * @param timeoutMs Timeout duration in milliseconds.
+     * @returns Focus result payload.
+     */
     private async waitForChatInputReady(timeoutMs = CHAT_READY_TIMEOUT_MS): Promise<{ ok: boolean; contextId?: number; error?: string }> {
         const deadline = Date.now() + timeoutMs;
         let lastError = 'Chat input field not found';
@@ -1428,6 +1557,11 @@ export class CdpService extends EventEmitter {
         return { ok: false, error: lastError };
     }
 
+    /**
+     * Determines if a message injection error is transient.
+     * @param error Error description string.
+     * @returns True if error is transient.
+     */
     private isTransientInjectError(error?: string): boolean {
         const message = String(error || '');
         return [
@@ -1438,6 +1572,10 @@ export class CdpService extends EventEmitter {
         ].some((fragment) => message.includes(fragment));
     }
 
+    /**
+     * Evaluates if the mode toggle button is ready in the DOM.
+     * @returns True if toggle button exists and is visible.
+     */
     private async isModeToggleReady(): Promise<boolean> {
         const expression = '(() => {'
             + ' const uiNameMap = { fast: "Fast", plan: "Planning" };'
@@ -1466,6 +1604,11 @@ export class CdpService extends EventEmitter {
         }
     }
 
+    /**
+     * Polls until the mode toggle button is ready.
+     * @param timeoutMs Timeout duration in milliseconds.
+     * @returns True if ready.
+     */
     private async waitForModeToggleReady(timeoutMs = MODE_READY_TIMEOUT_MS): Promise<boolean> {
         const deadline = Date.now() + timeoutMs;
         while (Date.now() < deadline) {
@@ -1477,6 +1620,11 @@ export class CdpService extends EventEmitter {
         return false;
     }
 
+    /**
+     * Determines if a mode toggle error is transient.
+     * @param error Error description string.
+     * @returns True if error is transient.
+     */
     private isTransientModeError(error?: string): boolean {
         const message = String(error || '');
         return [
@@ -1486,6 +1634,12 @@ export class CdpService extends EventEmitter {
         ].some((fragment) => message.includes(fragment));
     }
 
+    /**
+     * Core message injection logic.
+     * @param text Prompt text content.
+     * @param imageFilePaths Image file paths list to attach.
+     * @returns Injection outcome details.
+     */
     private async injectMessageCore(text: string, imageFilePaths?: string[]): Promise<InjectResult> {
         // Check if chat input is already available
         let focusResult = await this.waitForChatInputReady(500);
@@ -1519,6 +1673,13 @@ export class CdpService extends EventEmitter {
         };
     }
 
+    /**
+     * Retries message injection once if the first attempt fails.
+     * @param text Prompt text content.
+     * @param firstError The error message from the first attempt.
+     * @param imageFilePaths Optional image file paths list.
+     * @returns Injection outcome details.
+     */
     private async retryInjectOnce(
         text: string,
         firstError: string,

--- a/src/services/chatSessionService.ts
+++ b/src/services/chatSessionService.ts
@@ -17,13 +17,23 @@ export interface ChatSessionInfo {
     hasActiveChat: boolean;
 }
 
+/**
+ * Representation of the chat panel session view state diagnostics.
+ */
 interface SessionViewState extends ChatSessionInfo {
+    /** If the agent side panel container element was located in DOM. */
     panelFound?: boolean;
+    /** If a loading/progress spinner is active. */
     hasLoadingIndicator: boolean;
+    /** If actual assistant text messages exist. */
     hasRenderableContent: boolean;
+    /** Scraped content text summary pieces. */
     renderablePreview?: Array<{
+        /** Text element tag name. */
         tag: string;
+        /** Text element class names. */
         className: string;
+        /** Preview snippet text. */
         text: string;
     }>;
 }
@@ -344,6 +354,8 @@ function buildActivateChatByTitleScript(title: string): string {
 /**
  * Build a script that opens Past Conversations and selects a conversation by title.
  * This path is required for older chats that are not visible in the current side panel.
+ * @param title Target conversation title.
+ * @returns Serialized evaluation script.
  */
 export function buildActivateViaPastConversationsScript(title: string): string {
     const safeTitle = JSON.stringify(title);
@@ -713,6 +725,7 @@ export class ChatSessionService {
 
     /**
      * Close the Past Conversations panel by sending Escape key events.
+     * @param cdpService Target cdp client.
      */
     private async closePanelWithEscape(cdpService: CdpService): Promise<void> {
         try {
@@ -729,6 +742,10 @@ export class ChatSessionService {
 
     /**
      * Evaluate a script on the first context that returns a truthy value.
+     * @param cdpService Active CdpService client.
+     * @param expression Script string.
+     * @param awaitPromise Await promise setting.
+     * @returns Script evaluation result value.
      */
     private async evaluateOnAnyContext(
         cdpService: CdpService,
@@ -750,6 +767,9 @@ export class ChatSessionService {
 
     /**
      * Click at coordinates via CDP Input.dispatchMouseEvent.
+     * @param cdpService Target cdp client.
+     * @param x X coordinate.
+     * @param y Y coordinate.
      */
     private async cdpMouseClick(cdpService: CdpService, x: number, y: number): Promise<void> {
         await cdpService.call('Input.dispatchMouseEvent', {
@@ -763,6 +783,10 @@ export class ChatSessionService {
         });
     }
 
+    /**
+     * Sends shortcut key events triggering new conversation in the UI.
+     * @param cdpService Target cdp client.
+     */
     private async dispatchNewConversationShortcut(cdpService: CdpService): Promise<void> {
         const modifiers = process.platform === 'darwin' ? 8 : 10;
         await cdpService.call('Input.dispatchKeyEvent', {
@@ -887,6 +911,11 @@ export class ChatSessionService {
         }
     }
 
+    /**
+     * Retrieves current session view details including message content presence.
+     * @param cdpService Target cdp client.
+     * @returns Session view state diagnostics details.
+     */
     async getCurrentSessionViewState(cdpService: CdpService): Promise<SessionViewState> {
         try {
             const contexts = cdpService.getContexts();
@@ -929,6 +958,12 @@ export class ChatSessionService {
         };
     }
 
+    /**
+     * Checks if a session view appears stuck and tries to recover if needed.
+     * @param cdpService Target cdp client.
+     * @param title Active session title.
+     * @returns Recovery result state.
+     */
     async refreshSessionViewIfStuck(
         cdpService: CdpService,
         title: string,
@@ -953,6 +988,13 @@ export class ChatSessionService {
         };
     }
 
+    /**
+     * Recovers a stuck session view by performing a bounce through an empty chat.
+     * @param cdpService Target cdp client.
+     * @param title Target conversation title.
+     * @param options Bouncing delay overrides options.
+     * @returns Recovery result state.
+     */
     async recoverSessionViewWithNewConversationBounce(
         cdpService: CdpService,
         title: string,
@@ -1013,6 +1055,10 @@ export class ChatSessionService {
     /**
      * Activate an existing chat by title.
      * Returns ok:false if the target chat cannot be located or verified.
+     * @param cdpService Target cdp client.
+     * @param title Target conversation title.
+     * @param options Warmup/retry delay overrides options.
+     * @returns Operation result.
      */
     async activateSessionByTitle(
         cdpService: CdpService,
@@ -1160,6 +1206,12 @@ export class ChatSessionService {
         };
     }
 
+    /**
+     * Tries to find and select target conversation row from the direct visible side panel list.
+     * @param cdpService Target cdp client.
+     * @param title Target conversation title.
+     * @returns Selection script result.
+     */
     private async tryActivateByDirectSidePanel(
         cdpService: CdpService,
         title: string,
@@ -1167,6 +1219,12 @@ export class ChatSessionService {
         return this.tryActivateWithScript(cdpService, buildActivateChatByTitleScript(title), false);
     }
 
+    /**
+     * Tries to find and select target conversation row by opening Past Conversations wizard.
+     * @param cdpService Target cdp client.
+     * @param title Target conversation title.
+     * @returns Selection script result.
+     */
     private async tryActivateByPastConversations(
         cdpService: CdpService,
         title: string,
@@ -1174,6 +1232,13 @@ export class ChatSessionService {
         return this.tryActivateWithScript(cdpService, buildActivateViaPastConversationsScript(title), true);
     }
 
+    /**
+     * Runs custom activation script on the active cdp contexts.
+     * @param cdpService Target cdp client.
+     * @param script Script content string.
+     * @param awaitPromise Await promise setting.
+     * @returns Operation result.
+     */
     private async tryActivateWithScript(
         cdpService: CdpService,
         script: string,
@@ -1213,6 +1278,9 @@ export class ChatSessionService {
 
     /**
      * Get the state (enabled/disabled, coordinates) of the new chat button.
+     * @param cdpService Target cdp client.
+     * @param contexts Active cdp contexts.
+     * @returns Coordinates and state details of the new chat button.
      */
     private async getNewChatButtonState(
         cdpService: CdpService,
@@ -1238,6 +1306,9 @@ export class ChatSessionService {
      * Rename the current chat in the Antigravity UI directly by updating the DOM.
      * Note: This is a cosmetic change until Antigravity persists a rename.
      * IDE syncing for chat renaming is strictly "best-effort".
+     * @param cdpService Target cdp client.
+     * @param newTitle New chat title string.
+     * @returns Success/failure indicator.
      */
     async renameCurrentChatInUI(cdpService: CdpService, newTitle: string): Promise<{ ok: boolean; error?: string }> {
         try {

--- a/src/services/errorPopupDetector.ts
+++ b/src/services/errorPopupDetector.ts
@@ -13,6 +13,7 @@ export interface ErrorPopupInfo {
     buttons: string[];
 }
 
+/** Config options for ErrorPopupDetector. */
 export interface ErrorPopupDetectorOptions {
     /** CDP service instance */
     cdpService: CdpService;
@@ -296,7 +297,12 @@ export class ErrorPopupDetector {
         }
     }
 
-    /** Execute Runtime.evaluate with contextId and return result.value. */
+    /**
+     * Execute Runtime.evaluate with contextId and return result.value.
+     * @param expression Script string.
+     * @param awaitPromise Await promise setting.
+     * @returns Evaluation result.
+     */
     private async runEvaluateScript(expression: string, awaitPromise: boolean = false): Promise<any> {
         const contextId = this.cdpService.getPrimaryContextId();
         const callParams: Record<string, unknown> = {

--- a/src/services/heartbeatService.ts
+++ b/src/services/heartbeatService.ts
@@ -99,6 +99,7 @@ export class HeartbeatService {
      */
     public stop() {
         this.generationToken++;
+        this.nextSendQueued = false;
         if (this.intervalId) {
             clearInterval(this.intervalId);
             this.intervalId = null;
@@ -112,7 +113,7 @@ export class HeartbeatService {
      * @param channelId Destination Discord channel ID.
      */
     public async updateConfig(enabled: boolean, intervalMs: number, channelId: string) {
-        this.generationToken++;
+        this.stop();
         const gen = this.generationToken;
         const config = ConfigLoader.load();
         
@@ -174,7 +175,7 @@ export class HeartbeatService {
      * Deletes the active message, updates configuration state to disabled, and stops the loop.
      */
     public async disable() {
-        this.generationToken++;
+        this.stop();
         const gen = this.generationToken;
         const config = ConfigLoader.load();
         let clearId = false;
@@ -214,7 +215,6 @@ export class HeartbeatService {
             heartbeatEnabled: false,
             heartbeatLastMessageId: clearId ? undefined : config.heartbeatLastMessageId,
         });
-        this.stop();
         logger.info('[HeartbeatService] Heartbeat disabled.');
     }
 

--- a/src/services/heartbeatService.ts
+++ b/src/services/heartbeatService.ts
@@ -1,21 +1,43 @@
+/**
+ * Service to manage and send periodic heartbeat messages to a configured Discord channel.
+ */
+
 import { Client, EmbedBuilder, TextChannel } from 'discord.js';
 import { logger } from '../utils/logger';
 import { ConfigLoader } from '../utils/configLoader';
 import { CdpBridge } from './cdpBridgeManager';
 
+/**
+ * Service that publishes status, uptime, activity, and session metrics at regular intervals.
+ */
 export class HeartbeatService {
+    /** Target Discord client interface instance. */
     private client: Client | null = null;
+    /** Target CdpBridge manager. */
     private bridge: CdpBridge | null = null;
+    /** Active polling interval timer. */
     private intervalId: NodeJS.Timeout | null = null;
     
+    /** Generation token used to ignore obsolete delayed requests. */
     private generationToken: number = 0;
+    /** Lock flag to prevent overlapping send requests. */
     private isSending: boolean = false;
     
+    /** Timestamp when the bot application started. */
     public botStartTime: number = Date.now();
+    /** Timestamp of the most recent user action. */
     public lastActivityTimestamp: number = Date.now();
 
+    /**
+     * Initializes a new HeartbeatService.
+     */
     constructor() {}
 
+    /**
+     * Binds the Discord client and CdpBridge dependencies.
+     * @param client Discord client connection.
+     * @param bridge active bridge manager.
+     */
     public init(client: Client, bridge: CdpBridge) {
         this.client = client;
         this.bridge = bridge;
@@ -23,10 +45,16 @@ export class HeartbeatService {
         this.lastActivityTimestamp = Date.now();
     }
 
+    /**
+     * Records user/client activity by resetting the activity timestamp.
+     */
     public recordActivity() {
         this.lastActivityTimestamp = Date.now();
     }
 
+    /**
+     * Starts the periodic heartbeat posting loop if enabled by configuration.
+     */
     public start() {
         this.stop();
 
@@ -64,6 +92,9 @@ export class HeartbeatService {
         }, interval);
     }
 
+    /**
+     * Stops the periodic heartbeat loop and increments the generation token.
+     */
     public stop() {
         this.generationToken++;
         if (this.intervalId) {
@@ -72,6 +103,12 @@ export class HeartbeatService {
         }
     }
 
+    /**
+     * Updates the local configuration and restarts the loop.
+     * @param enabled Enabled state flag.
+     * @param intervalMs Cycle delay in milliseconds.
+     * @param channelId Destination Discord channel ID.
+     */
     public async updateConfig(enabled: boolean, intervalMs: number, channelId: string) {
         this.generationToken++;
         const config = ConfigLoader.load();
@@ -107,6 +144,9 @@ export class HeartbeatService {
         this.start();
     }
 
+    /**
+     * Deletes the active message, updates configuration state to disabled, and stops the loop.
+     */
     public async disable() {
         this.generationToken++;
         const config = ConfigLoader.load();
@@ -131,6 +171,9 @@ export class HeartbeatService {
         logger.info('[HeartbeatService] Heartbeat disabled.');
     }
 
+    /**
+     * Formulates and posts/edits the heartbeat embed on the configured channel.
+     */
     public async sendHeartbeat() {
         if (!this.client || !this.bridge) {
             logger.warn('[HeartbeatService] Cannot send heartbeat: client or bridge not initialized.');
@@ -207,6 +250,10 @@ export class HeartbeatService {
         }
     }
 
+    /**
+     * Constructs the heartbeat visual embed with diagnostic information.
+     * @returns Mapped EmbedBuilder instance.
+     */
     private buildHeartbeatEmbed(): EmbedBuilder {
         const uptimeMs = Date.now() - this.botStartTime;
         const uptimeStr = formatDuration(uptimeMs);
@@ -234,6 +281,8 @@ export class HeartbeatService {
 /**
  * Parse a duration string like "1h", "6h", "30m", or "2d" to milliseconds.
  * Requiring a unit prevents ambiguity with bare numbers.
+ * @param str Input raw interval string.
+ * @returns Millisecond value, or null if parser pattern mismatch.
  */
 export function parseInterval(str: string): number | null {
     const match = str.trim().toLowerCase().match(/^(\d+)(ms|s|m|h|d)$/);
@@ -253,6 +302,8 @@ export function parseInterval(str: string): number | null {
 
 /**
  * Format milliseconds to a human-readable duration (e.g. "2h 15m")
+ * @param ms Time segment in milliseconds.
+ * @returns Formatted friendly duration text.
  */
 export function formatDuration(ms: number): string {
     const seconds = Math.floor((ms / 1000) % 60);
@@ -270,6 +321,8 @@ export function formatDuration(ms: number): string {
 
 /**
  * Format a past timestamp to a relative string (e.g. "5m ago")
+ * @param timestamp Historical epoch timestamp.
+ * @returns Friendly relative time suffix.
  */
 export function formatRelativeTime(timestamp: number): string {
     const diff = Date.now() - timestamp;

--- a/src/services/heartbeatService.ts
+++ b/src/services/heartbeatService.ts
@@ -22,6 +22,8 @@ export class HeartbeatService {
     private generationToken: number = 0;
     /** Lock flag to prevent overlapping send requests. */
     private isSending: boolean = false;
+    /** Tracks whether a send request is queued to run after the active send completes. */
+    private nextSendQueued: boolean = false;
     
     /** Timestamp when the bot application started. */
     public botStartTime: number = Date.now();
@@ -111,26 +113,50 @@ export class HeartbeatService {
      */
     public async updateConfig(enabled: boolean, intervalMs: number, channelId: string) {
         this.generationToken++;
+        const gen = this.generationToken;
         const config = ConfigLoader.load();
         
         // If channel changed, clear the last message ID
         if (config.heartbeatChannelId !== channelId) {
+            let clearId = false;
             if (config.heartbeatChannelId && config.heartbeatLastMessageId) {
                 try {
                     const oldChannel = await this.client?.channels.fetch(config.heartbeatChannelId);
+                    if (gen !== this.generationToken) return;
                     if (oldChannel && oldChannel.isTextBased()) {
-                        const oldMsg = await (oldChannel as TextChannel).messages.fetch(config.heartbeatLastMessageId);
-                        if (oldMsg) {
-                            await oldMsg.delete().catch(() => {});
+                        try {
+                            const oldMsg = await (oldChannel as TextChannel).messages.fetch(config.heartbeatLastMessageId);
+                            if (gen !== this.generationToken) return;
+                            if (oldMsg) {
+                                await oldMsg.delete();
+                                clearId = true;
+                            }
+                        } catch (err: any) {
+                            if (err?.code === 10008 || err?.status === 404) {
+                                clearId = true;
+                            } else {
+                                throw err;
+                            }
                         }
+                    } else {
+                        clearId = true;
                     }
-                } catch (err) {
+                } catch (err: any) {
                     logger.debug('[HeartbeatService] Failed to delete old heartbeat message from previous channel:', err);
+                    if (err?.code === 10008 || err?.code === 10003 || err?.status === 404) {
+                        clearId = true;
+                    }
                 }
+            } else {
+                clearId = true;
             }
-            ConfigLoader.save({ heartbeatLastMessageId: undefined });
+            if (gen !== this.generationToken) return;
+            if (clearId) {
+                ConfigLoader.save({ heartbeatLastMessageId: undefined });
+            }
         }
 
+        if (gen !== this.generationToken) return;
         // Save to config.json
         ConfigLoader.save({
             heartbeatEnabled: enabled,
@@ -149,23 +175,44 @@ export class HeartbeatService {
      */
     public async disable() {
         this.generationToken++;
+        const gen = this.generationToken;
         const config = ConfigLoader.load();
+        let clearId = false;
         if (config.heartbeatChannelId && config.heartbeatLastMessageId) {
             try {
                 const oldChannel = await this.client?.channels.fetch(config.heartbeatChannelId);
+                if (gen !== this.generationToken) return;
                 if (oldChannel && oldChannel.isTextBased()) {
-                    const oldMsg = await (oldChannel as TextChannel).messages.fetch(config.heartbeatLastMessageId);
-                    if (oldMsg) {
-                        await oldMsg.delete().catch(() => {});
+                    try {
+                        const oldMsg = await (oldChannel as TextChannel).messages.fetch(config.heartbeatLastMessageId);
+                        if (gen !== this.generationToken) return;
+                        if (oldMsg) {
+                            await oldMsg.delete();
+                            clearId = true;
+                        }
+                    } catch (err: any) {
+                        if (err?.code === 10008 || err?.status === 404) {
+                            clearId = true;
+                        } else {
+                            throw err;
+                        }
                     }
+                } else {
+                    clearId = true;
                 }
-            } catch (err) {
+            } catch (err: any) {
                 logger.debug('[HeartbeatService] Failed to delete heartbeat message upon disabling:', err);
+                if (err?.code === 10008 || err?.code === 10003 || err?.status === 404) {
+                    clearId = true;
+                }
             }
+        } else {
+            clearId = true;
         }
+        if (gen !== this.generationToken) return;
         ConfigLoader.save({
             heartbeatEnabled: false,
-            heartbeatLastMessageId: undefined,
+            heartbeatLastMessageId: clearId ? undefined : config.heartbeatLastMessageId,
         });
         this.stop();
         logger.info('[HeartbeatService] Heartbeat disabled.');
@@ -181,21 +228,21 @@ export class HeartbeatService {
         }
 
         if (this.isSending) {
-            logger.debug('[HeartbeatService] Heartbeat send already in flight. Skipping overlapping execution.');
+            logger.debug('[HeartbeatService] Heartbeat send already in flight. Queueing follow-up send.');
+            this.nextSendQueued = true;
             return;
         }
 
         const gen = this.generationToken;
         this.isSending = true;
 
-        const config = ConfigLoader.load();
-        const channelId = config.heartbeatChannelId;
-        if (!channelId) {
-            this.isSending = false;
-            return;
-        }
-
         try {
+            const config = ConfigLoader.load();
+            const channelId = config.heartbeatChannelId;
+            if (!channelId) {
+                return;
+            }
+
             const channel = await this.client.channels.fetch(channelId);
             if (gen !== this.generationToken) {
                 logger.debug(`[HeartbeatService] Aborting heartbeat send: stale generation (expected ${gen}, current ${this.generationToken})`);
@@ -247,6 +294,12 @@ export class HeartbeatService {
             logger.error('[HeartbeatService] Error in sendHeartbeat:', error);
         } finally {
             this.isSending = false;
+            if (this.nextSendQueued) {
+                this.nextSendQueued = false;
+                this.sendHeartbeat().catch(err => {
+                    logger.error('[HeartbeatService] Failed to send queued heartbeat:', err);
+                });
+            }
         }
     }
 

--- a/src/services/notificationSender.ts
+++ b/src/services/notificationSender.ts
@@ -38,8 +38,11 @@ const ERROR_POPUP_COPY_DEBUG_ACTION_PREFIX = 'error_popup_copy_debug_action';
 const ERROR_POPUP_RETRY_ACTION_PREFIX = 'error_popup_retry_action';
 const RUN_COMMAND_RUN_ACTION_PREFIX = 'run_command_run_action';
 const RUN_COMMAND_REJECT_ACTION_PREFIX = 'run_command_reject_action';
+/** Prefix for interactive feedback action buttons. */
 export const FEEDBACK_ACTION_PREFIX = 'feedback_action';
+/** Prefix for interactive question choice option selection. */
 export const QUESTION_SELECT_ACTION_PREFIX = 'question_select_action';
+/** Prefix for interactive question skip button action. */
 export const QUESTION_SKIP_ACTION_PREFIX = 'question_skip_action';
 
 // ---------------------------------------------------------------------------
@@ -73,12 +76,22 @@ const PHASE_COLOURS: Readonly<Record<string, number>> = {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/** Create a single button definition. */
+/**
+ * Create a single button definition.
+ * @param customId Button identifier payload.
+ * @param label Button display text.
+ * @param style Button visual styling keyword.
+ * @returns ButtonDef configuration structure.
+ */
 function button(customId: string, label: string, style: ButtonStyle): ButtonDef {
     return { type: 'button', customId, label, style };
 }
 
-/** Wrap one or more buttons into a component row. */
+/**
+ * Wrap one or more buttons into a component row.
+ * @param buttons Buttons configuration array.
+ * @returns ComponentRow wrapper.
+ */
 function buttonRow(...buttons: readonly ButtonDef[]): ComponentRow {
     return { components: buttons };
 }
@@ -86,6 +99,10 @@ function buttonRow(...buttons: readonly ButtonDef[]): ComponentRow {
 /**
  * Build a colon-separated customId following the project convention:
  *   `<prefix>:<projectName>` or `<prefix>:<projectName>:<channelId>`
+ * @param prefix Action identifier prefix.
+ * @param projectName Active workspace name.
+ * @param channelId Optional channel snowflake.
+ * @returns Serialized customId string.
  */
 function customId(prefix: string, projectName: string, channelId: string | null): string {
     if (channelId !== null && channelId.trim().length > 0) {
@@ -98,7 +115,11 @@ function customId(prefix: string, projectName: string, channelId: string | null)
 // Public API
 // ---------------------------------------------------------------------------
 
-/** Build the approval notification message. */
+/**
+ * Build the approval notification message.
+ * @param opts Parameter attributes configuration.
+ * @returns Platform-agnostic MessagePayload result.
+ */
 export function buildApprovalNotification(opts: {
     readonly title: string;
     readonly description: string;
@@ -163,7 +184,11 @@ export function buildApprovalNotification(opts: {
     return { richContent, components };
 }
 
-/** Build the planning mode notification message. */
+/**
+ * Build the planning mode notification message.
+ * @param opts Parameter attributes configuration.
+ * @returns Platform-agnostic MessagePayload result.
+ */
 export function buildPlanningNotification(opts: {
     readonly title: string;
     readonly description: string;
@@ -205,7 +230,11 @@ export function buildPlanningNotification(opts: {
     return { richContent, components };
 }
 
-/** Build the error popup notification message. */
+/**
+ * Build the error popup notification message.
+ * @param opts Parameter attributes configuration.
+ * @returns Platform-agnostic MessagePayload result.
+ */
 export function buildErrorPopupNotification(opts: {
     readonly title: string;
     readonly errorMessage: string;
@@ -240,7 +269,11 @@ export function buildErrorPopupNotification(opts: {
     return { richContent, components };
 }
 
-/** Build the run command notification message. */
+/**
+ * Build the run command notification message.
+ * @param opts Parameter attributes configuration.
+ * @returns Platform-agnostic MessagePayload result.
+ */
 export function buildRunCommandNotification(opts: {
     readonly title: string;
     readonly commandText: string;
@@ -281,7 +314,11 @@ export function buildRunCommandNotification(opts: {
     return { richContent, components };
 }
 
-/** Build an auto-approved notification (shown when auto-accept fires). */
+/**
+ * Build an auto-approved notification (shown when auto-accept fires).
+ * @param opts Parameter attributes configuration.
+ * @returns Platform-agnostic MessagePayload result.
+ */
 export function buildAutoApprovedNotification(opts: {
     readonly accepted: boolean;
     readonly projectName: string;
@@ -319,6 +356,9 @@ export function buildAutoApprovedNotification(opts: {
 /**
  * Build a "resolved" overlay from an existing notification payload.
  * Changes colour to grey, adds a Status field, and disables all buttons.
+ * @param original Original source MessagePayload context.
+ * @param statusText Resulting outcome text label.
+ * @returns Modified resolved MessagePayload.
  */
 export function buildResolvedOverlay(
     original: MessagePayload,
@@ -334,7 +374,7 @@ export function buildResolvedOverlay(
         ? original.components.map((row) => ({
               components: row.components.map((comp) =>
                   comp.type === 'button' ? { ...comp, disabled: true as const } : comp,
-              ),
+               ),
           }))
         : undefined;
 
@@ -345,7 +385,11 @@ export function buildResolvedOverlay(
     };
 }
 
-/** Build a simple status embed. */
+/**
+ * Build a simple status embed.
+ * @param opts Parameter attributes configuration.
+ * @returns Platform-agnostic MessagePayload result.
+ */
 export function buildStatusNotification(opts: {
     readonly title: string;
     readonly description: string;
@@ -371,14 +415,25 @@ export function buildStatusNotification(opts: {
     return { richContent };
 }
 
+/** Configuration interface for buildQuestionNotification. */
 export interface BuildQuestionNotificationParams {
+    /** Alert question title. */
     title: string;
+    /** Question detailed prompt. */
     description: string;
+    /** Target workspace project name. */
     projectName: string;
+    /** Target channel identifier. */
     channelId: string;
+    /** Available choices list. */
     options: { text: string; x: number; y: number }[];
 }
 
+/**
+ * Build a multiple-choice question notification message.
+ * @param params Parameter attributes configuration.
+ * @returns Platform-agnostic MessagePayload result.
+ */
 export function buildQuestionNotification(
     params: BuildQuestionNotificationParams,
 ): MessagePayload {
@@ -441,7 +496,11 @@ export function buildQuestionNotification(
     };
 }
 
-/** Build a progress / phase notification (e.g. "Thinking...", "Generating..."). */
+/**
+ * Build a progress / phase notification (e.g. "Thinking...", "Generating...").
+ * @param opts Parameter attributes configuration.
+ * @returns Platform-agnostic MessagePayload result.
+ */
 export function buildProgressNotification(opts: {
     readonly phase: string;
     readonly projectName?: string;

--- a/src/services/planningDetector.ts
+++ b/src/services/planningDetector.ts
@@ -20,6 +20,7 @@ export interface PlanningInfo {
     hasOpenButton?: boolean;
 }
 
+/** Config options for PlanningDetector. */
 export interface PlanningDetectorOptions {
     /** CDP service instance */
     cdpService: CdpService;
@@ -383,7 +384,11 @@ export class PlanningDetector {
         }
     }
 
-    /** Execute Runtime.evaluate with contextId and return result.value. */
+    /**
+     * Execute Runtime.evaluate with contextId and return result.value.
+     * @param expression Script string.
+     * @returns Evaluation result.
+     */
     private async runEvaluateScript(expression: string): Promise<any> {
         const contextId = this.cdpService.getPrimaryContextId();
         const callParams: Record<string, unknown> = {

--- a/src/services/processManager.ts
+++ b/src/services/processManager.ts
@@ -1,29 +1,60 @@
+/**
+ * Service to manage executing, queueing, and terminating child processes.
+ */
+
 import { spawn, ChildProcess } from 'child_process';
 
+/**
+ * Configuration options defining a process task definition.
+ */
 export interface TaskOptions {
+    /** Unique task ID. */
     id: string;
+    /** Shell command to invoke. */
     command: string;
+    /** Arguments array passed to command. */
     args: string[];
+    /** Cwd working directory. */
     cwd: string;
+    /** Optional standard output listener callback. */
     onStdout?: (data: string) => void;
+    /** Optional standard error listener callback. */
     onStderr?: (data: string) => void;
+    /** Optional callback triggered on process exit. */
     onClose?: (code: number) => void;
 }
 
+/**
+ * Manager that executes background child process tasks with concurrency limits.
+ */
 export class ProcessManager {
+    /** Maximum allowed concurrent tasks. */
     private maxConcurrentTasks: number;
+    /** Pending tasks queue. */
     private queue: TaskOptions[] = [];
+    /** Active processes registry index map. */
     private runningProcesses: Map<string, ChildProcess> = new Map();
 
+    /**
+     * Initializes the ProcessManager instance.
+     * @param maxConcurrentTasks Concurrent run limits (default: 1).
+     */
     constructor(maxConcurrentTasks: number = 1) {
         this.maxConcurrentTasks = maxConcurrentTasks;
     }
 
+    /**
+     * Submits a new process task to the task queue.
+     * @param options Task specifications.
+     */
     public async submitTask(options: TaskOptions): Promise<void> {
         this.queue.push(options);
         this.runNext();
     }
 
+    /**
+     * Dequeues and spawns the next pending task if concurrency limits permit.
+     */
     private runNext() {
         if (this.runningProcesses.size >= this.maxConcurrentTasks) {
             return;
@@ -60,6 +91,11 @@ export class ProcessManager {
         });
     }
 
+    /**
+     * Force kills or removes a registered task.
+     * @param taskId The target task identifier.
+     * @returns True if successfully cancelled/terminated, false otherwise.
+     */
     public stopTask(taskId: string): boolean {
         const child = this.runningProcesses.get(taskId);
         if (child) {

--- a/src/services/processManager.ts
+++ b/src/services/processManager.ts
@@ -100,7 +100,6 @@ export class ProcessManager {
         const child = this.runningProcesses.get(taskId);
         if (child) {
             child.kill();
-            this.runningProcesses.delete(taskId);
             return true;
         }
         // Check if queued

--- a/src/services/progressSender.ts
+++ b/src/services/progressSender.ts
@@ -3,6 +3,7 @@
  */
 
 import { Message } from 'discord.js';
+import { logger } from '../utils/logger';
 
 /**
  * Options configuring the ProgressSender behavior.
@@ -95,7 +96,9 @@ export class ProgressSender {
             const content = this.wrapInCodeBlock ? `\`\`\`\n${chunk}\n\`\`\`` : chunk;
             this.promiseChain = this.promiseChain
                 .then(() => this.sendContent(content))
-                .catch(() => { });
+                .catch((err) => {
+                    logger.error('[ProgressSender] Failed to send progress chunk:', err);
+                });
         }
     }
 

--- a/src/services/progressSender.ts
+++ b/src/services/progressSender.ts
@@ -38,6 +38,8 @@ export class ProgressSender {
 
     /** Handler logic for executing message deliveries. */
     private sendContent: (content: string) => Promise<unknown>;
+    /** Sequential promise chain to ensure ordered delivery of message chunks. */
+    private promiseChain: Promise<any> = Promise.resolve();
 
     /**
      * Initializes the ProgressSender instance.
@@ -91,7 +93,9 @@ export class ProgressSender {
         const chunks = this.splitByLength(payload, this.maxLength);
         for (const chunk of chunks) {
             const content = this.wrapInCodeBlock ? `\`\`\`\n${chunk}\n\`\`\`` : chunk;
-            this.sendContent(content).catch(() => { });
+            this.promiseChain = this.promiseChain
+                .then(() => this.sendContent(content))
+                .catch(() => { });
         }
     }
 

--- a/src/services/progressSender.ts
+++ b/src/services/progressSender.ts
@@ -1,23 +1,48 @@
+/**
+ * Helper utility to throttle and send progress output logs.
+ */
+
 import { Message } from 'discord.js';
 
+/**
+ * Options configuring the ProgressSender behavior.
+ */
 export interface ProgressSenderOptions {
+    /** Target Discord message to reply to. */
     message?: Message;
+    /** Direct send callback function. */
     send?: (content: string) => Promise<unknown>;
+    /** Delay in milliseconds to throttle outputs. */
     throttleMs?: number;
+    /** Maximum length of a single message block. */
     maxLength?: number;
+    /** True to wrap output text in Markdown code blocks. */
     wrapInCodeBlock?: boolean;
 }
 
+/**
+ * Class that collects streaming text/logs and sends them in throttled chunks.
+ */
 export class ProgressSender {
+    /** Delay in milliseconds to wait before posting. */
     private throttleMs: number;
+    /** Maximum length of a single message chunk. */
     private maxLength: number;
+    /** Wrap logs in backticks layout. */
     private wrapInCodeBlock: boolean;
 
+    /** Internal log string buffer. */
     private buffer: string = '';
+    /** Active timeout timer. */
     private timer: NodeJS.Timeout | null = null;
 
+    /** Handler logic for executing message deliveries. */
     private sendContent: (content: string) => Promise<unknown>;
 
+    /**
+     * Initializes the ProgressSender instance.
+     * @param options Configuration options package.
+     */
     constructor(options: ProgressSenderOptions) {
         if (!options.send && !options.message) {
             throw new Error('ProgressSender requires either message or send option');
@@ -30,6 +55,10 @@ export class ProgressSender {
         this.wrapInCodeBlock = options.wrapInCodeBlock ?? true;
     }
 
+    /**
+     * Appends text to the internal log buffer and starts the throttle timer if not active.
+     * @param text Log text segment to append.
+     */
     public append(text: string) {
         this.buffer += text;
         if (!this.timer) {
@@ -39,10 +68,16 @@ export class ProgressSender {
         }
     }
 
+    /**
+     * Instantly flushes the accumulated buffer.
+     */
     public forceEmit() {
         this.emit();
     }
 
+    /**
+     * Flushes the buffer contents to the platform client by splitting by max length.
+     */
     private emit() {
         if (this.timer) {
             clearTimeout(this.timer);
@@ -60,6 +95,12 @@ export class ProgressSender {
         }
     }
 
+    /**
+     * Splits a large text string into chunks of max size.
+     * @param text Original large string.
+     * @param maxLength Split threshold block size.
+     * @returns Array of chunk segments.
+     */
     private splitByLength(text: string, maxLength: number): string[] {
         if (text.length <= maxLength) {
             return [text];

--- a/src/services/promptDispatcher.ts
+++ b/src/services/promptDispatcher.ts
@@ -1,3 +1,7 @@
+/**
+ * Dispatcher for routing prompting requests to the IDE target.
+ */
+
 import { Message } from 'discord.js';
 
 import { ChatSessionRepository } from '../database/chatSessionRepository';
@@ -14,32 +18,61 @@ import { UserPreferenceRepository } from '../database/userPreferenceRepository';
 import { ArtifactService } from './artifactService';
 import { logger } from '../utils/logger';
 
+/**
+ * Options package configuring prompt dispatch logic.
+ */
 export interface PromptDispatchOptions {
+    /** Target chat session manager. */
     chatSessionService: ChatSessionService;
+    /** Chat session SQLite database repository. */
     chatSessionRepo: ChatSessionRepository;
+    /** Channel mapping and UI updater service. */
     channelManager: ChannelManager;
+    /** Session/channel title generator service. */
     titleGenerator: TitleGeneratorService;
+    /** Optional user preferences database repository. */
     userPrefRepo?: UserPreferenceRepository;
+    /** Text/HTML rendering extraction mode preference. */
     extractionMode?: import('../utils/config').ExtractionMode;
+    /** Optional service managing workspace artifacts. */
     artifactService?: ArtifactService;
+    /** Optional callback invoked when response generation completely finishes. */
     onFullCompletion?: () => void;
+    /** Optional callback receiving the created response monitor controller. */
     onMonitorCreated?: (monitor: { stop: () => Promise<void> }) => void;
+    /** Max time in milliseconds to wait for a reply segment. */
     responseTimeoutMs?: number;
+    /** True if we should only resume checking/polling without sending a new text prompt. */
     resumeOnly?: boolean;
 }
 
+/**
+ * Encapsulates the request details for dispatching a prompt.
+ */
 export interface PromptDispatchRequest {
+    /** The source Discord message triggering the prompt. */
     message: Message;
+    /** Raw prompt text content. */
     prompt: string;
+    /** Active CDP connection instance. */
     cdp: CdpService;
+    /** Mapped image attachments sent by the user. */
     inboundImages?: InboundImageAttachment[];
+    /** Dispatcher options. */
     options?: PromptDispatchOptions;
 }
 
+/**
+ * Dependencies injected into the PromptDispatcher class.
+ */
 export interface PromptDispatcherDeps {
+    /** Channel CDP bridge controller. */
     bridge: CdpBridge;
+    /** Core mode state controller. */
     modeService: ModeService;
+    /** Model selection configuration service. */
     modelService: ModelService;
+    /** Core implementation executor function. */
     sendPromptImpl: (
         bridge: CdpBridge,
         message: Message,
@@ -57,18 +90,37 @@ export interface PromptDispatcherDeps {
  * Unifies dependency injection on the caller side and simplifies event handlers.
  */
 export class PromptDispatcher {
+    /** Active stream response monitors mapped by Discord/Telegram channel ID. */
     private readonly activeMonitors = new Map<string, { stop: () => Promise<void> }>();
 
+    /**
+     * Initializes the PromptDispatcher.
+     * @param deps Injected services and action implementation dependencies.
+     */
     constructor(private readonly deps: PromptDispatcherDeps) { }
 
+    /**
+     * Submits a new prompt message and starts active monitoring.
+     * @param req Prompt parameters.
+     */
     async send(req: PromptDispatchRequest): Promise<void> {
         await this._dispatch(req, req.options);
     }
 
+    /**
+     * Resumes checking progress of a previously active query.
+     * @param req Prompt parameters.
+     */
     async resume(req: PromptDispatchRequest): Promise<void> {
         await this._dispatch(req, { ...req.options, resumeOnly: true } as PromptDispatchOptions);
     }
 
+    /**
+     * Internal implementation of the dispatch action sequence.
+     * Aborts prior active monitors on the channel before sending the command.
+     * @param req Prompt request.
+     * @param options Execution options.
+     */
     private async _dispatch(req: PromptDispatchRequest, options?: PromptDispatchOptions): Promise<void> {
         const channelId = req.message.channelId;
         const existing = this.activeMonitors.get(channelId);

--- a/src/services/questionDetector.ts
+++ b/src/services/questionDetector.ts
@@ -2,25 +2,47 @@ import { EventEmitter } from 'events';
 import { CdpService } from './cdpService';
 import { logger } from '../utils/logger';
 
+/**
+ * Metadata representing a single selectable option in the IDE's question prompt.
+ */
 export interface QuestionOption {
+    /** Text content label of the option. */
     text: string;
+    /** Relative X coordinate of the option. */
     x: number;
+    /** Relative Y coordinate of the option. */
     y: number;
 }
 
+/**
+ * Structured details of a detected question modal/prompt.
+ */
 export interface QuestionInfo {
+    /** Header/title text of the question modal. */
     title: string;
+    /** Description or content of the question. */
     description: string;
+    /** List of selectable options. */
     options: QuestionOption[];
 }
 
+/**
+ * Options dictionary configuration for the QuestionDetector.
+ */
 export interface QuestionDetectorOptions {
+    /** Target CDP service client interface. */
     cdpService: CdpService;
+    /** Polling interval duration in ms. */
     pollIntervalMs?: number;
+    /** Callback triggered when a question modal is detected. */
     onQuestionRequired: (info: QuestionInfo) => void;
+    /** Callback triggered when the question modal disappears/resolves. */
     onResolved?: () => void;
 }
 
+/**
+ * CDP listener detector monitoring the browser for interactive multiple-choice question elements.
+ */
 export class QuestionDetector extends EventEmitter {
     private cdp: CdpService;
     private pollIntervalMs: number;
@@ -34,6 +56,9 @@ export class QuestionDetector extends EventEmitter {
     private onResolved?: () => void;
     private projectName: string = 'unknown';
 
+    /**
+     * @param options Detector configurations.
+     */
     constructor(options: QuestionDetectorOptions) {
         super();
         this.cdp = options.cdpService;
@@ -48,14 +73,25 @@ export class QuestionDetector extends EventEmitter {
         });
     }
     
+    /**
+     * Sets the active project name tag for logging context.
+     * @param name Active workspace project name.
+     */
     setProjectName(name: string) {
         this.projectName = name;
     }
 
+    /**
+     * Retrieves whether the detector is currently polling/running.
+     * @returns True if polling active.
+     */
     get isActive() {
         return this._isStarted;
     }
 
+    /**
+     * Starts active interval polling monitoring CDP DOM targets.
+     */
     start() {
         if (this._isStarted) return;
         this._isStarted = true;
@@ -67,6 +103,9 @@ export class QuestionDetector extends EventEmitter {
         this.poll();
     }
 
+    /**
+     * Stopes active interval polling.
+     */
     stop() {
         if (!this._isStarted) return;
         this._isStarted = false;
@@ -77,6 +116,11 @@ export class QuestionDetector extends EventEmitter {
         this.logger.debug(`[QuestionDetector:${this.projectName}] Stopped polling`);
     }
 
+    /**
+     * Simulates clicking/selecting the option at the given index in the browser.
+     * @param index Zero-based option list index.
+     * @returns True if submitted successfully.
+     */
     async submitOption(index: number): Promise<boolean> {
         this.logger.debug(`[QuestionDetector:${this.projectName}] Submitting option ${index}`);
         
@@ -180,6 +224,10 @@ export class QuestionDetector extends EventEmitter {
         }
     }
 
+    /**
+     * Simulates clicking the skip button on the question modal.
+     * @returns True if skipped successfully.
+     */
     async skipQuestion(): Promise<boolean> {
         this.logger.debug(`[QuestionDetector:${this.projectName}] Skipping question`);
         
@@ -264,6 +312,9 @@ export class QuestionDetector extends EventEmitter {
         }
     }
 
+    /**
+     * Poll evaluation handler query function.
+     */
     private async poll() {
         if (!this.cdp.isConnected()) return;
 

--- a/src/services/quotaService.ts
+++ b/src/services/quotaService.ts
@@ -1,3 +1,8 @@
+/**
+ * Service to retrieve model usage quota information.
+ * Communicates with the local language server process.
+ */
+
 import { logger } from '../utils/logger';
 import { exec } from 'child_process';
 import { promisify } from 'util';
@@ -5,26 +10,51 @@ import * as https from 'https';
 
 const execAsync = promisify(exec);
 
+/**
+ * Representation of remaining quota usage fraction and reset timestamp.
+ */
 export interface QuotaInfo {
+    /** Fractional value of remaining quota (0.0 to 1.0). */
     remainingFraction: number;
+    /** Date string of when the quota resets. */
     resetTime: string;
 }
 
+/**
+ * Represents the quota configuration metadata for a specific AI model.
+ */
 export interface ModelQuota {
+    /** The display name/label of the model. */
     label: string;
+    /** The internal model key/identifier. */
     model: string;
+    /** Optional quota details. */
     quotaInfo?: QuotaInfo;
 }
 
+/**
+ * Payload structure of the user status response.
+ */
 export interface UserStatusData {
+    /** List of model quotas for the client. */
     clientModelConfigs?: ModelQuota[];
 }
 
+/**
+ * Service that connects to the local language server to check current AI usage limits.
+ */
 export class QuotaService {
+    /** Cached TCP port of the active language server. */
     private cachedPort: number | null = null;
+    /** Cached CSRF security token. */
     private cachedCsrfToken: string | null = null;
+    /** Cached PID of the language server process. */
     private cachedPid: number | null = null;
 
+    /**
+     * Resolves the current language server process PID and CSRF token.
+     * @returns Process details, or null if not found.
+     */
     private async getUnixProcessInfo(): Promise<{pid: number, csrf_token: string} | null> {
         try {
             // macOS
@@ -47,6 +77,11 @@ export class QuotaService {
         return null;
     }
 
+    /**
+     * Finds active TCP ports the specified process ID is listening on.
+     * @param pid Process ID.
+     * @returns Array of active listening ports.
+     */
     private async getListeningPorts(pid: number): Promise<number[]> {
         const ports: number[] = [];
         try {
@@ -66,6 +101,12 @@ export class QuotaService {
         return ports;
     }
 
+    /**
+     * Query the language server status HTTP RPC endpoint.
+     * @param port Target localhost TCP port.
+     * @param csrfToken CSRF token header value.
+     * @returns UserStatusData payload.
+     */
     private requestApi(port: number, csrfToken: string): Promise<UserStatusData> {
         return new Promise((resolve, reject) => {
             const data = JSON.stringify({
@@ -125,6 +166,10 @@ export class QuotaService {
         });
     }
 
+    /**
+     * Resolves process details, queries target ports, and fetches current quota usages.
+     * @returns Array of ModelQuota configurations.
+     */
     public async fetchQuota(): Promise<ModelQuota[]> {
         let processInfo = await this.getUnixProcessInfo();
         if (!processInfo) {

--- a/src/services/responseMonitor.ts
+++ b/src/services/responseMonitor.ts
@@ -480,6 +480,7 @@ export const RESPONSE_SELECTORS = {
 /** Response generation phases */
 export type ResponsePhase = 'waiting' | 'thinking' | 'generating' | 'complete' | 'timeout' | 'quotaReached' | 'disconnected';
 
+/** Configuration options passed to constructed ResponseMonitor instances */
 export interface ResponseMonitorOptions {
     /** CDP service instance */
     cdpService: CdpService;
@@ -515,7 +516,9 @@ export interface ResponseMonitorOptions {
  * Snapshot of pre-injection output and process-log state used to seed monitoring.
  */
 export interface ResponseMonitorBaselineSnapshot {
+    /** Captured response output text. */
     text: string | null;
+    /** Unique activity line keys. */
     processLogKeys: string[];
 }
 
@@ -523,8 +526,11 @@ export interface ResponseMonitorBaselineSnapshot {
  * Execution context metadata used when probing multiple CDP runtime contexts.
  */
 interface ContextProbeTarget {
+    /** Execution context ID. */
     id: number;
+    /** Custom target context name string. */
     name?: string;
+    /** Target window page url address. */
     url?: string;
 }
 
@@ -532,14 +538,20 @@ interface ContextProbeTarget {
  * Evaluation result paired with the context that produced it.
  */
 interface ContextProbeResult<T = unknown> {
+    /** Evaluation result value payload. */
     value: T;
+    /** Executed context target ID. */
     contextId: number | null;
+    /** Executed context name. */
     contextName: string | null;
+    /** Executed context URL. */
     contextUrl: string | null;
 }
 
 /**
  * Prefer the active runtime context first, then fall back to any discovered contexts.
+ * @param cdpService Active CdpService client.
+ * @returns Ordered list of execution context targets.
  */
 function getOrderedContextTargets(cdpService: CdpService): ContextProbeTarget[] {
     const primaryId = cdpService.getPrimaryContextId?.() ?? null;
@@ -570,6 +582,11 @@ function getOrderedContextTargets(cdpService: CdpService): ContextProbeTarget[] 
 
 /**
  * Evaluate an expression across known runtime contexts until one returns an acceptable value.
+ * @param cdpService Active CdpService client.
+ * @param expression Script string to evaluate.
+ * @param accept Filtering validator callback.
+ * @param options Await evaluations settings.
+ * @returns Evaluated target context result value wrapper.
  */
 async function evaluateAcrossContexts<T = unknown>(
     cdpService: CdpService,
@@ -641,6 +658,8 @@ async function evaluateAcrossContexts<T = unknown>(
 /**
  * Capture the current assistant/output DOM state before sending a new prompt.
  * This avoids races where a fast reply is mistaken for baseline text.
+ * @param cdpService Active CdpService client.
+ * @returns Baseline snapshot data wrapper.
  */
 export async function captureResponseMonitorBaseline(
     cdpService: CdpService,
@@ -730,6 +749,9 @@ export class ResponseMonitor {
     private lastActivityTime: number = 0;
     private startTime: number = 0;
 
+    /**
+     * @param options Monitor setup configuration options.
+     */
     constructor(options: ResponseMonitorOptions) {
         this.cdpService = options.cdpService;
         this.pollIntervalMs = options.pollIntervalMs ?? 2000;
@@ -747,6 +769,10 @@ export class ResponseMonitor {
         this.initialSeenProcessLogKeys = options.initialSeenProcessLogKeys;
     }
 
+    /**
+     * Retrieves the latest structured classification data snapshot.
+     * @returns Last classified result.
+     */
     public getLastClassified(): ClassifyResult | null {
         return this.lastClassified;
     }
@@ -766,7 +792,10 @@ export class ResponseMonitor {
         return this.initMonitoring(true);
     }
 
-    /** Internal initialization shared between start() and startPassive() */
+    /**
+     * Core monitoring initialization method.
+     * @param passive Passive generation detection flag.
+     */
     private async initMonitoring(passive: boolean): Promise<void> {
         if (this.isRunning) return;
         this.isRunning = true;
@@ -914,6 +943,11 @@ export class ResponseMonitor {
         }
     }
 
+    /**
+     * Updates and logs response generation phases.
+     * @param phase Active generation phase.
+     * @param text Current extracted output text candidate.
+     */
     private setPhase(phase: ResponsePhase, text: string | null): void {
         if (this.currentPhase !== phase) {
             this.currentPhase = phase;
@@ -944,6 +978,9 @@ export class ResponseMonitor {
         }
     }
 
+    /**
+     * Subscribes connection hook events from active CdpService client.
+     */
     private registerCdpConnectionListeners(): void {
         this.onCdpDisconnected = () => {
             if (!this.isRunning) return;
@@ -984,6 +1021,9 @@ export class ResponseMonitor {
         this.cdpService.on('reconnectFailed', this.onCdpReconnectFailed);
     }
 
+    /**
+     * Unsubscribes connection hook events from active CdpService client.
+     */
     private unregisterCdpConnectionListeners(): void {
         if (this.onCdpDisconnected) {
             this.cdpService.removeListener('disconnected', this.onCdpDisconnected);
@@ -999,6 +1039,9 @@ export class ResponseMonitor {
         }
     }
 
+    /**
+     * Schedules the next polling timeout interval cycle.
+     */
     private schedulePoll(): void {
         if (!this.isRunning || this.isPaused) return;
         this.pollTimer = setTimeout(async () => {
@@ -1009,6 +1052,12 @@ export class ResponseMonitor {
         }, this.pollIntervalMs);
     }
 
+    /**
+     * Helper to evaluate script expressions across active contexts.
+     * @param expression Script string.
+     * @param accept Context validation filtering check.
+     * @returns Evaluation result.
+     */
     private async evaluateAcrossContexts<T = unknown>(
         expression: string,
         accept: (value: T) => boolean,
@@ -1029,6 +1078,10 @@ export class ResponseMonitor {
         return result;
     }
 
+    /**
+     * Logs structured data extraction warnings diagnostics details.
+     * @param payload Extracted DOM payload data.
+     */
     private async logStructuredExtractionDiagnostics(payload: unknown): Promise<void> {
         try {
             const dumpResult = await this.evaluateAcrossContexts<any[] | null>(
@@ -1103,6 +1156,7 @@ export class ResponseMonitor {
 
     /**
      * Emit new process log entries, deduplicating against previously seen keys.
+     * @param entries Log entries text array.
      */
     private emitNewProcessLogs(entries: string[]): void {
         const newEntries: string[] = [];

--- a/src/services/runCommandDetector.ts
+++ b/src/services/runCommandDetector.ts
@@ -15,6 +15,7 @@ export interface RunCommandInfo {
     rejectText: string;
 }
 
+/** Config options for RunCommandDetector. */
 export interface RunCommandDetectorOptions {
     /** CDP service instance */
     cdpService: CdpService;
@@ -273,6 +274,8 @@ export class RunCommandDetector {
 
     /**
      * Execute Runtime.evaluate with contextId and return result.value.
+     * @param expression Script string.
+     * @returns Evaluation result.
      */
     private async runEvaluateScript(expression: string): Promise<any> {
         const contextId = this.cdpService.getPrimaryContextId();

--- a/src/services/scheduleService.ts
+++ b/src/services/scheduleService.ts
@@ -175,6 +175,10 @@ export class ScheduleService {
             throw new Error('Invalid backup format: root must be an array of schedule objects.');
         }
 
+        if (parsed.length > 100) {
+            throw new Error('Backup exceeds maximum limit of 100 schedules.');
+        }
+
         // Validate items
         const validated: Array<{ cronExpression: string; prompt: string; workspacePath: string; channelId?: string; enabled: boolean }> = [];
         for (const item of parsed) {
@@ -183,6 +187,18 @@ export class ScheduleService {
             }
             if (typeof item.cronExpression !== 'string' || typeof item.prompt !== 'string' || typeof item.workspacePath !== 'string') {
                 throw new Error('Invalid backup format: each schedule must contain cronExpression, prompt, and workspacePath.');
+            }
+            if (item.cronExpression.length > 100) {
+                throw new Error('cronExpression exceeds maximum length of 100 characters.');
+            }
+            if (item.prompt.length > 10000) {
+                throw new Error('prompt exceeds maximum length of 10000 characters.');
+            }
+            if (item.workspacePath.length > 1000) {
+                throw new Error('workspacePath exceeds maximum length of 1000 characters.');
+            }
+            if (item.channelId !== undefined && (typeof item.channelId !== 'string' || item.channelId.length > 100)) {
+                throw new Error('channelId must be a string and not exceed maximum length of 100 characters.');
             }
             if (!cron.validate(item.cronExpression)) {
                 throw new Error(`Invalid cron expression in backup: "${item.cronExpression}"`);

--- a/src/services/scheduleService.ts
+++ b/src/services/scheduleService.ts
@@ -159,6 +159,12 @@ export class ScheduleService {
         return JSON.stringify(portable, null, 2);
     }
 
+    /**
+     * Restore schedules from JSON content.
+     * @param jsonContent Serialized JSON backup string.
+     * @param jobCallback Trigger callback function.
+     * @returns Number of successfully restored schedules.
+     */
     public restoreSchedules(jsonContent: string, jobCallback: JobCallback): number {
         if (!jobCallback) {
             throw new Error('Job callback is not initialized.');

--- a/src/services/screenshotService.ts
+++ b/src/services/screenshotService.ts
@@ -29,6 +29,7 @@ export interface CaptureResult {
     error?: string;
 }
 
+/** Config options for ScreenshotService. */
 export interface ScreenshotServiceOptions {
     /** CDP service instance */
     cdpService: CdpService;
@@ -43,6 +44,9 @@ export interface ScreenshotServiceOptions {
 export class ScreenshotService {
     private cdpService: CdpService;
 
+    /**
+     * @param options Service configuration options.
+     */
     constructor(options: ScreenshotServiceOptions) {
         this.cdpService = options.cdpService;
     }

--- a/src/services/updateCheckService.ts
+++ b/src/services/updateCheckService.ts
@@ -10,10 +10,16 @@ export const COOLDOWN_MS = 24 * 60 * 60 * 1000; // 24 hours
 const REGISTRY_URL = 'https://registry.npmjs.org/lazy-gravity/latest';
 const REQUEST_TIMEOUT_MS = 5000;
 
+/** Cache file format for update checking telemetry. */
 interface UpdateCheckCache {
+    /** Last check timestamp in milliseconds. */
     lastCheck: number;
 }
 
+/**
+ * Gets path to the local home settings update file.
+ * @returns Absolute cache path.
+ */
 function getCachePath(): string {
     return path.join(os.homedir(), CONFIG_DIR, UPDATE_CHECK_FILE);
 }
@@ -21,6 +27,7 @@ function getCachePath(): string {
 /**
  * Determine whether enough time has elapsed since the last update check.
  * Returns true if we should query the registry.
+ * @returns True if checking cooldown duration expired.
  */
 export function shouldCheckForUpdates(): boolean {
     const cachePath = getCachePath();
@@ -36,6 +43,7 @@ export function shouldCheckForUpdates(): boolean {
 
 /**
  * Query the npm registry for the latest published version.
+ * @returns Latest package version string.
  */
 export function fetchLatestVersion(): Promise<string> {
     return new Promise((resolve, reject) => {
@@ -67,6 +75,9 @@ export function fetchLatestVersion(): Promise<string> {
     });
 }
 
+/**
+ * Writes current timestamp cache details to disk file.
+ */
 function writeCache(): void {
     const cachePath = getCachePath();
     const dir = path.dirname(cachePath);
@@ -84,6 +95,9 @@ function writeCache(): void {
 /**
  * Compare two semver strings. Returns:
  *  -1 if a < b, 0 if a === b, 1 if a > b
+ * @param a First version string.
+ * @param b Second version string.
+ * @returns Comparison integer code.
  */
 function compareSemver(a: string, b: string): number {
     const partsA = a.split('.').map(Number);
@@ -99,6 +113,7 @@ function compareSemver(a: string, b: string): number {
 /**
  * Detect whether the process is running from a global npm install
  * (as opposed to a local dev checkout via `ts-node`, `tsx`, etc.).
+ * @returns True if global environment install.
  */
 export function isGlobalInstall(): boolean {
     const execPath = process.argv[1] || '';
@@ -112,6 +127,7 @@ export function isGlobalInstall(): boolean {
  * Non-blocking update check. Call at startup (fire-and-forget).
  * Respects a 24-hour cooldown via a local cache file.
  * Skipped when running from source (dev/local checkout).
+ * @param currentVersion Current package version string.
  */
 export async function checkForUpdates(currentVersion: string): Promise<void> {
     if (!isGlobalInstall()) return;

--- a/src/services/userMessageDetector.ts
+++ b/src/services/userMessageDetector.ts
@@ -9,6 +9,7 @@ export interface UserMessageInfo {
     text: string;
 }
 
+/** Config options for UserMessageDetector. */
 export interface UserMessageDetectorOptions {
     /** CDP service instance */
     cdpService: CdpService;
@@ -67,6 +68,8 @@ const DETECT_USER_MESSAGE_SCRIPT = `(() => {
 /**
  * Normalize text for echo hash comparison.
  * Trims, collapses whitespace, and takes first 200 chars.
+ * @param text Raw input string.
+ * @returns Clean normalized string.
  */
 function normalizeForHash(text: string): string {
     return text.trim().replace(/\s+/g, ' ').slice(0, 200);
@@ -74,6 +77,8 @@ function normalizeForHash(text: string): string {
 
 /**
  * Compute a short hash for echo prevention.
+ * @param text Raw message text.
+ * @returns Shortened checksum hash.
  */
 function computeEchoHash(text: string): string {
     return createHash('sha256').update(normalizeForHash(text)).digest('hex').slice(0, 16);
@@ -101,6 +106,9 @@ export class UserMessageDetector extends EventEmitter {
     /** True during the first poll — seeds existing DOM state without firing callback */
     private isPriming: boolean = false;
 
+    /**
+     * @param options Detector configurations.
+     */
     constructor(options: UserMessageDetectorOptions) {
         super();
         this.cdpService = options.cdpService;
@@ -110,6 +118,7 @@ export class UserMessageDetector extends EventEmitter {
     /**
      * Register a message hash as an echo (sent by LazyGravity).
      * When this message is detected in the DOM, it will be skipped.
+     * @param text Sent message text.
      */
     addEchoHash(text: string): void {
         const hash = computeEchoHash(text);
@@ -120,6 +129,9 @@ export class UserMessageDetector extends EventEmitter {
         }, 60000);
     }
 
+    /**
+     * Start active polling.
+     */
     start(): void {
         if (this.isRunning) return;
         this.isRunning = true;
@@ -141,7 +153,9 @@ export class UserMessageDetector extends EventEmitter {
         }
     }
 
-    /** Returns whether monitoring is currently active. */
+    /** Returns whether monitoring is currently active.
+     * @returns True if running.
+     */
     isActive(): boolean {
         return this.isRunning;
     }

--- a/src/ui/accountUi.ts
+++ b/src/ui/accountUi.ts
@@ -1,3 +1,7 @@
+/**
+ * UI Builder for the account selection interface.
+ */
+
 import { ActionRowBuilder, EmbedBuilder, StringSelectMenuBuilder } from 'discord.js';
 
 import type { MessagePayload } from '../platform/types';
@@ -10,8 +14,15 @@ import {
     withTimestamp,
 } from '../platform/richContentBuilder';
 
+/** Custom component identifier string for the account select menu. */
 export const ACCOUNT_SELECT_ID = 'account_select';
 
+/**
+ * Builds the platform-agnostic MessagePayload for rendering the account selection interface.
+ * @param currentAccount Current active account name.
+ * @param accountNames List of all available account options.
+ * @returns Fully constructed MessagePayload.
+ */
 export function buildAccountPayload(currentAccount: string, accountNames: string[]): MessagePayload {
     const names = accountNames.length > 0 ? accountNames : ['default'];
 
@@ -54,6 +65,12 @@ export function buildAccountPayload(currentAccount: string, accountNames: string
     };
 }
 
+/**
+ * Renders and sends the account management UI to the Discord target response.
+ * @param target The target Discord response handle.
+ * @param currentAccount Active account name.
+ * @param accountNames Available accounts list.
+ */
 export async function sendAccountUI(
     target: { editReply: (opts: any) => Promise<any> },
     currentAccount: string,

--- a/src/ui/artifactsUi.ts
+++ b/src/ui/artifactsUi.ts
@@ -40,11 +40,22 @@ const MAX_SELECT_OPTIONS = 25;
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Truncates a string value if it exceeds the specified maximum length.
+ * @param str Target string.
+ * @param max Maximum length.
+ * @returns Truncated string with ellipsis.
+ */
 function truncate(str: string, max: number): string {
     if (str.length <= max) return str;
     return str.slice(0, max - 1) + '…';
 }
 
+/**
+ * Formats the select menu option description for an artifact.
+ * @param artifact Artifact metadata.
+ * @returns Description string, or undefined if empty.
+ */
 function formatOptionDescription(artifact: ArtifactInfo): string | undefined {
     const parts: string[] = [];
     parts.push(artifactTypeLabel(artifact.artifactType));
@@ -56,6 +67,11 @@ function formatOptionDescription(artifact: ArtifactInfo): string | undefined {
     return combined.length > 0 ? truncate(combined, 100) : undefined;
 }
 
+/**
+ * Formats an ISO date string into a localized friendly date representation.
+ * @param iso ISO date string.
+ * @returns Localized friendly date string.
+ */
 function formatUpdatedAt(iso?: string): string {
     if (!iso) return '';
     try {

--- a/src/ui/autoAcceptUi.ts
+++ b/src/ui/autoAcceptUi.ts
@@ -63,6 +63,11 @@ export function buildAutoAcceptPayload(enabled: boolean): MessagePayload {
     };
 }
 
+/**
+ * Sends or updates the auto-accept configuration UI.
+ * @param target The target response handler.
+ * @param autoAcceptService AutoAcceptService managing current configuration state.
+ */
 export async function sendAutoAcceptUI(
     target: { editReply: (opts: any) => Promise<any> },
     autoAcceptService: AutoAcceptService,

--- a/src/ui/modeUi.ts
+++ b/src/ui/modeUi.ts
@@ -17,7 +17,11 @@ import {
     withTimestamp,
 } from '../platform/richContentBuilder';
 
+/**
+ * Dependencies injected into Mode UI builder functions.
+ */
 export interface ModeUiDeps {
+    /** Optional getter returning the currently active CdpService connection. */
     getCurrentCdp?: () => CdpService | null;
 }
 

--- a/src/ui/modelsUi.ts
+++ b/src/ui/modelsUi.ts
@@ -11,15 +11,26 @@ import {
     withTimestamp,
 } from '../platform/richContentBuilder';
 
+/**
+ * Dependencies injected into Model UI builder functions.
+ */
 export interface ModelsUiDeps {
+    /** Getter returning the currently active CdpService connection. */
     getCurrentCdp: () => CdpService | null;
+    /** Callback for fetching quota data. */
     fetchQuota: () => Promise<any[]>;
 }
 
+/**
+ * Return type containing the structured Discord components payload for model display.
+ */
 export interface ModelsUiPayload {
+    /** Formatted embed cards. */
     embeds: EmbedBuilder[];
+    /** Formatted button action rows. */
     components: ActionRowBuilder<ButtonBuilder>[];
 }
+
 
 /**
  * Build a platform-agnostic MessagePayload for model selection UI.

--- a/src/ui/outputUi.ts
+++ b/src/ui/outputUi.ts
@@ -58,6 +58,11 @@ export function buildOutputPayload(currentFormat: OutputFormat): MessagePayload 
     };
 }
 
+/**
+ * Sends or updates the output format preference UI.
+ * @param target The target Discord response context.
+ * @param currentFormat Active OutputFormat preference.
+ */
 export async function sendOutputUI(
     target: { editReply: (opts: any) => Promise<any> },
     currentFormat: OutputFormat,

--- a/src/utils/accountUtils.ts
+++ b/src/utils/accountUtils.ts
@@ -1,16 +1,35 @@
+/**
+ * Interface representing a simple account configuration option.
+ */
 export interface AccountConfigLike {
+    /** Account name. */
     name: string;
+    /** Debugging port. */
     cdpPort: number;
 }
 
+/**
+ * Interface representing channel preferences storage lookups.
+ */
 export interface ChannelPreferenceLookup {
+    /** Retrieve active account name configuration by channel. */
     getAccountName(channelId: string): string | null;
 }
 
+/**
+ * Interface representing user preferences storage lookups.
+ */
 export interface AccountPreferenceLookup {
+    /** Retrieve active account name configuration by user. */
     getAccountName(userId: string): string | null;
 }
 
+/**
+ * Resolves a requested account name ensuring it belongs to the defined accounts configuration.
+ * @param requested Candidate name.
+ * @param accounts Active configured accounts list.
+ * @returns Sanitized verified account name.
+ */
 export function resolveValidAccountName(
     requested: string | null | undefined,
     accounts: AccountConfigLike[] | undefined,
@@ -20,11 +39,22 @@ export function resolveValidAccountName(
     return safeAccounts.some((account) => account.name === requested) ? requested : safeAccounts[0].name;
 }
 
+/**
+ * Lists the names of all configured accounts.
+ * @param accounts Configuration accounts list.
+ * @returns Array of name strings.
+ */
 export function listAccountNames(accounts: AccountConfigLike[] | undefined): string[] {
     const safeAccounts = accounts && accounts.length > 0 ? accounts : [{ name: 'default', cdpPort: 9222 }];
     return safeAccounts.map((account) => account.name);
 }
 
+/**
+ * Infers parent channel scope ID for thread subchannels.
+ * @param channelId Target channel ID.
+ * @param explicitParentChannelId Optional explicit parent channel ID.
+ * @returns Resolved parent channel ID, or null.
+ */
 export function inferParentScopeChannelId(channelId: string, explicitParentChannelId?: string | null): string | null {
     if (explicitParentChannelId && explicitParentChannelId.trim().length > 0) {
         return explicitParentChannelId.trim();
@@ -38,6 +68,12 @@ export function inferParentScopeChannelId(channelId: string, explicitParentChann
     return null;
 }
 
+/**
+ * Resolves the active account name according to context scope hierarchy.
+ * Options order: session preference -> interactive channel override -> channel pref -> parent channel overrides -> user pref.
+ * @param options Scope options dictionary.
+ * @returns Resolved account name string.
+ */
 export function resolveScopedAccountName(
     options: {
         channelId: string;

--- a/src/utils/cdpPorts.ts
+++ b/src/utils/cdpPorts.ts
@@ -1,12 +1,23 @@
 /** Default CDP port list scanned for Antigravity connections. */
 export const DEFAULT_CDP_PORTS = [9222, 9223, 9333, 9444, 9555, 9666] as const;
 
+/**
+ * Representation of account metadata containing connection settings.
+ */
 export interface AntigravityAccountConfigLike {
+    /** Account name. */
     name: string;
+    /** Debugging port. */
     cdpPort: number;
+    /** User data directory path. */
     userDataDir?: string;
 }
 
+/**
+ * Helper to parse a raw string port value into integer.
+ * @param raw Raw port string.
+ * @returns Parsed port integer, or null if invalid.
+ */
 function parsePort(raw: string | undefined): number | null {
     const port = Number(raw);
     if (!Number.isInteger(port)) return null;
@@ -14,6 +25,11 @@ function parsePort(raw: string | undefined): number | null {
     return port;
 }
 
+/**
+ * Normalizes accounts configurations list and fills default parameters if empty.
+ * @param accounts Candidate accounts.
+ * @returns Normalized list of accounts.
+ */
 export function normalizeAntigravityAccounts(
     accounts: readonly AntigravityAccountConfigLike[] | undefined,
 ): AntigravityAccountConfigLike[] {
@@ -44,6 +60,12 @@ export function normalizeAntigravityAccounts(
         : [{ name: 'default', cdpPort: DEFAULT_CDP_PORTS[0] }];
 }
 
+/**
+ * Parses raw configuration environment string into accounts arrays.
+ * Format: name:port[@userDataDir],...
+ * @param rawValue Raw environment string value.
+ * @returns Array of parsed account configurations.
+ */
 export function parseAntigravityAccounts(
     rawValue: string | undefined,
 ): AntigravityAccountConfigLike[] {
@@ -77,6 +99,11 @@ export function parseAntigravityAccounts(
     return normalizeAntigravityAccounts(parsed);
 }
 
+/**
+ * Serializes accounts list back into formatted environment string format.
+ * @param accounts Normalized accounts list.
+ * @returns Serialized format string.
+ */
 export function serializeAntigravityAccounts(
     accounts: readonly AntigravityAccountConfigLike[] | undefined,
 ): string {
@@ -92,6 +119,11 @@ export function serializeAntigravityAccounts(
         .join(',');
 }
 
+/**
+ * Extracts distinct list of ports from raw accounts value string.
+ * @param rawValue Raw value string.
+ * @returns Array of port integers.
+ */
 export function getConfiguredCdpPorts(rawValue?: string): number[] {
     if (!rawValue || rawValue.trim().length === 0) {
         return [...DEFAULT_CDP_PORTS];
@@ -107,6 +139,11 @@ export function getConfiguredCdpPorts(rawValue?: string): number[] {
     return uniquePorts.size > 0 ? [...uniquePorts] : [...DEFAULT_CDP_PORTS];
 }
 
+/**
+ * Constructs a name-to-port dictionary mapping object.
+ * @param rawValue Raw value string.
+ * @returns Name-to-port dictionary mappings.
+ */
 export function getAccountPortMap(rawValue?: string): Record<string, number> {
     return Object.fromEntries(
         parseAntigravityAccounts(rawValue).map((account) => [account.name, account.cdpPort]),

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,19 +3,30 @@ import type { LogLevel } from './logger';
 import type { PlatformType } from '../platform/types';
 import type { AntigravityAccountConfig } from './configLoader';
 
+/** Extraction mode setting option string. */
 export type ExtractionMode = 'legacy' | 'structured';
 
+/**
+ * Interface defining the application config structure.
+ */
 export interface AppConfig {
     /** Discord Bot Token (optional — only required when 'discord' is in platforms). */
     discordToken?: string;
     /** Discord Application Client ID (optional — only required when 'discord' is in platforms). */
     clientId?: string;
+    /** Discord Guild identifier. */
     guildId?: string;
+    /** Allowed Discord user IDs. */
     allowedUserIds: string[];
+    /** Base workspace path. */
     workspaceBaseDir: string;
+    /** Auto approve file edits flag. */
     autoApproveFileEdits: boolean;
+    /** Logging level setting. */
     logLevel: LogLevel;
+    /** Dom extraction mode strategy. */
     extractionMode: ExtractionMode;
+    /** Cdp target server host. */
     cdpHost: string;
     /** Named Antigravity instances mapped to CDP ports and optional user-data-dir. */
     antigravityAccounts: AntigravityAccountConfig[];
@@ -27,17 +38,23 @@ export interface AppConfig {
     platforms: PlatformType[];
     /** Response monitor inactivity timeout in ms. 0 = disabled. Default: 900000 (15 min). */
     responseTimeoutMs: number;
+    /** Heartbeat enabled flag. */
     heartbeatEnabled: boolean;
+    /** Heartbeat log interval in milliseconds. */
     heartbeatIntervalMs: number;
+    /** Heartbeat destination channel identifier. */
     heartbeatChannelId?: string;
+    /** Heartbeat last message identifier trace. */
     heartbeatLastMessageId?: string;
 }
 
+/** Response delivery mode setting type. */
 export type ResponseDeliveryMode = 'stream';
 
 /**
  * Response delivery is fixed to 'stream'.
  * Env vars are read for backward compatibility but the value is always 'stream'.
+ * @returns Fixed 'stream' ResponseDeliveryMode.
  */
 export function resolveResponseDeliveryMode(): ResponseDeliveryMode {
     return 'stream';
@@ -47,6 +64,7 @@ export function resolveResponseDeliveryMode(): ResponseDeliveryMode {
  * Load application config.
  * Delegates to ConfigLoader which resolves:
  *   env vars  >  ~/.lazy-gravity/config.json  >  .env  >  defaults
+ * @returns Configured AppConfig details.
  */
 export function loadConfig(): AppConfig {
     return ConfigLoader.load();

--- a/src/utils/configLoader.ts
+++ b/src/utils/configLoader.ts
@@ -23,29 +23,53 @@ const DEFAULT_DB_NAME = 'antigravity.db';
  * Every field is optional — missing keys fall through to env / defaults.
  */
 export interface PersistedConfig {
+    /** Bot token credential. */
     discordToken?: string;
+    /** Client application ID. */
     clientId?: string;
+    /** Discord guild/server ID. */
     guildId?: string;
+    /** Allowed Discord user IDs list. */
     allowedUserIds?: string[];
+    /** Default base workspace directory path. */
     workspaceBaseDir?: string;
+    /** Auto approve file edits toggle flag. */
     autoApproveFileEdits?: boolean;
+    /** Log severity level limit. */
     logLevel?: LogLevel;
+    /** Output extraction mode. */
     extractionMode?: 'legacy' | 'structured';
+    /** Telegram token credential. */
     telegramToken?: string;
+    /** Allowed Telegram user IDs list. */
     telegramAllowedUserIds?: string[];
+    /** Platforms enabled list. */
     platforms?: PlatformType[];
+    /** Response monitor timeout in ms. */
     responseTimeoutMs?: number;
+    /** Serialized or object config accounts array. */
     antigravityAccounts?: string | AntigravityAccountConfig[];
+    /** CDP target hostname. */
     cdpHost?: string;
+    /** Heartbeat notification enabled state. */
     heartbeatEnabled?: boolean;
+    /** Heartbeat notification frequency interval in ms. */
     heartbeatIntervalMs?: number;
+    /** Heartbeat notification destination channel. */
     heartbeatChannelId?: string;
+    /** Last heartbeat notification message ID. */
     heartbeatLastMessageId?: string;
 }
 
+/**
+ * Config item representation for accounts.
+ */
 export interface AntigravityAccountConfig {
+    /** Account name. */
     name: string;
+    /** CDP port identifier. */
     cdpPort: number;
+    /** Custom user data directory. */
     userDataDir?: string;
 }
 
@@ -53,25 +77,45 @@ export interface AntigravityAccountConfig {
 // Pure helpers (no side-effects)
 // ---------------------------------------------------------------------------
 
+/**
+ * Gets the home config directory path.
+ * @returns Absolute path string.
+ */
 function getConfigDir(): string {
     return path.join(os.homedir(), CONFIG_DIR_NAME);
 }
 
+/**
+ * Gets the config.json filepath.
+ * @returns Absolute filepath string.
+ */
 function getConfigFilePath(): string {
     return path.join(getConfigDir(), CONFIG_FILE_NAME);
 }
 
+/**
+ * Gets the default SQLite database path location.
+ * @returns Database filepath string.
+ */
 function getDefaultDbPath(): string {
     return path.join(getConfigDir(), DEFAULT_DB_NAME);
 }
 
-/** Expand leading `~` or `~/` to the user's home directory. */
+/** Expand leading `~` or `~/` to the user's home directory.
+ * @param raw Input path string.
+ * @returns Expanded absolute path string.
+ */
 function expandTilde(raw: string): string {
     if (raw === '~') return os.homedir();
     if (raw.startsWith('~/')) return path.join(os.homedir(), raw.slice(2));
     return raw;
 }
 
+/**
+ * Reads config.json contents safely.
+ * @param filePath Config json file location.
+ * @returns Read PersistedConfig options object.
+ */
 function readPersistedConfig(filePath: string): PersistedConfig {
     if (!fs.existsSync(filePath)) return {};
     const raw = fs.readFileSync(filePath, 'utf-8');
@@ -81,6 +125,8 @@ function readPersistedConfig(filePath: string): PersistedConfig {
 /**
  * Merge layers with priority: env vars > persisted config > defaults.
  * Returns a fresh AppConfig object (immutable pattern).
+ * @param persisted Parsed config options from disk.
+ * @returns Constructed AppConfig container.
  */
 function mergeConfig(persisted: PersistedConfig): AppConfig {
     // Resolve platforms FIRST so we only validate credentials for enabled platforms
@@ -193,6 +239,11 @@ function mergeConfig(persisted: PersistedConfig): AppConfig {
     };
 }
 
+/**
+ * Resolves allowed Discord user IDs list.
+ * @param persisted Persisted configuration values.
+ * @returns Array of user ID strings.
+ */
 function resolveAllowedUserIds(persisted: PersistedConfig): string[] {
     const envValue = process.env.ALLOWED_USER_IDS;
     if (envValue) {
@@ -209,6 +260,12 @@ function resolveAllowedUserIds(persisted: PersistedConfig): string[] {
 
 const VALID_LOG_LEVELS: readonly LogLevel[] = ['debug', 'info', 'warn', 'error', 'none'];
 
+/**
+ * Resolves active LogLevel settings parameter.
+ * @param envValue Environment string value.
+ * @param persistedValue Configured persisted log level.
+ * @returns Active LogLevel string.
+ */
 function resolveLogLevel(
     envValue: string | undefined,
     persistedValue: LogLevel | undefined,
@@ -220,6 +277,12 @@ function resolveLogLevel(
     return 'info';
 }
 
+/**
+ * Resolves output parsing/extraction mode parameters.
+ * @param envValue Environment string value.
+ * @param persistedValue Configured persisted extraction mode.
+ * @returns Active ExtractionMode string.
+ */
 function resolveExtractionMode(
     envValue: string | undefined,
     persistedValue: 'legacy' | 'structured' | undefined,
@@ -229,6 +292,11 @@ function resolveExtractionMode(
     return 'structured';
 }
 
+/**
+ * Resolves allowed Telegram operator user IDs list.
+ * @param persisted Persisted configuration values.
+ * @returns Array of user ID strings or undefined.
+ */
 function resolveTelegramAllowedUserIds(persisted: PersistedConfig): string[] | undefined {
     const envValue = process.env.TELEGRAM_ALLOWED_USER_IDS;
     if (envValue) {
@@ -243,6 +311,12 @@ function resolveTelegramAllowedUserIds(persisted: PersistedConfig): string[] | u
     return undefined;
 }
 
+/**
+ * Resolves configured accounts connections metadata configurations.
+ * @param envValue Environment string value.
+ * @param persistedValue Configured persisted accounts value.
+ * @returns Normalized accounts configurations list.
+ */
 function resolveAntigravityAccounts(
     envValue: string | undefined,
     persistedValue: string | AntigravityAccountConfig[] | undefined,
@@ -262,6 +336,12 @@ function resolveAntigravityAccounts(
 
 const VALID_PLATFORMS: readonly PlatformType[] = ['discord', 'telegram'];
 
+/**
+ * Resolves active platform adapters configuration list.
+ * @param envValue Environment platforms configuration string.
+ * @param persistedValue Persisted configurations enabled platforms.
+ * @returns Array of enabled platform types.
+ */
 function resolvePlatforms(
     envValue: string | undefined,
     persistedValue: PlatformType[] | undefined,
@@ -282,6 +362,13 @@ function resolvePlatforms(
     return ['discord'];
 }
 
+/**
+ * Resolves a simple boolean toggle flag.
+ * @param envValue Environment toggle string.
+ * @param persistedValue Persisted boolean parameter.
+ * @param defaultValue Default fallback boolean state.
+ * @returns Resolved boolean parameter state.
+ */
 function resolveBoolean(
     envValue: string | undefined,
     persistedValue: boolean | undefined,
@@ -295,6 +382,10 @@ function resolveBoolean(
 /**
  * Resolve a non-negative integer value from env var > persisted config > default.
  * Returns the default if the env/persisted value is not a valid non-negative integer.
+ * @param envValue Environment string integer.
+ * @param persistedValue Persisted integer.
+ * @param defaultValue Default fallback integer value.
+ * @returns Resolved integer configuration value.
  */
 function resolvePositiveInt(
     envValue: string | undefined,
@@ -313,6 +404,7 @@ function resolvePositiveInt(
 // Public API (ConfigLoader namespace)
 // ---------------------------------------------------------------------------
 
+/** Public ConfigLoader namespace containing load, read, and save configurations scripts. */
 export const ConfigLoader = {
     /** Return the config directory path (~/.lazy-gravity/). */
     getConfigDir,

--- a/src/utils/configLoader.ts
+++ b/src/utils/configLoader.ts
@@ -45,7 +45,7 @@ export interface PersistedConfig {
     telegramAllowedUserIds?: string[];
     /** Platforms enabled list. */
     platforms?: PlatformType[];
-    /** Response monitor timeout in ms. */
+    /** Response monitor inactivity timeout in ms. 0 = disabled. Default: 900000 (15 min). */
     responseTimeoutMs?: number;
     /** Serialized or object config accounts array. */
     antigravityAccounts?: string | AntigravityAccountConfig[];

--- a/src/utils/consecutiveEmptyPollGate.ts
+++ b/src/utils/consecutiveEmptyPollGate.ts
@@ -1,17 +1,33 @@
+/**
+ * Helper class to gate state transitions based on consecutive empty polls.
+ */
 export class ConsecutiveEmptyPollGate {
     private count: number = 0;
     
+    /**
+     * @param requiredEmptyPolls Number of empty polls required before gating.
+     */
     constructor(private readonly requiredEmptyPolls: number = 3) {}
     
+    /**
+     * Resets the empty poll count upon successful detection.
+     */
     recordDetection(): void {
         this.count = 0;
     }
     
+    /**
+     * Records a poll event where no changes were found.
+     * @returns True if the consecutive empty poll threshold has been met/exceeded.
+     */
     recordEmptyPoll(): boolean {
         this.count++;
         return this.count >= this.requiredEmptyPolls;
     }
     
+    /**
+     * Resets the poll counter back to zero.
+     */
     reset(): void {
         this.count = 0;
     }

--- a/src/utils/fileOpenCache.ts
+++ b/src/utils/fileOpenCache.ts
@@ -6,11 +6,19 @@ class BoundedCache<K, V> {
     private max_size: number;
     private map: Map<K, V>;
 
+    /**
+     * @param max_size Maximum size of the cache.
+     */
     constructor(max_size = 1000) {
         this.max_size = max_size;
         this.map = new Map<K, V>();
     }
 
+    /**
+     * Set a key-value pair in the cache, evicting the oldest entry if size limit is exceeded.
+     * @param key Entry key.
+     * @param value Entry value.
+     */
     set(key: K, value: V) {
         if (this.map.size >= this.max_size) {
             // Remove the oldest entry (first item in the map's insertion order)
@@ -22,9 +30,15 @@ class BoundedCache<K, V> {
         this.map.set(key, value);
     }
 
+    /**
+     * Get a value by key.
+     * @param key Target key.
+     * @returns Value if found, or undefined.
+     */
     get(key: K): V | undefined {
         return this.map.get(key);
     }
 }
 
+/** BoundedCache instance for file opening mappings */
 export const fileOpenCache = new BoundedCache<string, string>(1000);

--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -7,11 +7,18 @@ export type Language = 'en' | 'ja';
 let currentLanguage: Language = 'en';
 let translations: Record<string, Record<string, string>> = {};
 
+/**
+ * Initializes i18n configurations loading local translations directories.
+ * @param lang Target Language code.
+ */
 export function initI18n(lang: Language = 'en') {
     currentLanguage = lang;
     loadTranslations();
 }
 
+/**
+ * Internal sync file loader reading locales translation json files.
+ */
 function loadTranslations() {
     try {
         const enPath = path.join(__dirname, '../../locales/en.json');
@@ -33,6 +40,12 @@ function loadTranslations() {
     }
 }
 
+/**
+ * Translates a key string with optional template variable interpolations.
+ * @param key Key name string.
+ * @param variables Optional interpolation variables dictionary.
+ * @returns Translated text string.
+ */
 export function t(key: string, variables?: Record<string, any>): string {
     const langDict = translations[currentLanguage] || translations['en'];
     let text = langDict?.[key] || translations['en']?.[key] || key;

--- a/src/utils/imageHandler.ts
+++ b/src/utils/imageHandler.ts
@@ -10,18 +10,36 @@ const MAX_INBOUND_IMAGE_ATTACHMENTS = 4;
 const IMAGE_EXT_PATTERN = /\.(png|jpe?g|webp|gif|bmp)$/i;
 const TEMP_IMAGE_DIR = path.join(os.tmpdir(), 'lazy-gravity-images');
 
+/**
+ * Representation of downloaded inbound attachment metadata.
+ */
 export interface InboundImageAttachment {
+    /** Temporary local disk path. */
     localPath: string;
+    /** Original URL location. */
     url: string;
+    /** File base name. */
     name: string;
+    /** Content MIME type. */
     mimeType: string;
 }
 
+/**
+ * Validates if the content metadata corresponds to images.
+ * @param contentType HTTP content-type header.
+ * @param fileName Candidate filename.
+ * @returns True if validated as image.
+ */
 export function isImageAttachment(contentType: string | null | undefined, fileName: string | null | undefined): boolean {
     if ((contentType || '').toLowerCase().startsWith('image/')) return true;
     return IMAGE_EXT_PATTERN.test(fileName || '');
 }
 
+/**
+ * Maps a MIME type value to its canonical file extension suffix.
+ * @param mimeType MIME type string.
+ * @returns Extension suffix.
+ */
 export function mimeTypeToExtension(mimeType: string): string {
     const normalized = (mimeType || '').toLowerCase();
     if (normalized.includes('jpeg') || normalized.includes('jpg')) return 'jpg';
@@ -31,11 +49,22 @@ export function mimeTypeToExtension(mimeType: string): string {
     return 'png';
 }
 
+/**
+ * Sanitizes a filename string to make it safe for disk/URL usage.
+ * @param fileName Original filename candidate.
+ * @returns Sanitized safe filename string.
+ */
 export function sanitizeFileName(fileName: string): string {
     const sanitized = fileName.replace(/[^a-zA-Z0-9._-]/g, '-').replace(/-+/g, '-').replace(/^-+|-+$/g, '');
     return sanitized || `image-${Date.now()}.png`;
 }
 
+/**
+ * Extends the user prompt with descriptions and URLs of attached images.
+ * @param prompt User prompt text.
+ * @param attachments Downloaded image attachments.
+ * @returns Extended prompt text.
+ */
 export function buildPromptWithAttachmentUrls(prompt: string, attachments: InboundImageAttachment[]): string {
     const base = prompt.trim() || 'Please review the attached images and respond accordingly.';
     if (attachments.length === 0) return base;
@@ -47,6 +76,11 @@ export function buildPromptWithAttachmentUrls(prompt: string, attachments: Inbou
     return `${base}\n\n[Discord Attached Images]\n${lines.join('\n\n')}\n\nPlease refer to the attached images above in your response.`;
 }
 
+/**
+ * Downloader utility downloading message attachments locally.
+ * @param message Discord message payload.
+ * @returns Array of downloaded attachment metadata.
+ */
 export async function downloadInboundImageAttachments(message: Message): Promise<InboundImageAttachment[]> {
     const allAttachments = Array.from(message.attachments.values());
     const imageAttachments = allAttachments
@@ -96,12 +130,22 @@ export async function downloadInboundImageAttachments(message: Message): Promise
     return downloaded;
 }
 
+/**
+ * Cleans up temporary downloaded image files on disk.
+ * @param attachments Downloaded image list.
+ */
 export async function cleanupInboundImageAttachments(attachments: InboundImageAttachment[]): Promise<void> {
     for (const image of attachments) {
         await fs.unlink(image.localPath).catch(() => { });
     }
 }
 
+/**
+ * Formats a CDP image payload into a Discord AttachmentBuilder helper.
+ * @param image Captured/Extracted image info.
+ * @param index Sequence index of the image.
+ * @returns Discord AttachmentBuilder helper, or null if failed.
+ */
 export async function toDiscordAttachment(image: ExtractedResponseImage, index: number): Promise<AttachmentBuilder | null> {
     let buffer: Buffer | null = null;
     let mimeType = image.mimeType || 'image/png';

--- a/src/utils/logBuffer.ts
+++ b/src/utils/logBuffer.ts
@@ -1,8 +1,14 @@
 import type { LogLevel } from './logger';
 
+/**
+ * Log entry payload structure stored in the memory buffer.
+ */
 export interface LogEntry {
+    /** Log timestamp in ISO format. */
     timestamp: string;
+    /** Message severity level. */
     level: LogLevel;
+    /** Text content message. */
     message: string;
 }
 
@@ -11,15 +17,28 @@ const MAX_ENTRIES = 200;
 // Strip ANSI escape codes for clean buffer storage
 const ANSI_REGEX = /\x1b\[[0-9;]*m/g;
 
+/**
+ * Helper removing terminal ANSI color/styling codes from messages.
+ * @param text Original terminal message.
+ * @returns Clean text string.
+ */
 function stripAnsi(text: string): string {
     return text.replace(ANSI_REGEX, '');
 }
 
+/**
+ * Circular log buffer class keeping track of recent console output logs.
+ */
 export class LogBuffer {
     private readonly buffer: LogEntry[] = [];
     private head = 0;
     private count = 0;
 
+    /**
+     * Appends a new log entry to the buffer.
+     * @param level Severity level of the log message.
+     * @param message Text message content.
+     */
     append(level: LogLevel, message: string): void {
         const entry: LogEntry = {
             timestamp: new Date().toISOString(),
@@ -36,6 +55,12 @@ export class LogBuffer {
         this.head = (this.head + 1) % MAX_ENTRIES;
     }
 
+    /**
+     * Retrieves recent log entries up to specified count, optionally filtering by level.
+     * @param count Maximum log entry count to return.
+     * @param levelFilter Optional log level severity filter.
+     * @returns Array of log entry objects.
+     */
     getRecent(count: number, levelFilter?: LogLevel): readonly LogEntry[] {
         const all: LogEntry[] = [];
         for (let i = 0; i < this.count; i++) {
@@ -50,6 +75,9 @@ export class LogBuffer {
         return filtered.slice(-count);
     }
 
+    /**
+     * Resets/clears the entire circular log buffer.
+     */
     clear(): void {
         this.buffer.length = 0;
         this.head = 0;
@@ -57,4 +85,5 @@ export class LogBuffer {
     }
 }
 
+/** Default global LogBuffer instance */
 export const logBuffer = new LogBuffer();

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -21,16 +21,29 @@ const LEVEL_PRIORITY: Record<LogLevel, number> = {
     none: 4,
 };
 
+/**
+ * Interface representing custom logger implementation functions.
+ */
 export interface Logger {
+    /** Output info severity messages. */
     info(...args: any[]): void;
+    /** Output warn severity messages. */
     warn(...args: any[]): void;
+    /** Output error severity messages. */
     error(...args: any[]): void;
+    /** Output debug severity messages. */
     debug(...args: any[]): void;
+    /** Output phase transitions/milestone messages. */
     phase(...args: any[]): void;
+    /** Output completed operation status messages. */
     done(...args: any[]): void;
+    /** Output structured user prompts. */
     prompt(text: string): void;
+    /** Output a stylized divider line. */
     divider(label?: string): void;
+    /** Set current severity level threshold. */
     setLogLevel(level: LogLevel): void;
+    /** Get current severity level threshold. */
     getLogLevel(): LogLevel;
 }
 
@@ -40,6 +53,11 @@ const getTimestamp = () => {
     return `${COLORS.dim}[${timeString}]${COLORS.reset}`;
 };
 
+/**
+ * Factory creating Logger instance with specified log level.
+ * @param initialLevel Initial log severity filter limit.
+ * @returns Logger implementation.
+ */
 export function createLogger(initialLevel: LogLevel = 'info'): Logger {
     let currentLevel: LogLevel = initialLevel;
 

--- a/src/utils/metadataExtractor.ts
+++ b/src/utils/metadataExtractor.ts
@@ -1,8 +1,18 @@
+/**
+ * Metadata parameters parsed from message footers.
+ */
 export interface TaskMetadata {
+    /** Target background execution task identifier. */
     taskId?: string;
+    /** Current working directory path of the task. */
     directory?: string;
 }
 
+/**
+ * Extracts task identifiers and working directory paths from a formatted footer string.
+ * @param footerText Raw footer text.
+ * @returns Parsed metadata properties object.
+ */
 export function extractMetadataFromFooter(footerText: string): TaskMetadata {
     const result: TaskMetadata = {};
 

--- a/src/utils/metadataExtractor.ts
+++ b/src/utils/metadataExtractor.ts
@@ -11,9 +11,9 @@ export function extractMetadataFromFooter(footerText: string): TaskMetadata {
         result.taskId = taskIdMatch[1];
     }
 
-    const dirMatch = footerText.match(/Dir:\s*([^\s|]+)/i);
+    const dirMatch = footerText.match(/Dir:\s*([^|]+)/i);
     if (dirMatch && dirMatch[1]) {
-        result.directory = dirMatch[1];
+        result.directory = dirMatch[1].trim();
     }
 
     return result;

--- a/src/utils/processLogBuffer.ts
+++ b/src/utils/processLogBuffer.ts
@@ -1,6 +1,12 @@
+/**
+ * Options configuration object for custom CLI/process log formatting and buffering.
+ */
 export interface ProcessLogBufferOptions {
+    /** Maximum character limit allowed in the log snapshot. */
     maxChars?: number;
+    /** Maximum number of distinct log lines/entries to keep in memory. */
     maxEntries?: number;
+    /** Maximum character length of any single log entry. */
     maxEntryLength?: number;
 }
 
@@ -8,10 +14,20 @@ const DEFAULT_MAX_CHARS = 3500;
 const DEFAULT_MAX_ENTRIES = 120;
 const DEFAULT_MAX_ENTRY_LENGTH = 260;
 
+/**
+ * Normalizes multi-line whitespace and strips raw carriage return characters.
+ * @param text Raw log text chunk.
+ * @returns Clean normalized string.
+ */
 function collapseWhitespace(text: string): string {
     return (text || '').replace(/\r/g, '').replace(/\s+/g, ' ').trim();
 }
 
+/**
+ * Splits raw process logs into discrete blocks/lines.
+ * @param raw Raw process logs.
+ * @returns Array of separate log message blocks.
+ */
 function parseBlocks(raw: string): string[] {
     const normalized = (raw || '').replace(/\r/g, '').trim();
     if (!normalized) return [];
@@ -29,6 +45,11 @@ function parseBlocks(raw: string): string[] {
         .filter((line) => line.length > 0);
 }
 
+/**
+ * Picks an illustrative emoji icon for the entry text prefix.
+ * @param entry The formatted entry text.
+ * @returns An emoji character indicator.
+ */
 function pickEmoji(entry: string): string {
     const lower = entry.toLowerCase();
     if (/^thought for\b/.test(lower) || /^thinking\b/.test(lower)) return '🧠';
@@ -41,6 +62,12 @@ function pickEmoji(entry: string): string {
     return '•';
 }
 
+/**
+ * Prepares a raw entry for display by collapsing white space, picking an emoji, and truncating if too long.
+ * @param rawEntry Raw log line.
+ * @param maxEntryLength Maximum character limit for this single entry.
+ * @returns Clean display entry string.
+ */
 function toDisplayEntry(rawEntry: string, maxEntryLength: number): string {
     const trimmed = collapseWhitespace(rawEntry);
     if (!trimmed) return '';
@@ -51,6 +78,9 @@ function toDisplayEntry(rawEntry: string, maxEntryLength: number): string {
     return `${pickEmoji(clipped)} ${clipped}`;
 }
 
+/**
+ * Deduplicating log buffer designed for displaying formatted CLI activity logs in chat UI updates.
+ */
 export class ProcessLogBuffer {
     private readonly maxChars: number;
     private readonly maxEntries: number;
@@ -58,12 +88,20 @@ export class ProcessLogBuffer {
     private readonly entries: string[] = [];
     private readonly seen = new Set<string>();
 
+    /**
+     * @param options Buffer tuning options.
+     */
     constructor(options: ProcessLogBufferOptions = {}) {
         this.maxChars = options.maxChars ?? DEFAULT_MAX_CHARS;
         this.maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
         this.maxEntryLength = options.maxEntryLength ?? DEFAULT_MAX_ENTRY_LENGTH;
     }
 
+    /**
+     * Appends raw process log chunks to the buffer.
+     * @param raw Raw process logs chunk.
+     * @returns Consolidated snapshot string.
+     */
     append(raw: string): string {
         const blocks = parseBlocks(raw);
         for (const block of blocks) {
@@ -79,10 +117,17 @@ export class ProcessLogBuffer {
         return this.snapshot();
     }
 
+    /**
+     * Retrieves the consolidated buffer representation text.
+     * @returns Merged entries string.
+     */
     snapshot(): string {
         return this.entries.join('\n');
     }
 
+    /**
+     * Trims old entries from the circular queue if boundaries are exceeded.
+     */
     private trim(): void {
         while (this.entries.length > this.maxEntries) {
             this.dropOldest();
@@ -100,6 +145,9 @@ export class ProcessLogBuffer {
         }
     }
 
+    /**
+     * Discards the oldest cached entry in the queue.
+     */
     private dropOldest(): void {
         const removed = this.entries.shift();
         if (!removed) return;

--- a/src/utils/processLogBuffer.ts
+++ b/src/utils/processLogBuffer.ts
@@ -21,7 +21,7 @@ function parseBlocks(raw: string): string[] {
         .map((chunk) => collapseWhitespace(chunk))
         .filter((chunk) => chunk.length > 0);
 
-    if (blocks.length > 0) return blocks;
+    if (blocks.length > 1) return blocks;
 
     return normalized
         .split('\n')

--- a/src/utils/projectResolver.ts
+++ b/src/utils/projectResolver.ts
@@ -1,6 +1,14 @@
 import type { WorkspaceCommandHandler } from '../commands/workspaceCommandHandler';
 import type { CdpBridge } from '../services/cdpBridgeManager';
 
+/**
+ * Resolves the target workspace project name. If not explicitly provided, attempts to resolve
+ * from the session channel bindings.
+ * @param deps Injected dependencies.
+ * @param channelId Active channel ID.
+ * @param providedProjectName Optional explicit project name.
+ * @returns Resolved project name, or undefined.
+ */
 export function resolveProjectName(
     deps: { wsHandler: WorkspaceCommandHandler; bridge: CdpBridge },
     channelId: string,

--- a/src/utils/questionActionUtils.ts
+++ b/src/utils/questionActionUtils.ts
@@ -2,6 +2,12 @@ import type { CdpService } from '../services/cdpService';
 import { logger } from './logger';
 import { buildClickScript } from '../services/approvalDetector';
 
+/**
+ * Parses question action button customIds into actions and scope metadata.
+ * @param customId Raw customId.
+ * @param expectedPrefix Expected prefix string.
+ * @returns Parsed properties dictionary, or null.
+ */
 export function parseQuestionCustomId(customId: string, expectedPrefix: string): { action: string; projectName?: string; channelId?: string } | null {
     if (customId !== expectedPrefix && !customId.startsWith(expectedPrefix + ':')) return null;
 
@@ -27,6 +33,9 @@ export function parseQuestionCustomId(customId: string, expectedPrefix: string):
 /**
  * Executes a click on an element matching the target text in the IDE.
  * Returns true if the click was successfully dispatched, false otherwise.
+ * @param cdp Active CdpService.
+ * @param buttonText Target innerText of the button.
+ * @returns True if click succeeded.
  */
 export async function executeBrowserClick(cdp: CdpService, buttonText: string): Promise<boolean> {
     try {

--- a/tests/bot.test.ts
+++ b/tests/bot.test.ts
@@ -301,6 +301,9 @@ describe('Bot Startup', () => {
             expect(editReplySpy).toHaveBeenCalledWith(expect.objectContaining({
                 content: expect.stringContaining('Heartbeat enabled'),
             }));
+
+            const mockServiceInstance = (HeartbeatService as jest.Mock).mock.results[0].value;
+            expect(mockServiceInstance.updateConfig).toHaveBeenCalledWith(true, 1800000, 'heartbeat-channel-id');
         });
 
         it('fails heartbeat on if bot lacks send permissions', async () => {

--- a/tests/services/cdpService.workspace.test.ts
+++ b/tests/services/cdpService.workspace.test.ts
@@ -294,4 +294,34 @@ describe('CdpService - Cross-Platform Workspace Launching', () => {
             expect(service.getCurrentWorkspaceName()).toBe('trailing-slash-proj');
         });
     });
+
+    describe('Connection Reuse / Reconnect Check', () => {
+        it('should reuse the active connection when requested workspace matches the current workspace', async () => {
+            jest.spyOn(service as any, 'verifyCurrentWorkspace').mockResolvedValue(true);
+            (service as any).isConnectedFlag = true;
+            (service as any).currentWorkspaceName = 'MyProject';
+            (service as any).currentWorkspacePath = '/Users/test/Documents/MyProject';
+
+            const workspacePath = '/Users/test/Documents/MyProject';
+            const result = await service.discoverAndConnectForWorkspace(workspacePath);
+
+            expect(result).toBe(true);
+            expect(mockGetJson).not.toHaveBeenCalled();
+            expect(mockRunCommand).not.toHaveBeenCalled();
+        });
+
+        it('should correctly extract workspace name from title with dash separator in discoverTarget', async () => {
+            mockGetJson.mockResolvedValue([{
+                id: 'page-id',
+                type: 'page',
+                title: 'MyProject — Antigravity',
+                webSocketDebuggerUrl: 'ws://debug-url',
+                url: 'file:///workbench'
+            }]);
+
+            const url = await (service as any).discoverTarget();
+            expect(url).toBe('ws://debug-url');
+            expect(service.getCurrentWorkspaceName()).toBe('MyProject');
+        });
+    });
 });

--- a/tests/services/heartbeatService.test.ts
+++ b/tests/services/heartbeatService.test.ts
@@ -359,5 +359,53 @@ describe('HeartbeatService', () => {
                 heartbeatLastMessageId: expect.any(String),
             });
         });
+
+        it('queues a follow-up send and executes it immediately when reconfigured while channels.fetch is pending', async () => {
+            (ConfigLoader.load as jest.Mock).mockReturnValue({
+                heartbeatEnabled: true,
+                heartbeatChannelId: 'channel-123',
+                heartbeatIntervalMs: 15000,
+            });
+
+            // Simulate delayed fetch
+            let resolveFetch: (value: any) => void = () => {};
+            const fetchPromise = new Promise((resolve) => {
+                resolveFetch = resolve;
+            });
+            mockClient.channels.fetch.mockReturnValue(fetchPromise);
+
+            service.init(mockClient, mockBridge);
+            
+            // Start the first heartbeat (this sets isSending to true and calls fetch)
+            const firstSendPromise = service.sendHeartbeat();
+
+            expect((service as any).isSending).toBe(true);
+
+            // Reconfigure/restart while first fetch is pending
+            const updatePromise = service.updateConfig(true, 15000, 'channel-123');
+
+            // Wait a tiny bit to let promises resolve/tick
+            await Promise.resolve();
+
+            // Next send should be queued
+            expect((service as any).nextSendQueued).toBe(true);
+
+            // Now resolve the first fetch
+            resolveFetch(mockChannel);
+
+            // Let the first call finish
+            await firstSendPromise;
+
+            // Wait for updateConfig to finish
+            await updatePromise;
+
+            // By now, the first send should have aborted due to stale generation,
+            // and the queued send should have started and resolved.
+            // Since mockChannel is returned, the new/queued heartbeat send should have called channel.send!
+            expect(mockChannel.send).toHaveBeenCalled();
+            expect(ConfigLoader.save).toHaveBeenCalledWith({
+                heartbeatLastMessageId: 'msg-abc',
+            });
+        });
     });
 });

--- a/tests/services/heartbeatService.test.ts
+++ b/tests/services/heartbeatService.test.ts
@@ -355,9 +355,7 @@ describe('HeartbeatService', () => {
 
             // Expected: should abort and NOT call channel.send or ConfigLoader.save
             expect(mockChannel.send).not.toHaveBeenCalled();
-            expect(ConfigLoader.save).not.toHaveBeenCalledWith({
-                heartbeatLastMessageId: expect.any(String),
-            });
+            expect(ConfigLoader.save).not.toHaveBeenCalled();
         });
 
         it('queues a follow-up send and executes it immediately when reconfigured while channels.fetch is pending', async () => {

--- a/tests/services/processManager.test.ts
+++ b/tests/services/processManager.test.ts
@@ -148,4 +148,42 @@ describe('ProcessManager', () => {
         expect(result).toBe(true);
         expect(mockKill).toHaveBeenCalled();
     });
+
+    it('should keep the task in runningProcesses on stopTask until close event fires', async () => {
+        const mockKill = jest.fn();
+        let closeCallback: any;
+        mockSpawn.mockReturnValue({
+            pid: 123,
+            stdout: { on: jest.fn() },
+            stderr: { on: jest.fn() },
+            on: jest.fn((event, cb) => {
+                if (event === 'close') {
+                    closeCallback = cb;
+                }
+            }),
+            kill: mockKill,
+        });
+
+        processManager.submitTask({ id: 'task-to-kill-delayed', command: 'sleep', args: ['10'], cwd: '/' });
+
+        await new Promise(process.nextTick);
+
+        // Verify it is in runningProcesses
+        expect((processManager as any).runningProcesses.has('task-to-kill-delayed')).toBe(true);
+
+        const result = processManager.stopTask('task-to-kill-delayed');
+
+        expect(result).toBe(true);
+        expect(mockKill).toHaveBeenCalled();
+        // It should still be in runningProcesses immediately after stopTask (before close fires)
+        expect((processManager as any).runningProcesses.has('task-to-kill-delayed')).toBe(true);
+
+        // Now trigger the close event callback
+        if (closeCallback) {
+            closeCallback(0);
+        }
+
+        // Now it should be removed from runningProcesses
+        expect((processManager as any).runningProcesses.has('task-to-kill-delayed')).toBe(false);
+    });
 });

--- a/tests/services/progressSender.test.ts
+++ b/tests/services/progressSender.test.ts
@@ -19,7 +19,7 @@ describe('ProgressSender', () => {
         jest.clearAllMocks();
     });
 
-    it('should throttle reply calls', () => {
+    it('should throttle reply calls', async () => {
         const sender = new ProgressSender({ message: mockMessage, throttleMs: 3000 });
 
         sender.append('chunk 1\n');
@@ -31,6 +31,7 @@ describe('ProgressSender', () => {
 
         // Advance by 3000ms
         jest.advanceTimersByTime(3000);
+        await (sender as any).promiseChain;
 
         // Verify it was called once, and the buffered content was sent all at once
         expect(mockReply).toHaveBeenCalledTimes(1);
@@ -39,11 +40,12 @@ describe('ProgressSender', () => {
         }));
     });
 
-    it('should send immediately if forced', () => {
+    it('should send immediately if forced', async () => {
         const sender = new ProgressSender({ message: mockMessage, throttleMs: 3000 });
 
         sender.append('chunk 1\n');
         sender.forceEmit();
+        await (sender as any).promiseChain;
 
         expect(mockReply).toHaveBeenCalledTimes(1);
         expect(mockReply).toHaveBeenCalledWith(expect.objectContaining({
@@ -51,7 +53,7 @@ describe('ProgressSender', () => {
         }));
     });
 
-    it('should fallback to reply or split if max length is exceeded', () => {
+    it('should fallback to reply or split if max length is exceeded', async () => {
         const sender = new ProgressSender({ message: mockMessage, throttleMs: 3000, maxLength: 50 });
 
         // Add a string longer than 50 characters to the buffer
@@ -60,6 +62,7 @@ describe('ProgressSender', () => {
         sender.append(longString);
 
         jest.advanceTimersByTime(3000);
+        await (sender as any).promiseChain;
 
         const expectedChunks = Math.ceil(longString.length / 50);
         expect(mockReply).toHaveBeenCalledTimes(expectedChunks);
@@ -72,7 +75,7 @@ describe('ProgressSender', () => {
         expect(sentBody).toContain(longString);
     });
 
-    it('should use custom send function when provided', () => {
+    it('should use custom send function when provided', async () => {
         const mockSend = jest.fn().mockResolvedValue(undefined);
         const sender = new ProgressSender({
             send: mockSend,
@@ -82,9 +85,36 @@ describe('ProgressSender', () => {
 
         sender.append('line 1\n');
         jest.advanceTimersByTime(1000);
+        await (sender as any).promiseChain;
 
         expect(mockSend).toHaveBeenCalledTimes(1);
         expect(mockSend).toHaveBeenCalledWith('line 1\n');
         expect(mockReply).not.toHaveBeenCalled();
+    });
+
+    it('should send chunks sequentially in order and tolerate individual send failures', async () => {
+        const sentChunks: string[] = [];
+        const mockSend = jest.fn().mockImplementation(async (content: string) => {
+            if (content.includes('fail')) {
+                throw new Error('Send failed');
+            }
+            sentChunks.push(content);
+        });
+
+        const sender = new ProgressSender({
+            send: mockSend,
+            throttleMs: 1000,
+            maxLength: 5,
+            wrapInCodeBlock: false,
+        });
+
+        sender.append('12345fail7890');
+        jest.advanceTimersByTime(1000);
+
+        // Wait for all promises in the chain to resolve
+        await (sender as any).promiseChain;
+
+        expect(mockSend).toHaveBeenCalledTimes(3);
+        expect(sentChunks).toEqual(['12345', '890']);
     });
 });

--- a/tests/services/quotaService.test.ts
+++ b/tests/services/quotaService.test.ts
@@ -117,4 +117,47 @@ describe('QuotaService', () => {
         expect(mockRequest.mock.calls[0][0].port).toBe(4444);
         expect(mockRequest.mock.calls[1][0].port).toBe(4444);
     });
+
+    it('correctly matches IPv4, IPv6, and wildcard addresses from lsof output', async () => {
+        mockExec.mockImplementation((cmd: string, cb: (err: Error | null, stdout: string, stderr: string) => void) => {
+            if (cmd.startsWith('pgrep -fl language_server')) {
+                cb(null, '123 language_server --csrf_token abc-123\n', '');
+                return {} as any;
+            }
+            if (cmd.startsWith('lsof -nP -a -iTCP -sTCP:LISTEN -p 123')) {
+                const sampleOutput = [
+                    'node    123 user   23u  IPv6 0x1234      0t0  TCP [::1]:9222 (LISTEN)',
+                    'node    123 user   24u  IPv4 0x1235      0t0  TCP 127.0.0.1:9223 (LISTEN)',
+                    'node    123 user   25u  IPv4 0x1236      0t0  TCP *:9224 (LISTEN)',
+                ].join('\n');
+                cb(null, sampleOutput, '');
+                return {} as any;
+            }
+            cb(new Error(`unexpected command: ${cmd}`), '', '');
+            return {} as any;
+        });
+
+        mockRequest.mockImplementation((options: any, cb: (res: any) => void) => {
+            const req = new EventEmitter() as any;
+            req.write = jest.fn();
+            req.destroy = jest.fn();
+            req.end = jest.fn(() => {
+                const res = new EventEmitter() as any;
+                res.statusCode = 500; // Fail so it tries all discovered ports
+                cb(res);
+                res.emit('data', 'Server Error');
+                res.emit('end');
+            });
+            return req;
+        });
+
+        const service = new QuotaService();
+        await service.fetchQuota();
+
+        const portCalls = mockRequest.mock.calls.map((call) => call[0].port);
+        expect(portCalls).toContain(9222);
+        expect(portCalls).toContain(9223);
+        expect(portCalls).toContain(9224);
+        expect(portCalls).toHaveLength(3);
+    });
 });

--- a/tests/services/scheduleService.test.ts
+++ b/tests/services/scheduleService.test.ts
@@ -294,8 +294,19 @@ describe('ScheduleService', () => {
     describe('restoreSchedules - import schedules', () => {
         it('parses valid JSON, stops active tasks, calls bulkRestore, and registers enabled crons', () => {
             mockCronValidate.mockReturnValue(true);
-            const mockTask = { stop: jest.fn(), start: jest.fn() };
-            mockCronSchedule.mockReturnValue(mockTask);
+            const mockExistingTask = { stop: jest.fn(), start: jest.fn() };
+            const mockNewTask = { stop: jest.fn(), start: jest.fn() };
+            mockCronSchedule
+                .mockReturnValueOnce(mockExistingTask)
+                .mockReturnValueOnce(mockNewTask);
+
+            const jobCallback = jest.fn();
+            mockRepo.create.mockReturnValue({
+                id: 1, cronExpression: '0 8 * * *', prompt: 'テスト1', workspacePath: '/p1', enabled: true
+            });
+
+            // Register an active schedule/task first
+            scheduleService.addSchedule('0 8 * * *', 'テスト1', '/p1', jobCallback);
 
             const json = JSON.stringify([{
                 cronExpression: '0 9 * * *',
@@ -305,21 +316,21 @@ describe('ScheduleService', () => {
             }]);
 
             const restored: ScheduleRecord[] = [
-                { id: 1, cronExpression: '0 9 * * *', prompt: 'ジョブ1', workspacePath: '/p1', enabled: true }
+                { id: 2, cronExpression: '0 9 * * *', prompt: 'ジョブ1', workspacePath: '/p1', enabled: true }
             ];
             mockRepo.bulkRestore.mockReturnValue(restored);
 
-            const jobCallback = jest.fn();
             const count = scheduleService.restoreSchedules(json, jobCallback);
 
             expect(count).toBe(1);
+            expect(mockExistingTask.stop).toHaveBeenCalled();
             expect(mockRepo.bulkRestore).toHaveBeenCalledWith([{
                 cronExpression: '0 9 * * *',
                 prompt: 'ジョブ1',
                 workspacePath: '/p1',
                 enabled: true
             }]);
-            expect(mockCronSchedule).toHaveBeenCalledTimes(1);
+            expect(mockCronSchedule).toHaveBeenCalledTimes(2);
         });
 
         it('throws an error for invalid JSON format', () => {
@@ -420,6 +431,9 @@ describe('ScheduleService', () => {
     });
         it('supports channelId in addSchedule, backupSchedules, and restoreSchedules', () => {
             mockCronValidate.mockReturnValue(true);
+            const mockTask = { stop: jest.fn(), start: jest.fn() };
+            mockCronSchedule.mockReturnValue(mockTask);
+
             const jobCallback = jest.fn();
 
             mockRepo.create.mockReturnValue({


### PR DESCRIPTION
### Overview
This pull request raises the documentation coverage in the LazyGravity TypeScript codebase to 100.0% across all classes, interfaces, functions, and methods (910/910 items). This ensures maintainability and full developer context across all modules while preserving hard-written technical details and domain knowledge.

### Detailed Key Changes

#### Documentation & JSDoc Restorations
- **Complete JSDoc Coverage**: Achieved 100.0% static documentation coverage across all TypeScript source files (`ts-morph`).
- **Restored Module Headers & Specific Technical Notes**:
  - Restored Telegram command parser header in `src/bot/telegramCommands.ts`.
  - Restored Telegram `/project` user flow header in `src/bot/telegramProjectCommand.ts`.
  - Restored `ComponentRow` platform limits note (Discord 5 buttons/row or 1 select/row) in `src/platform/types.ts`.
  - Restored `showModal` requirement note ("Must be the first response") in `src/platform/types.ts`.
  - Restored grammY `InputFile` wrapper notes on `toInputFile` in `src/platform/telegram/wrappers.ts`.
  - Restored default value notes on `responseTimeoutMs` (900,000 ms / 15 min default) in `src/utils/config.ts` and `src/utils/configLoader.ts`.

#### Bug Fixes & Architectural Guardrails
- **lsof Regex Alignment (`src/services/quotaService.ts`)**: Reverted `lsof` output regex escaping to be byte-identical to `main`, guarded by unit tests in `tests/services/quotaService.test.ts` verifying IPv4, IPv6, and wildcard listening addresses.
- **CDP Title-Split & Connection Reuse (`src/services/cdpService.ts`)**: Moved session title-split handling into the feat path with test coverage in `tests/services/cdpService.workspace.test.ts` to ensure reliable workspace reuse.

#### Asynchronous Lifecycle & Concurrency Refinements (`f30ae7f`/`ae90f8c`)
- **Heartbeat Generation Tokens & Queued Sends (`src/services/heartbeatService.ts`)**: Integrated generation-token validation checks for async operations, single-send queuing when updates overlap, and safe `heartbeatLastMessageId` retention on delete failures.
- **Ordered Chunk Delivery (`src/services/progressSender.ts`)**: Implemented a sequential promise chain (`promiseChain`) to preserve strict chunk delivery ordering during log streaming.
- **Process Manager Lifecycle (`src/services/processManager.ts`)**: Deferred task table cleanup inside `stopTask()` to the process `close` event handler to prevent overlapping task execution.
- **DM Channel Permission Relaxation (`src/bot/index.ts`)**: Relaxed the channel permission check in `/schedule restore` so falsy values returned by `permissionsFor` (which occur in DM channels lacking guild permissions) permit setting up schedules/heartbeats in DMs while enforcing full permissions in guild channels.

#### Schedule Backup & Restore Support
- **Schedule Backup & Restore (`src/services/scheduleService.ts`)**: Supported schedule export/import backup functionality with size and payload validation limits.

---

### New Tests & Validation

- **Coverage Metric**: Verified 100.0% overall JSDoc coverage via static analysis (`ts-morph`).
- **Compilation**: Compiled cleanly with no errors or warnings (`npm run build`).
- **Unit Test Suite**: All tests pass cleanly across 115 test suites and 1,548 unit tests (`npm test`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schedules can now be associated with channels and backed up or restored in bulk.
  * Telegram commands support multi-line arguments.
  * Added richer response diagnostics, including disconnected status and baseline progress tracking.
  * Added support for inline Telegram keyboards and improved interaction handling.

* **Bug Fixes**
  * Improved heartbeat reliability during configuration changes and overlapping sends.
  * Preserved progress-message order when individual deliveries fail.
  * Pending tasks can now be cancelled before starting.
  * Improved workspace detection and message-processing behavior.

* **Documentation**
  * Expanded help and developer-facing documentation across commands and services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->